### PR TITLE
POC: AST paramorphism

### DIFF
--- a/packages/effect/src/schema/AST.ts
+++ b/packages/effect/src/schema/AST.ts
@@ -2179,32 +2179,28 @@ export function getFilters(checks: Checks | undefined): Array<Check.Filter<any>>
  * @since 4.0.0
  */
 export type ReducerAlg<A> = {
-  readonly onEnter?: ((ast: AST, go: (ast: AST) => A) => Option.Option<A>) | undefined
-  readonly Declaration: (ast: Declaration, typeParameters: ReadonlyArray<A>) => A
-  readonly NullKeyword: (ast: NullKeyword) => A
-  readonly UndefinedKeyword: (ast: UndefinedKeyword) => A
-  readonly VoidKeyword: (ast: VoidKeyword) => A
-  readonly NeverKeyword: (ast: NeverKeyword) => A
-  readonly UnknownKeyword: (ast: UnknownKeyword) => A
-  readonly AnyKeyword: (ast: AnyKeyword) => A
-  readonly StringKeyword: (ast: StringKeyword) => A
-  readonly NumberKeyword: (ast: NumberKeyword) => A
-  readonly BooleanKeyword: (ast: BooleanKeyword) => A
-  readonly SymbolKeyword: (ast: SymbolKeyword) => A
-  readonly BigIntKeyword: (ast: BigIntKeyword) => A
-  readonly UniqueSymbol: (ast: UniqueSymbol) => A
-  readonly ObjectKeyword: (ast: ObjectKeyword) => A
-  readonly Enums: (ast: Enums) => A
-  readonly LiteralType: (ast: LiteralType) => A
-  readonly TemplateLiteral: (ast: TemplateLiteral, parts: ReadonlyArray<A | TemplateLiteral.LiteralPart>) => A
-  readonly TupleType: (ast: TupleType, elements: ReadonlyArray<A>, rest: ReadonlyArray<A>) => A
-  readonly TypeLiteral: (
-    ast: TypeLiteral,
-    propertySignatures: ReadonlyArray<[PropertySignature, A]>,
-    indexSignatures: ReadonlyArray<[IndexSignature, A]>
-  ) => A
-  readonly UnionType: (ast: UnionType, getCandidates: (ast: AST) => ReadonlyArray<AST>, go: (ast: AST) => A) => A
-  readonly Suspend: (ast: Suspend, thunk: () => A) => A
+  readonly onEnter?: ((ast: AST, reduce: (ast: AST) => A) => Option.Option<A>) | undefined
+  readonly Declaration: (ast: Declaration, reduce: (ast: AST) => A) => A
+  readonly NullKeyword: (ast: NullKeyword, reduce: (ast: AST) => A) => A
+  readonly UndefinedKeyword: (ast: UndefinedKeyword, reduce: (ast: AST) => A) => A
+  readonly VoidKeyword: (ast: VoidKeyword, reduce: (ast: AST) => A) => A
+  readonly NeverKeyword: (ast: NeverKeyword, reduce: (ast: AST) => A) => A
+  readonly UnknownKeyword: (ast: UnknownKeyword, reduce: (ast: AST) => A) => A
+  readonly AnyKeyword: (ast: AnyKeyword, reduce: (ast: AST) => A) => A
+  readonly StringKeyword: (ast: StringKeyword, reduce: (ast: AST) => A) => A
+  readonly NumberKeyword: (ast: NumberKeyword, reduce: (ast: AST) => A) => A
+  readonly BooleanKeyword: (ast: BooleanKeyword, reduce: (ast: AST) => A) => A
+  readonly SymbolKeyword: (ast: SymbolKeyword, reduce: (ast: AST) => A) => A
+  readonly BigIntKeyword: (ast: BigIntKeyword, reduce: (ast: AST) => A) => A
+  readonly UniqueSymbol: (ast: UniqueSymbol, reduce: (ast: AST) => A) => A
+  readonly ObjectKeyword: (ast: ObjectKeyword, reduce: (ast: AST) => A) => A
+  readonly Enums: (ast: Enums, reduce: (ast: AST) => A) => A
+  readonly LiteralType: (ast: LiteralType, reduce: (ast: AST) => A) => A
+  readonly TemplateLiteral: (ast: TemplateLiteral, reduce: (ast: AST) => A) => A
+  readonly TupleType: (ast: TupleType, reduce: (ast: AST) => A) => A
+  readonly TypeLiteral: (ast: TypeLiteral, reduce: (ast: AST) => A) => A
+  readonly UnionType: (ast: UnionType, reduce: (ast: AST) => A, getCandidates: (ast: AST) => ReadonlyArray<AST>) => A
+  readonly Suspend: (ast: Suspend, reduce: (ast: AST) => A) => A
 }
 
 /**
@@ -2223,58 +2219,13 @@ export function getReducer<A>(alg: ReducerAlg<A>) {
       }
     }
     // ---------------------------------------------
-    // handle AST
+    // handle AST nodes
     // ---------------------------------------------
     switch (ast._tag) {
-      case "Declaration":
-        return alg.Declaration(ast, ast.typeParameters.map(reduce))
-      case "NullKeyword":
-        return alg.NullKeyword(ast)
-      case "UndefinedKeyword":
-        return alg.UndefinedKeyword(ast)
-      case "VoidKeyword":
-        return alg.VoidKeyword(ast)
-      case "NeverKeyword":
-        return alg.NeverKeyword(ast)
-      case "UnknownKeyword":
-        return alg.UnknownKeyword(ast)
-      case "AnyKeyword":
-        return alg.AnyKeyword(ast)
-      case "StringKeyword":
-        return alg.StringKeyword(ast)
-      case "NumberKeyword":
-        return alg.NumberKeyword(ast)
-      case "BooleanKeyword":
-        return alg.BooleanKeyword(ast)
-      case "BigIntKeyword":
-        return alg.BigIntKeyword(ast)
-      case "SymbolKeyword":
-        return alg.SymbolKeyword(ast)
-      case "UniqueSymbol":
-        return alg.UniqueSymbol(ast)
-      case "ObjectKeyword":
-        return alg.ObjectKeyword(ast)
-      case "Enums":
-        return alg.Enums(ast)
-      case "LiteralType":
-        return alg.LiteralType(ast)
-      case "TemplateLiteral":
-        return alg.TemplateLiteral(
-          ast,
-          ast.parts.map((part) => Predicate.isObject(part) ? reduce(part) : part)
-        )
-      case "TupleType":
-        return alg.TupleType(ast, ast.elements.map(reduce), ast.rest.map(reduce))
-      case "TypeLiteral":
-        return alg.TypeLiteral(
-          ast,
-          ast.propertySignatures.map((ps) => [ps, reduce(ps.type)]),
-          ast.indexSignatures.map((is) => [is, reduce(is.type)])
-        )
       case "UnionType":
-        return alg.UnionType(ast, (t) => getCandidates(t, ast.types), reduce)
-      case "Suspend":
-        return alg.Suspend(ast, () => reduce(ast.thunk()))
+        return alg.UnionType(ast, reduce, (t) => getCandidates(t, ast.types))
+      default:
+        return alg[ast._tag](ast as any, reduce)
     }
   }
 }

--- a/packages/effect/src/schema/ToPretty.ts
+++ b/packages/effect/src/schema/ToPretty.ts
@@ -2,6 +2,7 @@
  * @since 4.0.0
  */
 import { formatPropertyKey, formatUnknown, memoizeThunk } from "../internal/schema/util.js"
