### PR TITLE
Remove provideServiceScoped

### DIFF
--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -3595,13 +3595,6 @@ export const provideServiceEffect: {
   ): Effect<A, E | E2, Exclude<R, I> | R2>
 } = internal.provideServiceEffect
 
-/**
- * @since 4.0.0
- * @category Context
- */
-export const provideServiceScoped: <I, S>(tag: Context.Tag<I, S>, service: S) => Effect<void, never, Scope> =
-  internal.provideServiceScoped
-
 // -----------------------------------------------------------------------------
 // References
 // -----------------------------------------------------------------------------
@@ -4392,12 +4385,6 @@ export const withTracer: {
   (value: Tracer): <A, E, R>(effect: Effect<A, E, R>) => Effect<A, E, R>
   <A, E, R>(effect: Effect<A, E, R>, value: Tracer): Effect<A, E, R>
 } = internal.withTracer
-
-/**
- * @since 2.0.0
- * @category Tracing
- */
-export const withTracerScoped: (tracer: Tracer) => Effect<void, never, Scope> = internal.withTracerScoped
 
 /**
  * Disable the tracer for the given Effect.

--- a/src/internal/effect.ts
+++ b/src/internal/effect.ts
@@ -1384,25 +1384,6 @@ export const makeProvideService: {
   )) as any
 
 /** @internal */
-export const provideServiceScoped = <I, S>(
-  tag: Context.Tag<I, S>,
-  service: S
-): Effect.Effect<void, never, Scope.Scope> =>
-  uninterruptible(withFiber((fiber) => {
-    const scope = InternalContext.unsafeGet(fiber.context, scopeTag)
-    const prev = InternalContext.getOption(fiber.context, tag)
-    fiber.setContext(InternalContext.add(fiber.context, tag, service))
-    return scopeAddFinalizer(scope, () =>
-      sync(() => {
-        fiber.setContext(
-          prev._tag === "Some"
-            ? InternalContext.add(fiber.context, tag, prev.value)
-            : InternalContext.omit(tag as any)(fiber.context as any)
-        )
-      }))
-  }))
-
-/** @internal */
 export const provideServiceEffect: {
   <I, S, E2, R2>(
     tag: Context.Tag<I, S>,
@@ -3356,12 +3337,6 @@ export const withTracer: {
   fiberMiddleware.tracerContext = tracerContextMiddleware
   return provideService(effect, Tracer.CurrentTracer, tracer)
 })
-
-/* @internal */
-export const withTracerScoped = (tracer: Tracer.Tracer): Effect.Effect<void, never, Scope.Scope> => {
-  fiberMiddleware.tracerContext = tracerContextMiddleware
-  return provideServiceScoped(Tracer.CurrentTracer, tracer)
-}
 
 /** @internal */
 export const withTracerEnabled: {


### PR DESCRIPTION
Given that FiberRefs are now simply services in context we can use normal providing, the Scoped alternatives were used to provide references in layers