### PR TITLE
Redacted: the ability to override the default label was added

### DIFF
--- a/.changeset/chilly-doors-go.md
+++ b/.changeset/chilly-doors-go.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-In the Redacted module, the ability to override the default label was added.

--- a/.changeset/chilly-doors-go.md
+++ b/.changeset/chilly-doors-go.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+In the Redacted module, the ability to override the default label was added.

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -92,10 +92,10 @@ const Proto = {
   label: undefined,
   ...PipeInspectableProto,
   toJSON() {
-    return this.label ?? "<redacted>"
+    return `<${this.label ?? "redacted"}>`
   },
   toString() {
-    return this.label ?? "<redacted>"
+    return `<${this.label ?? "redacted"}>`
   },
   [Hash.symbol]<T>(this: Redacted<T>): number {
     return Hash.cached(this, () => Hash.hash(redactedRegistry.get(this)))

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -31,7 +31,9 @@ export type TypeId = "~effect/Redacted"
  * @since 3.3.0
  * @category models
  */
-export interface Redacted<out A = string> extends Redacted.Variance<A>, Equal.Equal, Pipeable {}
+export interface Redacted<out A = string> extends Redacted.Variance<A>, Equal.Equal, Pipeable {
+  readonly label: string | undefined
+}
 
 /**
  * @since 3.3.0
@@ -87,13 +89,13 @@ const Proto = {
   [TypeId]: {
     _A: (_: never) => _
   },
-  label: "redacted",
+  label: undefined,
   ...PipeInspectableProto,
   toJSON() {
-    return `<${this.label}>`
+    return this.label ?? "<redacted>"
   },
   toString() {
-    return `<${this.label}>`
+    return this.label ?? "<redacted>"
   },
   [Hash.symbol]<T>(this: Redacted<T>): number {
     return Hash.cached(this, () => Hash.hash(redactedRegistry.get(this)))
@@ -127,7 +129,8 @@ export const value = <T>(self: Redacted<T>): T => {
   if (redactedRegistry.has(self)) {
     return redactedRegistry.get(self)
   } else {
-    throw new Error(`Unable to get redacted value with label: "${label(self)}"`)
+    const label_ = label(self)
+    throw new Error("Unable to get redacted value" + label_ ? ` with label: "${label_}"` : "")
   }
 }
 
@@ -147,7 +150,7 @@ export const value = <T>(self: Redacted<T>): T => {
  * @since 3.3.0
  * @category getters
  */
-export const label = (self: Redacted<any>): string => (self as any).label
+export const label = (self: Redacted<any>): string | undefined => self.label
 
 /**
  * Erases the underlying value of a `Redacted` instance, rendering it unusable.

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -125,6 +125,24 @@ export const value = <T>(self: Redacted<T>): T => {
 }
 
 /**
+ * Retrieves the label of a `Redacted` instance.
+ *
+ * @example
+ * ```ts
+ * import * as assert from "node:assert"
+ * import { Redacted } from "effect"
+ *
+ * const API_KEY = Redacted.make(123, "API_KEY")
+ *
+ * assert.equal(Redacted.label(API_KEY), "API_KEY")
+ * ```
+ *
+ * @since 3.3.0
+ * @category getters
+ */
+export const label: (self: Redacted<any>) => string = redacted_.label
+
+/**
  * Erases the underlying value of a `Redacted` instance, rendering it unusable.
  * This function is intended to ensure that sensitive data does not remain in
  * memory longer than necessary.

--- a/packages/effect/src/Redacted.ts
+++ b/packages/effect/src/Redacted.ts
@@ -130,7 +130,7 @@ export const value = <T>(self: Redacted<T>): T => {
     return redactedRegistry.get(self)
   } else {
     const label_ = label(self)
-    throw new Error("Unable to get redacted value" + label_ ? ` with label: "${label_}"` : "")
+    throw new Error("Unable to get redacted value" + (label_ ? ` with label: "${label_}"` : ""))
   }
 }
 

--- a/packages/effect/test/Redacted.test.ts
+++ b/packages/effect/test/Redacted.test.ts
@@ -34,8 +34,8 @@ describe("Redacted", () => {
   it("label", () => {
     const redacted = Redacted.make("redacted", "MY_LABEL")
     strictEqual(Redacted.label(redacted), "MY_LABEL")
-    strictEqual(redacted.toString(), "MY_LABEL")
-    strictEqual(JSON.stringify(redacted), "\"MY_LABEL\"")
+    strictEqual(redacted.toString(), "<MY_LABEL>")
+    strictEqual(JSON.stringify(redacted), "\"<MY_LABEL>\"")
 
     assertTrue(Redacted.unsafeWipe(redacted))
     throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"MY_LABEL\""))

--- a/packages/effect/test/Redacted.test.ts
+++ b/packages/effect/test/Redacted.test.ts
@@ -34,8 +34,8 @@ describe("Redacted", () => {
   it("label", () => {
     const redacted = Redacted.make("redacted", "MY_LABEL")
     strictEqual(Redacted.label(redacted), "MY_LABEL")
-    strictEqual(redacted.toString(), "<MY_LABEL>")
-    strictEqual(JSON.stringify(redacted), "\"<MY_LABEL>\"")
+    strictEqual(redacted.toString(), "MY_LABEL")
+    strictEqual(JSON.stringify(redacted), "\"MY_LABEL\"")
 
     assertTrue(Redacted.unsafeWipe(redacted))
     throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"MY_LABEL\""))
@@ -44,7 +44,7 @@ describe("Redacted", () => {
   it("unsafeWipe", () => {
     const redacted = Redacted.make("redacted")
     assertTrue(Redacted.unsafeWipe(redacted))
-    throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"redacted\""))
+    throws(() => Redacted.value(redacted), new Error("Unable to get redacted value"))
   })
 
   it("Equal", () => {

--- a/packages/effect/test/Redacted.test.ts
+++ b/packages/effect/test/Redacted.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "@effect/vitest"
+import { assertFalse, assertTrue, strictEqual, throws } from "@effect/vitest/utils"
+import { Chunk, Equal, Hash, Redacted } from "effect"
+
+describe("Redacted", () => {
+  it("chunk constructor", () => {
+    const redacted = Redacted.make(Chunk.fromIterable("redacted".split("")))
+    assertTrue(Equal.equals(redacted, Redacted.make(Chunk.fromIterable("redacted".split("")))))
+  })
+
+  it("value", () => {
+    const redacted = Redacted.make(Chunk.fromIterable("redacted".split("")))
+    const value = Redacted.value(redacted)
+    assertTrue(Equal.equals(value, Chunk.fromIterable("redacted".split(""))))
+  })
+
+  it("pipe", () => {
+    const value = { asd: 123 }
+    const redacted = Redacted.make(value)
+    const extractedValue = redacted.pipe(Redacted.value)
+    strictEqual(value, extractedValue)
+  })
+
+  it("toString", () => {
+    const redacted = Redacted.make("redacted")
+    strictEqual(`${redacted}`, "<redacted>")
+  })
+
+  it("toJSON", () => {
+    const redacted = Redacted.make("redacted")
+    strictEqual(JSON.stringify(redacted), "\"<redacted>\"")
+  })
+
+  it("label", () => {
+    const redacted = Redacted.make("redacted", "MY_LABEL")
+    strictEqual(Redacted.label(redacted), "MY_LABEL")
+    strictEqual(redacted.toString(), "<MY_LABEL>")
+    strictEqual(JSON.stringify(redacted), "\"<MY_LABEL>\"")
+
+    assertTrue(Redacted.unsafeWipe(redacted))
+    throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"MY_LABEL\""))
+  })
+
+  it("unsafeWipe", () => {
+    const redacted = Redacted.make("redacted")
+    assertTrue(Redacted.unsafeWipe(redacted))
+    throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"redacted\""))
+  })
+
+  it("Equal", () => {
+    assertTrue(Equal.equals(Redacted.make(1), Redacted.make(1)))
+    assertFalse(Equal.equals(Redacted.make(1), Redacted.make(2)))
+  })
+
+  it("Hash", () => {
+    strictEqual(Hash.hash(Redacted.make(1)), Hash.hash(Redacted.make(1)))
+    assertTrue(Hash.hash(Redacted.make(1)) !== Hash.hash(Redacted.make(2)))
+  })
+})


### PR DESCRIPTION
+ port tests
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

```ts
const redacted = Redacted.make("redacted", "MY_LABEL")
strictEqual(Redacted.label(redacted), "MY_LABEL")
strictEqual(redacted.toString(), "<MY_LABEL>")
strictEqual(JSON.stringify(redacted), "\"<MY_LABEL>\"")

assertTrue(Redacted.unsafeWipe(redacted))
throws(() => Redacted.value(redacted), new Error("Unable to get redacted value with label: \"MY_LABEL\""))
```

I considered adding a label `field` to the `interface Redacted { }` — but it might be confusing.
For example, it could give the impression that `Redacted.getEquivalence` compares labels, which it doesn't.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