+import * as Option from "../Option.js"
 import * as AST from "./AST.js"
 import type * as Schema from "./Schema.js"
 import * as ToParser from "./ToParser.js"
@@ -40,13 +41,6 @@ export declare namespace Annotation {
 /**
  * @since 4.0.0
  */
-export function make<T>(schema: Schema.Schema<T>): Pretty<T> {
-  return go(schema.ast)
-}
-
-/**
- * @since 4.0.0
- */
 export function override<S extends Schema.Top>(override: () => Pretty<S["Type"]>) {
   return (self: S): S["~rebuild.out"] => {
     return self.annotate({ pretty: { type: "override", override } })
@@ -62,135 +56,147 @@ export function getAnnotation(
   return ast.annotations?.pretty as any
 }
 
-const go = AST.memoize((ast: AST.AST): Pretty<any> => {
-  // ---------------------------------------------
-  // handle annotations
-  // ---------------------------------------------
-  const annotation = getAnnotation(ast)
-  if (annotation) {
-    switch (annotation.type) {
-      case "declaration": {
-        const typeParameters = (AST.isDeclaration(ast) ? ast.typeParameters : []).map(go)
-        return annotation.declaration(typeParameters)
-      }
-      case "override":
-        return annotation.override()
-    }
-  }
-  switch (ast._tag) {
-    case "NeverKeyword":
-      throw new Error("cannot generate Pretty, no annotation found for never", { cause: ast })
-    case "VoidKeyword":
-      return () => "void(0)"
-    case "Declaration":
-    case "NullKeyword":
-    case "UndefinedKeyword":
-    case "UnknownKeyword":
-    case "AnyKeyword":
-    case "StringKeyword":
-    case "NumberKeyword":
-    case "BooleanKeyword":
-    case "BigIntKeyword":
-    case "SymbolKeyword":
-    case "LiteralType":
-    case "UniqueSymbol":
-    case "ObjectKeyword":
-    case "Enums":
-    case "TemplateLiteral":
-      return formatUnknown
-    case "TupleType": {
-      const elements = ast.elements.map(go)
-      const rest = ast.rest.map(go)
-      return (t) => {
-        const out: Array<string> = []
-        let i = 0
-        // ---------------------------------------------
-        // handle elements
-        // ---------------------------------------------
-        for (; i < elements.length; i++) {
-          if (t.length < i + 1) {
-            if (AST.isOptional(ast.elements[i])) {
-              continue
-            }
-          } else {
-            out.push(elements[i](t[i]))
-          }
-        }
-        // ---------------------------------------------
-        // handle rest element
-        // ---------------------------------------------
-        if (rest.length > 0) {
-          const [head, ...tail] = rest
-          for (; i < t.length - tail.length; i++) {
-            out.push(head(t[i]))
-          }
-          // ---------------------------------------------
-          // handle post rest elements
-          // ---------------------------------------------
-          for (let j = 0; j < tail.length; j++) {
-            i += j
-            out.push(tail[j](t[i]))
-          }
-        }
+const defaultFormat = () => formatUnknown
 
-        return "[" + out.join(", ") + "]"
+/**
+ * @category Reducer
+ * @since 4.0.0
+ */
+export const defaultReducerAlg: AST.ReducerAlg<Pretty<any>> = {
+  onEnter: (ast, go) => {
+    const annotation = getAnnotation(ast)
+    if (annotation) {
+      switch (annotation.type) {
+        case "declaration": {
+          const typeParameters = (AST.isDeclaration(ast) ? ast.typeParameters : []).map(go)
+          return Option.some(annotation.declaration(typeParameters))
+        }
+        case "override":
+          return Option.some(annotation.override())
       }
     }
-    case "TypeLiteral": {
-      if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return formatUnknown
+    return Option.none()
+  },
+  Declaration: defaultFormat,
+  NullKeyword: defaultFormat,
+  UndefinedKeyword: defaultFormat,
+  VoidKeyword: () => () => "void(0)",
+  NeverKeyword: (ast) => {
+    throw new Error("cannot generate Pretty, no annotation found for never", { cause: ast })
+  },
+  UnknownKeyword: defaultFormat,
+  AnyKeyword: defaultFormat,
+  StringKeyword: defaultFormat,
+  NumberKeyword: defaultFormat,
+  BooleanKeyword: defaultFormat,
+  BigIntKeyword: defaultFormat,
+  SymbolKeyword: defaultFormat,
+  UniqueSymbol: defaultFormat,
+  ObjectKeyword: defaultFormat,
+  Enums: defaultFormat,
+  LiteralType: defaultFormat,
+  TemplateLiteral: defaultFormat,
+  TupleType: (ast, elements, rest) => (t) => {
+    const out: Array<string> = []
+    let i = 0
+    // ---------------------------------------------
+    // handle elements
+    // ---------------------------------------------
+    for (; i < elements.length; i++) {
+      if (t.length < i + 1) {
+        if (AST.isOptional(ast.elements[i])) {
+          continue
+        }
+      } else {
+        out.push(elements[i](t[i]))
       }
-      const propertySignatures = ast.propertySignatures.map((ps) => go(ps.type))
-      const indexSignatures = ast.indexSignatures.map((is) => go(is.type))
-      return (t) => {
-        const out: Array<string> = []
-        const visited = new Set<PropertyKey>()
-        // ---------------------------------------------
-        // handle property signatures
-        // ---------------------------------------------
-        for (let i = 0; i < propertySignatures.length; i++) {
-          const ps = ast.propertySignatures[i]
-          const name = ps.name
-          visited.add(name)
-          if (AST.isOptional(ps.type) && !Object.hasOwn(t, name)) {
+    }
+    // ---------------------------------------------
+    // handle rest element
+    // ---------------------------------------------
+    if (rest.length > 0) {
+      const [head, ...tail] = rest
+      for (; i < t.length - tail.length; i++) {
+        out.push(head(t[i]))
+      }
+      // ---------------------------------------------
+      // handle post rest elements
+      // ---------------------------------------------
+      for (let j = 0; j < tail.length; j++) {
+        i += j
+        out.push(tail[j](t[i]))
+      }
+    }
+
+    return "[" + out.join(", ") + "]"
+  },
+  TypeLiteral: (ast, propertySignatures, indexSignatures) => {
+    if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
+      return formatUnknown
+    }
+    return (t) => {
+      const out: Array<string> = []
+      const visited = new Set<PropertyKey>()
+      // ---------------------------------------------
+      // handle property signatures
+      // ---------------------------------------------
+      for (let i = 0; i < propertySignatures.length; i++) {
+        const ps = ast.propertySignatures[i]
+        const name = ps.name
+        visited.add(name)
+        if (AST.isOptional(ps.type) && !Object.hasOwn(t, name)) {
+          continue
+        }
+        out.push(
+          `${formatPropertyKey(name)}: ${propertySignatures[i][1](t[name])}`
+        )
+      }
+      // ---------------------------------------------
+      // handle index signatures
+      // ---------------------------------------------
+      for (let i = 0; i < indexSignatures.length; i++) {
+        const keys = AST.getIndexSignatureKeys(t, ast.indexSignatures[i])
+        for (const key of keys) {
+          if (visited.has(key)) {
             continue
           }
-          out.push(
-            `${formatPropertyKey(name)}: ${propertySignatures[i](t[name])}`
-          )
+          visited.add(key)
+          out.push(`${formatPropertyKey(key)}: ${indexSignatures[i][1](t[key])}`)
         }
-        // ---------------------------------------------
-        // handle index signatures
-        // ---------------------------------------------
-        for (let i = 0; i < indexSignatures.length; i++) {
-          const keys = AST.getIndexSignatureKeys(t, ast.indexSignatures[i])
-          for (const key of keys) {
-            if (visited.has(key)) {
-              continue
-            }
-            visited.add(key)
-            out.push(`${formatPropertyKey(key)}: ${indexSignatures[i](t[key])}`)
-          }
-        }
+      }
 
-        return out.length > 0 ? "{ " + out.join(", ") + " }" : "{}"
+      return out.length > 0 ? "{ " + out.join(", ") + " }" : "{}"
+    }
+  },
+  UnionType: (_, getCandidates, go) => (t) => {
+    const candidates = getCandidates(t)
+    const refinements = candidates.map(ToParser.refinement)
+    for (let i = 0; i < candidates.length; i++) {
+      const is = refinements[i]
+      if (is(t)) {
+        return go(candidates[i])(t)
       }
     }
-    case "UnionType":
-      return (t) => {
-        const candidates = AST.getCandidates(t, ast.types)
-        const types = candidates.map(ToParser.refinement)
-        for (let i = 0; i < candidates.length; i++) {
-          const is = types[i]
-          if (is(t)) {
-            return go(candidates[i])(t)
-          }
-        }
-        return formatUnknown(t)
-      }
-    case "Suspend": {
-      const get = memoizeThunk(() => go(ast.thunk()))
-      return (t) => get()(t)
-    }
+    return formatUnknown(t)
+  },
+  Suspend: (_, thunk) => {
+    const get = memoizeThunk(thunk)
+    return (t) => get()(t)
   }
-})
+}
+
+/**
+ * @category Reducer
+ * @since 4.0.0
+ */
+export function getReducer(alg: AST.ReducerAlg<Pretty<any>>) {
+  const reducer = AST.memoize(AST.getReducer<Pretty<any>>(alg))
+  return <T>(schema: Schema.Schema<T>): Pretty<T> => {
+    return reducer(schema.ast)
+  }
+}
+
+/**
+ * @since 4.0.0
+ */
+export const make = getReducer(defaultReducerAlg)

--- a/packages/effect/test/schema/ToPretty.test.ts
+++ b/packages/effect/test/schema/ToPretty.test.ts
@@ -420,4 +420,15 @@ describe("ToPretty", () => {
     strictEqual(pretty(true), "TRUE")
     strictEqual(pretty(false), "FALSE")
   })
+
+  it("should allow for custom compilers", () => {
+    const alg = {
+      ...ToPretty.defaultReducerAlg,
+      "BooleanKeyword": () => (b: boolean) => b ? "True" : "False"
+    }
+    const make = ToPretty.getReducer(alg)
+    strictEqual(make(Schema.Boolean)(true), `True`)
+    const schema = Schema.Tuple([Schema.String, Schema.Boolean])
+    strictEqual(make(schema)(["a", true]), `["a", True]`)
+  })
 })


### PR DESCRIPTION
Goal: port to v4 a feature that exists in v3, namely, the ability to override the default pretty printer

```ts
import { Schema, ToPretty } from "effect/schema"

const alg = {
  ...ToPretty.defaultReducerAlg,
  // override the default reducer for the BooleanKeyword
  "BooleanKeyword": () => (b: boolean) => b ? "True" : "False"
}

const make = ToPretty.getReducer(alg)

const schema = Schema.Tuple([Schema.String, Schema.Boolean])

console.log(make(schema)(["a", true]))
// ["a", True]
```