### PR TITLE
remove `main` property from package.json in favor of exports

### DIFF
--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -26,7 +26,6 @@
     "observability"
   ],
   "sideEffects": [],
-  "main": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
@@ -46,7 +45,6 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "main": "./dist/index.js",
     "exports": {
       "./package.json": "./package.json",
       ".": "./dist/index.js",

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -26,7 +26,6 @@
     "functional-programming"
   ],
   "sideEffects": [],
-  "main": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
@@ -40,7 +39,6 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "main": "./dist/index.js",
     "exports": {
       "./package.json": "./package.json",
       ".": "./dist/index.js",

--- a/packages/platform-node-shared/package.json
+++ b/packages/platform-node-shared/package.json
@@ -27,7 +27,6 @@
     "node": ">=18.0.0"
   },
   "sideEffects": [],
-  "main": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
@@ -41,7 +40,6 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "main": "./dist/index.js",
     "exports": {
       "./package.json": "./package.json",
       ".": "./dist/index.js",

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -29,7 +29,6 @@
     "node": ">=18.0.0"
   },
   "sideEffects": [],
-  "main": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
@@ -43,7 +42,6 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "main": "./dist/index.js",
     "exports": {
       "./package.json": "./package.json",
       ".": "./dist/index.js",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -14,7 +14,6 @@
     "url": "https://github.com/Effect-TS/effect/issues"
   },
   "sideEffects": [],
-  "main": "./src/index.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
@@ -28,7 +27,6 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "main": "./dist/index.js",
     "exports": {
       "./package.json": "./package.json",
       ".": "./dist/index.js",


### PR DESCRIPTION
`exports` with a `.` export should be good enough nowadays. I do recall recently running into issues with this with some cli tools that were still expecting package.json's to have a `main` property. But I couldn't figure out anymore which one that was. Either way, the more we can elimiate the better ...