### PR TITLE
Add key annotations support

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -1236,6 +1236,42 @@ console.log(Schema.decodeUnknownSync(Product)({ quantity: "2" }))
 // Output: { quantity: { _id: 'Option', _tag: 'Some', value: 2 }
 ```
 
+### Key Annotations
+
+You can annotate keys using `Schema.annotateKey`.
+
+**Example** (Annotating a key)
+
+```ts
+import {
+  Effect,
+  Schema,
+  SchemaFormatter,
+  SchemaResult,
+  SchemaToParser
+} from "effect"
+
+const schema = Schema.Struct({
+  a: Schema.String.pipe(
+    Schema.annotateKey({ description: "my key description" })
+  )
+})
+
+SchemaToParser.decodeUnknownSchemaResult(schema)({})
+  .pipe(
+    SchemaResult.asEffect,
+    Effect.mapError((issue) => SchemaFormatter.TreeFormatter.format(issue)),
+    Effect.runPromise
+  )
+  .then(console.log, console.error)
+/*
+Output:
+{ readonly "a": string }
+└─ ["a"] (my key description)
+   └─ Missing key
+*/
+```
+
 ### Index Signatures
 
 You can extend a struct with an index signature using `Schema.StructWithRest`. This allows you to define both fixed and dynamic properties in a single schema.
@@ -1678,6 +1714,42 @@ export type Type = typeof schema.Type
 type Encoded = readonly [string, string, ...boolean[], string]
 */
 export type Encoded = typeof schema.Encoded
+```
+
+### Element Annotations
+
+You can annotate elements using `Schema.annotateKey`.
+
+**Example** (Annotating an element)
+
+```ts
+import {
+  Effect,
+  Schema,
+  SchemaFormatter,
+  SchemaResult,
+  SchemaToParser
+} from "effect"
+
+const schema = Schema.Tuple([
+  Schema.String.pipe(
+    Schema.annotateKey({ description: "my element description" })
+  )
+])
+
+SchemaToParser.decodeUnknownSchemaResult(schema)([])
+  .pipe(
+    SchemaResult.asEffect,
+    Effect.mapError((issue) => SchemaFormatter.TreeFormatter.format(issue)),
+    Effect.runPromise
+  )
+  .then(console.log, console.error)
+/*
+Output:
+readonly [string]
+└─ [0] (my element description)
+   └─ Missing key
+*/
 ```
 
 ## Classes

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -132,14 +132,20 @@ export function revealBottom<S extends Top>(
 }
 
 /**
- * Universal annotation function, works with any
- * {@link SchemaAnnotations.Annotable} (e.g. `Schema`, `SchemaCheck`, etc.).
- *
  * @since 4.0.0
  */
 export function annotate<S extends Top>(annotations: S["~annotate.in"]) {
   return (self: S): S["~rebuild.out"] => {
     return self.annotate(annotations)
+  }
+}
+
+/**
+ * @since 4.0.0
+ */
+export function annotateKey<S extends Top>(annotations: SchemaAnnotations.Documentation) {
+  return (self: S): S["~rebuild.out"] => {
+    return self.rebuild(SchemaAST.annotateKey(self.ast, annotations))
   }
 }
 
@@ -2835,9 +2841,10 @@ function getComputeAST(
             context.isOptional,
             context.isReadonly,
             context.defaultValue,
-            context.make ? [...context.make, contextLink] : [contextLink]
+            context.make ? [...context.make, contextLink] : [contextLink],
+            context.annotations
           ) :
-          new SchemaAST.Context(false, true, undefined, [contextLink])
+          new SchemaAST.Context(false, true, undefined, [contextLink], undefined)
       )
     }
     return memo

--- a/packages/effect/src/SchemaFormatter.ts
+++ b/packages/effect/src/SchemaFormatter.ts
@@ -107,6 +107,15 @@ function formatForbidden(issue: SchemaIssue.Forbidden): string {
   return "Forbidden operation"
 }
 
+function formatPointer(issue: SchemaIssue.Pointer): string {
+  const path = formatPath(issue.path)
+  const hint = issue.annotations?.title ?? issue.annotations?.description
+  if (hint) {
+    return `${path} (${hint})`
+  }
+  return path
+}
+
 function formatTree(issue: SchemaIssue.Issue): Tree<string> {
   switch (issue._tag) {
     case "InvalidType":
@@ -116,7 +125,7 @@ function formatTree(issue: SchemaIssue.Issue): Tree<string> {
     case "Composite":
       return makeTree(SchemaAST.format(issue.ast), issue.issues.map(formatTree))
     case "Pointer":
-      return makeTree(formatPath(issue.path), [formatTree(issue.issue)])
+      return makeTree(formatPointer(issue), [formatTree(issue.issue)])
     case "Check":
       return makeTree(SchemaAST.formatCheck(issue.check), [formatTree(issue.issue)])
     case "MissingKey":

--- a/packages/effect/src/SchemaIssue.ts
+++ b/packages/effect/src/SchemaIssue.ts
@@ -99,7 +99,11 @@ export class Pointer extends Base {
     /**
      * The issue that occurred.
      */
-    readonly issue: Issue
+    readonly issue: Issue,
+    /**
+     * The annotations for the key that caused the issue.
+     */
+    readonly annotations?: SchemaAnnotations.Documentation
   ) {
     super()
   }

--- a/packages/effect/test/Schema.test.ts
+++ b/packages/effect/test/Schema.test.ts
@@ -4153,4 +4153,32 @@ describe("SchemaGetter", () => {
       )
     })
   })
+
+  describe("annotateKey", () => {
+    it("Struct", async () => {
+      const schema = Schema.Struct({
+        a: Schema.String.pipe(Schema.annotateKey({ description: "description" }))
+      })
+
+      await assertions.decoding.fail(
+        schema,
+        {},
+        `{ readonly "a": string }
+└─ ["a"] (description)
+   └─ Missing key`
+      )
+    })
+
+    it("Tuple", async () => {
+      const schema = Schema.Tuple([Schema.String.pipe(Schema.annotateKey({ description: "description" }))])
+
+      await assertions.decoding.fail(
+        schema,
+        [],
+        `readonly [string]
+└─ [0] (description)
+   └─ Missing key`
+      )
+    })
+  })
 })


### PR DESCRIPTION
- Introduced `Schema.annotateKey` for annotating keys and elements in schemas.
- Updated `SchemaAST` and `SchemaIssue` to handle annotations in error reporting.
- Enhanced `SchemaFormatter` to display annotations in error messages.
- Added tests for key annotations in both Struct and Tuple schemas.
