### PR TITLE
feat(Cause): add Cause.merge function to merge two causes

### DIFF
--- a/.changeset/cause-merge-addition.md
+++ b/.changeset/cause-merge-addition.md
@@ -1,7 +1,0 @@
----
-"effect": minor
----
-
-feat(Cause): add Cause.merge function to merge two causes
-
-Added `Cause.merge` function that merges two causes into a single cause containing failures from both. The function supports both curried and uncurried signatures following the dual pattern used throughout the Effect library.

--- a/.changeset/cause-merge-addition.md
+++ b/.changeset/cause-merge-addition.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+feat(Cause): add Cause.merge function to merge two causes
+
+Added `Cause.merge` function that merges two causes into a single cause containing failures from both. The function supports both curried and uncurried signatures following the dual pattern used throughout the Effect library.

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -421,6 +421,27 @@ export const interrupt: (fiberId?: number | undefined) => Cause<never> = effect.
 export const isInterruptedOnly: <E>(self: Cause<E>) => boolean = effect.causeIsInterruptedOnly
 
 /**
+ * Merges two causes into a single cause containing failures from both.
+ *
+ * @example
+ * ```ts
+ * import { Cause } from "effect"
+ *
+ * const cause1 = Cause.fail("error1")
+ * const cause2 = Cause.fail("error2")
+ * const merged = Cause.merge(cause1, cause2)
+ * console.log(merged.failures.length) // 2
+ * ```
+ *
+ * @category utils
+ * @since 4.0.0
+ */
+export const merge: {
+  <E2>(that: Cause<E2>): <E>(self: Cause<E>) => Cause<E | E2>
+  <E, E2>(self: Cause<E>, that: Cause<E2>): Cause<E | E2>
+} = effect.causeMerge
+
+/**
  * Squashes a `Cause` down to a single defect, chosen to be the "most important"
  * defect.
  *


### PR DESCRIPTION
## Summary
- Added `Cause.merge` function to the public API
- Exposes existing internal `causeMerge` implementation from `internal/effect.ts`
- Supports both curried and uncurried signatures following Effect library patterns

## Changes
- Added `Cause.merge` export to `packages/effect/src/Cause.ts`
- Added proper JSDoc documentation with TypeScript example
- Added changeset for minor version bump

## Function Signature
```typescript
export const merge: {
  <E2>(that: Cause<E2>): <E>(self: Cause<E>) => Cause<E | E2>
  <E, E2>(self: Cause<E>, that: Cause<E2>): Cause<E | E2>
}
```

## Usage Example
```typescript
import { Cause } from "effect"

const cause1 = Cause.fail("error1")
const cause2 = Cause.fail("error2")
const merged = Cause.merge(cause1, cause2)
console.log(merged.failures.length) // 2
```

## Test Plan
- [x] All linting passes (`pnpm lint`)
- [x] All tests pass (`pnpm test`)
- [x] Documentation generation succeeds (`pnpm docgen`)
- [x] JSDoc examples compile correctly
- [x] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)