### PR TITLE
add stringLeafJson serializer

### DIFF
--- a/bundle/schema-stringLeafJson.ts
+++ b/bundle/schema-stringLeafJson.ts
@@ -1,0 +1,13 @@
+import * as Effect from "#dist/effect/Effect"
+import * as Schema from "#dist/effect/schema/Schema"
+import * as Serializer from "#dist/effect/schema/Serializer"
+
+const schema = Serializer.stringLeafJson(Schema.Struct({
+  a: Schema.String,
+  b: Schema.optionalKey(Schema.Number),
+  c: Schema.Array(Schema.String)
+}))
+
+Schema.decodeUnknownEffect(schema)({ a: "a", b: "1", c: ["c"] }).pipe(
+  Effect.runFork
+)

--- a/packages/effect/src/schema/AST.ts
+++ b/packages/effect/src/schema/AST.ts
@@ -12,12 +12,12 @@ import { formatPropertyKey, memoizeThunk, ownKeys } from "../internal/schema/uti
 import * as RegEx from "../primitives/RegExp.ts"
 import type { Annotated } from "./Annotations.ts"
 import type * as Annotations from "./Annotations.ts"
-import type * as Check from "./Check.ts"
+import * as Check from "./Check.ts"
 import * as Getter from "./Getter.ts"
 import * as Issue from "./Issue.ts"
 import type * as Schema from "./Schema.ts"
 import type * as ToParser from "./ToParser.ts"
-import * as Transformation_ from "./Transformation.ts"
+import * as Transformation from "./Transformation.ts"
 
 /**
  * @category model
@@ -180,25 +180,17 @@ export const isSuspend = makeGuard("Suspend")
  * @category model
  * @since 4.0.0
  */
-export type Middleware = Transformation_.Middleware<any, any, any, any, any, any>
-
-/**
- * @category model
- * @since 4.0.0
- */
-export type Transformation = Transformation_.Transformation<any, any, any, any>
-
-/**
- * @category model
- * @since 4.0.0
- */
 export class Link {
   readonly to: AST
-  readonly transformation: Transformation | Middleware
+  readonly transformation:
+    | Transformation.Transformation<any, any, any, any>
+    | Transformation.Middleware<any, any, any, any, any, any>
 
   constructor(
     to: AST,
-    transformation: Transformation | Middleware
+    transformation:
+      | Transformation.Transformation<any, any, any, any>
+      | Transformation.Middleware<any, any, any, any, any, any>
   ) {
     this.to = to
     this.transformation = transformation
@@ -549,36 +541,15 @@ export class Enums extends AbstractParser {
  */
 export const objectKeyword = new ObjectKeyword()
 
-/**
- * @since 4.0.0
- */
-export declare namespace TemplateLiteral {
-  /**
-   * @category model
-   * @since 4.0.0
-   */
-  export type ASTPart =
-    | StringKeyword
-    | NumberKeyword
-    | BigIntKeyword
-    | LiteralType
-    | TemplateLiteral
-    | UnionType<ASTPart>
-  /**
-   * @since 4.0.0
-   */
-  export type LiteralPart = string | number | bigint
-  /**
-   * @since 4.0.0
-   */
-  export type Part = ASTPart | LiteralPart
-  /**
-   * @since 4.0.0
-   */
-  export type Parts = ReadonlyArray<Part>
-}
+type TemplateLiteralPart =
+  | StringKeyword
+  | NumberKeyword
+  | BigIntKeyword
+  | LiteralType
+  | TemplateLiteral
+  | UnionType<TemplateLiteralPart>
 
-function isASTPart(ast: AST): ast is TemplateLiteral.ASTPart {
+function isTemplateLiteralPart(ast: AST): ast is TemplateLiteralPart {
   switch (ast._tag) {
     case "StringKeyword":
     case "NumberKeyword":
@@ -587,7 +558,7 @@ function isASTPart(ast: AST): ast is TemplateLiteral.ASTPart {
     case "TemplateLiteral":
       return true
     case "UnionType":
-      return ast.types.every(isASTPart)
+      return ast.types.every(isTemplateLiteralPart)
     default:
       return false
   }
@@ -599,33 +570,29 @@ function isASTPart(ast: AST): ast is TemplateLiteral.ASTPart {
  */
 export class TemplateLiteral extends AbstractParser {
   readonly _tag = "TemplateLiteral"
-  readonly parts: ReadonlyArray<AST | TemplateLiteral.LiteralPart>
+  readonly parts: ReadonlyArray<AST>
   /** @internal */
-  readonly flippedParts: ReadonlyArray<TemplateLiteral.ASTPart>
+  readonly encodedParts: ReadonlyArray<TemplateLiteralPart>
 
   constructor(
-    parts: ReadonlyArray<AST | TemplateLiteral.LiteralPart>,
+    parts: ReadonlyArray<AST>,
     annotations?: Annotations.Annotations,
     checks?: Checks,
     encoding?: Encoding,
     context?: Context
   ) {
     super(annotations, checks, encoding, context)
-    this.parts = parts
-    const flippedParts: Array<TemplateLiteral.ASTPart> = []
+    const encodedParts: Array<TemplateLiteralPart> = []
     for (const part of parts) {
-      if (Predicate.isObject(part)) {
-        const flipped = flip(part)
-        if (isASTPart(flipped)) {
-          flippedParts.push(flipped)
-        } else {
-          throw new Error("Invalid TemplateLiteral part")
-        }
+      const encoded = encodedAST(part)
+      if (isTemplateLiteralPart(encoded)) {
+        encodedParts.push(encoded)
       } else {
-        flippedParts.push(new LiteralType(part))
+        throw new Error("Invalid TemplateLiteral part")
       }
     }
-    this.flippedParts = flippedParts
+    this.parts = parts
+    this.encodedParts = encodedParts
   }
   /** @internal */
   parser(go: (ast: AST) => ToParser.Parser): ToParser.Parser {
@@ -639,54 +606,23 @@ export class TemplateLiteral extends AbstractParser {
       )
   }
   /** @internal */
-  asTemplateLiteralParser() {
-    const elements = this.flippedParts.map((part) => flip(addPartCoercion(part)))
-    const tuple = new TupleType(false, elements, [])
+  asTemplateLiteralParser(): TupleType {
+    const tuple = goStringLeafJson(new TupleType(false, this.parts, [])) as TupleType
     const regex = getTemplateLiteralRegExp(this)
     return decodeTo(
       stringKeyword,
       tuple,
-      new Transformation_.Transformation(
+      new Transformation.Transformation(
         Getter.map((s: string) => {
           const match = regex.exec(s)
           if (match) {
-            return match.slice(1, elements.length + 1)
+            return match.slice(1, this.parts.length + 1)
           }
           return []
         }),
         Getter.map((parts) => parts.join(""))
       )
     )
-  }
-}
-
-function addPartNumberCoercion(part: NumberKeyword | LiteralType): AST {
-  return decodeTo(part, stringKeyword, Transformation_.numberFromString.flip())
-}
-
-function addPartBigIntCoercion(part: BigIntKeyword | LiteralType): AST {
-  return decodeTo(part, stringKeyword, Transformation_.bigintFromString.flip())
-}
-
-function addPartCoercion(part: TemplateLiteral.ASTPart): AST {
-  switch (part._tag) {
-    case "NumberKeyword":
-      return addPartNumberCoercion(part)
-    case "BigIntKeyword":
-      return addPartBigIntCoercion(part)
-    case "UnionType":
-      return new UnionType(part.types.map(addPartCoercion), part.mode)
-    case "LiteralType": {
-      if (Predicate.isNumber(part.literal)) {
-        return addPartNumberCoercion(part)
-      } else if (Predicate.isBigInt(part.literal)) {
-        return addPartBigIntCoercion(part)
-      } else {
-        return part
-      }
-    }
-    default:
-      return part
   }
 }
 
@@ -1099,9 +1035,11 @@ export class TupleType extends Base {
 }
 
 function getIndexSignatureHash(ast: AST): string {
-  return isTemplateLiteral(ast) ?
-    ast.parts.map((part) => Predicate.isObject(part) ? `\${${getIndexSignatureHash(part)}}` : String(part)).join("") :
-    ast._tag
+  if (isTemplateLiteral(ast)) {
+    return ast.parts.map((part) => isLiteralType(part) ? String(part.literal) : `\${${getIndexSignatureHash(part)}}`)
+      .join("")
+  }
+  return ast._tag
 }
 
 /** @internal */
@@ -1811,18 +1749,26 @@ function applyEncoded<A extends AST>(ast: A, f: (ast: AST) => AST): A {
 }
 
 /** @internal */
-export function decodingMiddleware(ast: AST, middleware: Middleware): AST {
+export function decodingMiddleware(
+  ast: AST,
+  middleware: Transformation.Middleware<any, any, any, any, any, any>
+): AST {
   return appendTransformation(ast, middleware, typeAST(ast))
 }
 
 /** @internal */
-export function encodingMiddleware(ast: AST, middleware: Middleware): AST {
+export function encodingMiddleware(
+  ast: AST,
+  middleware: Transformation.Middleware<any, any, any, any, any, any>
+): AST {
   return appendTransformation(encodedAST(ast), middleware, ast)
 }
 
 function appendTransformation<A extends AST>(
   from: AST,
-  transformation: Transformation | Middleware,
+  transformation:
+    | Transformation.Transformation<any, any, any, any>
+    | Transformation.Middleware<any, any, any, any, any, any>,
   to: A
 ): A {
   const link = new Link(from, transformation)
@@ -1906,7 +1852,7 @@ export function withConstructorDefault<A extends AST>(
   ast: A,
   defaultValue: (input: Option.Option<undefined>) => Option.Option<unknown> | Effect.Effect<Option.Option<unknown>>
 ): A {
-  const transformation = new Transformation_.Transformation(
+  const transformation = new Transformation.Transformation(
     new Getter.Getter((o) => {
       if (Option.isNone(Option.filter(o, Predicate.isNotUndefined))) {
         const oe = defaultValue(o as Option.Option<undefined>)
@@ -1928,7 +1874,7 @@ export function withConstructorDefault<A extends AST>(
 export function decodeTo<A extends AST>(
   from: AST,
   to: A,
-  transformation: Transformation
+  transformation: Transformation.Transformation<any, any, any, any>
 ): A {
   return appendTransformation(from, transformation, to)
 }
@@ -2103,10 +2049,10 @@ function formatTail(tail: ReadonlyArray<AST>): string {
 }
 
 const formatTemplateLiteral = (ast: TemplateLiteral): string =>
-  "`" + ast.flippedParts.map((ast) => formatTemplateLiteralASTPart(typeAST(ast))).join("") +
+  "`" + ast.encodedParts.map((ast) => formatTemplateLiteralASTPart(ast)).join("") +
   "`"
 
-function formatTemplateLiteralASTPart(part: TemplateLiteral.ASTPart): string {
+function formatTemplateLiteralASTPart(part: TemplateLiteralPart): string {
   switch (part._tag) {
     case "LiteralType":
       return String(part.literal)
@@ -2120,7 +2066,7 @@ function formatTemplateLiteralASTPart(part: TemplateLiteral.ASTPart): string {
   }
 }
 
-const formatTemplateLiteralASTWithinUnion = (part: TemplateLiteral.ASTPart): string => {
+const formatTemplateLiteralASTWithinUnion = (part: TemplateLiteralPart): string => {
   if (isUnionType(part)) {
     return part.types.map(formatTemplateLiteralASTWithinUnion).join(" | ")
   }
@@ -2139,7 +2085,7 @@ export const format = memoize((ast: AST): string => {
       return "<Declaration>"
     }
     case "LiteralType":
-      return JSON.stringify(ast.literal)
+      return Predicate.isString(ast.literal) ? JSON.stringify(ast.literal) : String(ast.literal)
     case "NeverKeyword":
       return "never"
     case "AnyKeyword":
@@ -2222,7 +2168,7 @@ export const format = memoize((ast: AST): string => {
 })
 
 function getTemplateLiteralSource(ast: TemplateLiteral, top: boolean): string {
-  return ast.flippedParts.map((part) =>
+  return ast.encodedParts.map((part) =>
     handleTemplateLiteralASTPartParens(part, getTemplateLiteralASTPartPattern(part), top)
   ).join("")
 }
@@ -2232,15 +2178,20 @@ export const getTemplateLiteralRegExp = memoize((ast: TemplateLiteral): RegExp =
   return new RegExp(`^${getTemplateLiteralSource(ast, true)}$`)
 })
 
-// any string, including newlines
+/**
+ * any string, including newlines
+ */
 const STRING_KEYWORD_PATTERN = "[\\s\\S]*"
-// floating point or integer, with optional exponent
-/** @internal */
-export const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
-// signed integer only (no leading “+”)
+/**
+ * floating point or integer, with optional exponent, no leading “+”
+ */
+const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
+/**
+ * signed integer only (no leading “+”)
+ */
 const BIGINT_KEYWORD_PATTERN = "-?\\d+"
 
-function getTemplateLiteralASTPartPattern(part: TemplateLiteral.ASTPart): string {
+function getTemplateLiteralASTPartPattern(part: TemplateLiteralPart): string {
   switch (part._tag) {
     case "LiteralType":
       return RegEx.escape(String(part.literal))
@@ -2257,7 +2208,7 @@ function getTemplateLiteralASTPartPattern(part: TemplateLiteral.ASTPart): string
   }
 }
 
-function handleTemplateLiteralASTPartParens(part: TemplateLiteral.ASTPart, s: string, top: boolean): string {
+function handleTemplateLiteralASTPartParens(part: TemplateLiteralPart, s: string, top: boolean): string {
   if (isUnionType(part)) {
     if (!top) {
       return `(?:${s})`
@@ -2268,8 +2219,7 @@ function handleTemplateLiteralASTPartParens(part: TemplateLiteral.ASTPart, s: st
   return `(${s})`
 }
 
-/** @internal */
-export function fromRefinement<T>(
+function fromRefinement<T>(
   ast: AST,
   refinement: (input: unknown) => input is T
 ): ToParser.Parser {
@@ -2362,3 +2312,172 @@ export function getReducer<A>(alg: ReducerAlg<A>) {
     }
   }
 }
+
+const stringNull = new LiteralType("")
+
+const nullLink = new Link(
+  stringNull,
+  Transformation.transform({
+    decode: () => null,
+    encode: () => stringNull.literal
+  })
+)
+
+function coerceNull(ast: NullKeyword): NullKeyword {
+  return replaceEncoding(ast, [nullLink])
+}
+
+const numberKeywordPattern = appendChecks(stringKeyword, [
+  Check.regex(new RegExp(NUMBER_KEYWORD_PATTERN))
+])
+
+const numberLink = new Link(
+  numberKeywordPattern,
+  Transformation.numberFromString
+)
+
+function coerceNumber<A extends NumberKeyword | LiteralType>(ast: A): A {
+  return replaceEncoding(ast, [numberLink])
+}
+
+const booleanLink = new Link(
+  new UnionType([new LiteralType("true"), new LiteralType("false")], "anyOf"),
+  new Transformation.Transformation(
+    Getter.map((s) => s === "true"),
+    Getter.String()
+  )
+)
+
+function coerceBoolean<A extends BooleanKeyword | LiteralType>(ast: A): A {
+  return replaceEncoding(ast, [booleanLink])
+}
+
+const bigIntLink = new Link(
+  numberKeywordPattern,
+  new Transformation.Transformation(
+    Getter.map(BigInt),
+    Getter.String()
+  )
+)
+
+/** @internal */
+export function coerceBigInt<A extends BigIntKeyword | LiteralType>(ast: A): A {
+  return replaceEncoding(ast, [bigIntLink])
+}
+
+/** @internal */
+export const goStringLeafJson = memoize((ast: AST): AST => {
+  if (ast.encoding) {
+    const links = ast.encoding
+    const last = links[links.length - 1]
+    const to = goStringLeafJson(last.to)
+    if (to === last.to) {
+      return ast
+    }
+    return replaceEncoding(
+      ast,
+      Arr.append(
+        links.slice(0, links.length - 1),
+        new Link(to, last.transformation)
+      )
+    )
+  }
+  switch (ast._tag) {
+    case "StringKeyword":
+    case "TemplateLiteral":
+      return ast
+    case "NumberKeyword":
+      return coerceNumber(ast)
+    case "BooleanKeyword":
+      return coerceBoolean(ast)
+    case "NullKeyword":
+      return coerceNull(ast)
+    case "BigIntKeyword":
+      return coerceBigInt(ast)
+    case "LiteralType": {
+      if (Predicate.isNumber(ast.literal)) {
+        return coerceNumber(ast)
+      }
+      if (Predicate.isBoolean(ast.literal)) {
+        return coerceBoolean(ast)
+      }
+      if (Predicate.isBigInt(ast.literal)) {
+        return coerceBigInt(ast)
+      }
+      return ast
+    }
+    case "Enums": {
+      if (ast.enums.some(([_, v]) => Predicate.isNumber(v))) {
+        const coercions = Object.fromEntries(ast.enums.map(([_, v]) => [String(v), v]))
+        const enumLink = new Link(
+          new UnionType(Object.keys(coercions).map((k) => new LiteralType(k)), "anyOf"),
+          new Transformation.Transformation(
+            Getter.map((s) => coercions[s]),
+            Getter.String()
+          )
+        )
+        return replaceEncoding(ast, [enumLink])
+      }
+      return ast
+    }
+    case "TypeLiteral": {
+      const propertySignatures = mapOrSame(
+        ast.propertySignatures,
+        (ps) => {
+          const type = goStringLeafJson(ps.type)
+          if (type === ps.type) {
+            return ps
+          }
+          return new PropertySignature(ps.name, type)
+        }
+      )
+      const indexSignatures = mapOrSame(
+        ast.indexSignatures,
+        (is) => {
+          const parameter = goStringLeafJson(is.parameter)
+          const type = goStringLeafJson(is.type)
+          if (parameter === is.parameter && type === is.type) {
+            return is
+          }
+          return new IndexSignature(is.isMutable, parameter, type, is.merge)
+        }
+      )
+      if (propertySignatures === ast.propertySignatures && indexSignatures === ast.indexSignatures) {
+        return ast
+      }
+      return new TypeLiteral(
+        propertySignatures,
+        indexSignatures,
+        ast.annotations,
+        ast.checks,
+        undefined,
+        ast.context
+      )
+    }
+    case "TupleType": {
+      const elements = mapOrSame(ast.elements, goStringLeafJson)
+      const rest = mapOrSame(ast.rest, goStringLeafJson)
+      if (elements === ast.elements && rest === ast.rest) {
+        return ast
+      }
+      return new TupleType(ast.isMutable, elements, rest, ast.annotations, ast.checks, undefined, ast.context)
+    }
+    case "UnionType": {
+      const types = mapOrSame(ast.types, goStringLeafJson)
+      if (types === ast.types) {
+        return ast
+      }
+      return new UnionType(types, ast.mode, ast.annotations, ast.checks, undefined, ast.context)
+    }
+    case "Suspend":
+      return new Suspend(
+        () => goStringLeafJson(ast.thunk()),
+        ast.annotations,
+        ast.checks,
+        undefined,
+        ast.context
+      )
+    default:
+      throw new Error(`BUG: unreachable: ${ast._tag}`)
+  }
+})

--- a/packages/effect/src/schema/AST.ts
+++ b/packages/effect/src/schema/AST.ts
@@ -2235,7 +2235,8 @@ export const getTemplateLiteralRegExp = memoize((ast: TemplateLiteral): RegExp =
 // any string, including newlines
 const STRING_KEYWORD_PATTERN = "[\\s\\S]*"
 // floating point or integer, with optional exponent
-const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
+/** @internal */
+export const NUMBER_KEYWORD_PATTERN = "[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?"
 // signed integer only (no leading “+”)
 const BIGINT_KEYWORD_PATTERN = "-?\\d+"
 

--- a/packages/effect/src/schema/Getter.ts
+++ b/packages/effect/src/schema/Getter.ts
@@ -220,6 +220,13 @@ export function Number<E>(): Getter<number, E> {
 }
 
 /**
+ * @since 4.0.0
+ */
+export function parseFloat<E extends string>(): Getter<number, E> {
+  return map(globalThis.parseFloat)
+}
+
+/**
  * @category Coercions
  * @since 4.0.0
  */

--- a/packages/effect/src/schema/MetaAST.ts
+++ b/packages/effect/src/schema/MetaAST.ts
@@ -351,9 +351,7 @@ export const TemplateLiteral = Schema.instanceOf(
       Schema.link<ast.TemplateLiteral>()(
         Schema.Struct({
           _tag: Schema.tag("TemplateLiteral"),
-          parts: Schema.Array(
-            Schema.Union([SuspendedAST, Schema.String, Schema.Number, Schema.BigInt])
-          )
+          parts: Schema.Array(SuspendedAST)
         }),
         Transformation.transform({
           decode: (i) => new ast.TemplateLiteral(i.parts),

--- a/packages/effect/src/schema/Schema.ts
+++ b/packages/effect/src/schema/Schema.ts
@@ -1074,10 +1074,17 @@ export declare namespace TemplateLiteral {
   export interface SchemaPart extends Top {
     readonly Encoded: string | number | bigint
   }
+
   /**
    * @since 4.0.0
    */
-  export type Part = SchemaPart | AST.TemplateLiteral.LiteralPart
+  export type LiteralPart = string | number | bigint
+
+  /**
+   * @since 4.0.0
+   */
+  export type Part = SchemaPart | LiteralPart
+
   /**
    * @since 4.0.0
    */
@@ -1086,8 +1093,8 @@ export declare namespace TemplateLiteral {
   type AppendType<
     Template extends string,
     Next
-  > = Next extends AST.TemplateLiteral.LiteralPart ? `${Template}${Next}`
-    : Next extends Codec<unknown, infer E extends AST.TemplateLiteral.LiteralPart, unknown, unknown> ? `${Template}${E}`
+  > = Next extends LiteralPart ? `${Template}${Next}`
+    : Next extends Codec<unknown, infer E extends LiteralPart, unknown, unknown> ? `${Template}${E}`
     : never
 
   /**
@@ -1126,17 +1133,14 @@ class TemplateLiteral$<Parts extends TemplateLiteral.Parts> extends make$<Templa
 }
 
 function templateLiteralFromParts<Parts extends TemplateLiteral.Parts>(parts: Parts) {
-  return new AST.TemplateLiteral(parts.map((part) => isSchema(part) ? part.ast : part))
+  return new AST.TemplateLiteral(parts.map((part) => isSchema(part) ? part.ast : new AST.LiteralType(part)))
 }
 
 /**
  * @since 4.0.0
  */
 export function TemplateLiteral<const Parts extends TemplateLiteral.Parts>(parts: Parts): TemplateLiteral<Parts> {
-  return new TemplateLiteral$(
-    templateLiteralFromParts(parts),
-    [...parts] as Parts
-  )
+  return new TemplateLiteral$(templateLiteralFromParts(parts), [...parts] as Parts)
 }
 
 /**
@@ -1147,7 +1151,7 @@ export declare namespace TemplateLiteralParser {
    * @since 4.0.0
    */
   export type Type<Parts> = Parts extends readonly [infer Head, ...infer Tail] ? readonly [
-      Head extends AST.TemplateLiteral.LiteralPart ? Head :
+      Head extends TemplateLiteral.LiteralPart ? Head :
         Head extends Codec<infer T, unknown, unknown, unknown> ? T
         : never,
       ...Type<Tail>
@@ -1189,10 +1193,7 @@ class TemplateLiteralParser$<Parts extends TemplateLiteral.Parts> extends make$<
 export function TemplateLiteralParser<const Parts extends TemplateLiteral.Parts>(
   parts: Parts
 ): TemplateLiteralParser<Parts> {
-  return new TemplateLiteralParser$(
-    templateLiteralFromParts(parts).asTemplateLiteralParser(),
-    [...parts] as Parts
-  )
+  return new TemplateLiteralParser$(templateLiteralFromParts(parts).asTemplateLiteralParser(), [...parts] as Parts)
 }
 
 /**

--- a/packages/effect/src/schema/Serializer.ts
+++ b/packages/effect/src/schema/Serializer.ts
@@ -222,10 +222,10 @@ const booleanFromString = new Transformation.Transformation(
 
 const stringNull = new AST.LiteralType("")
 
-const nullFromEmptyString = new Transformation.Transformation(
-  Getter.succeed(null),
-  Getter.succeed(stringNull.literal)
-)
+const nullFromEmptyString = Transformation.transform({
+  decode: () => null,
+  encode: () => stringNull.literal
+})
 
 const goStringLeafJson = AST.memoize((ast: AST.AST): AST.AST => {
   if (ast.encoding) {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3661,7 +3661,7 @@ describe("Schema", () => {
     })
 
     it("< + h + (1|2) + >", async () => {
-      const schema = Schema.TemplateLiteral(["<", Schema.TemplateLiteral(["h", Schema.Literals([1, 2])]), ">"])
+      const schema = Schema.TemplateLiteral(["<", Schema.TemplateLiteral(["h", Schema.Literals([1, 2n])]), ">"])
 
       assertions.schema.format(schema, "`<${`h${1 | 2}`}>`")
 

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -1,5 +1,5 @@
 import { Option } from "effect/data"
-import { Schema, Serializer, Transformation } from "effect/schema"
+import { Check, Schema, Serializer, Transformation } from "effect/schema"
 import { describe, it } from "vitest"
 import { strictEqual } from "../utils/assert.ts"
 import { assertions } from "../utils/schema.ts"
@@ -13,204 +13,385 @@ const FiniteFromDate = Schema.Date.pipe(Schema.decodeTo(
 ))
 
 describe("Serializer", () => {
-  describe("default serialization", () => {
-    describe("should return the same reference if nothing changed", () => {
-      it("Struct", async () => {
+  describe("json", () => {
+    describe("default serialization", () => {
+      describe("should return the same reference if nothing changed", () => {
+        it("Struct", async () => {
+          const schema = Schema.Struct({
+            a: Schema.String,
+            b: Schema.Number
+          })
+          const serializer = Serializer.json(schema)
+          strictEqual(serializer.ast, schema.ast)
+        })
+
+        it("Record", async () => {
+          const schema = Schema.Record(Schema.String, Schema.Number)
+          const serializer = Serializer.json(schema)
+          strictEqual(serializer.ast, schema.ast)
+        })
+
+        it("Tuple", async () => {
+          const schema = Schema.Tuple([Schema.String, Schema.Number])
+          const serializer = Serializer.json(schema)
+          strictEqual(serializer.ast, schema.ast)
+        })
+
+        it("Array", async () => {
+          const schema = Schema.Array(Schema.String)
+          const serializer = Serializer.json(schema)
+          strictEqual(serializer.ast, schema.ast)
+        })
+
+        it("Union", async () => {
+          const schema = Schema.Union([Schema.String, Schema.Number])
+          const serializer = Serializer.json(schema)
+          strictEqual(serializer.ast, schema.ast)
+        })
+      })
+
+      it("should apply the construction process to the provided link in the annotations", async () => {
         const schema = Schema.Struct({
-          a: Schema.String,
+          a: Schema.Date.annotate({
+            defaultJsonSerializer: () =>
+              Schema.link<Date>()(
+                Schema.Date,
+                Transformation.passthrough()
+              )
+          }),
           b: Schema.Number
         })
-        const serializer = Serializer.json(schema)
-        strictEqual(serializer.ast, schema.ast)
+        await assertions.serialization.json.schema.succeed(schema, { a: new Date("2021-01-01"), b: 1 }, {
+          a: "2021-01-01T00:00:00.000Z",
+          b: 1
+        })
       })
 
-      it("Record", async () => {
-        const schema = Schema.Record(Schema.String, Schema.Number)
-        const serializer = Serializer.json(schema)
-        strictEqual(serializer.ast, schema.ast)
+      it("Undefined", async () => {
+        const schema = Schema.Undefined
+
+        await assertions.serialization.json.schema.fail(
+          schema,
+          undefined,
+          "cannot serialize to JSON, required `defaultJsonSerializer` annotation"
+        )
       })
 
-      it("Tuple", async () => {
-        const schema = Schema.Tuple([Schema.String, Schema.Number])
-        const serializer = Serializer.json(schema)
-        strictEqual(serializer.ast, schema.ast)
+      it("String", async () => {
+        const schema = Schema.String
+
+        await assertions.serialization.json.schema.succeed(schema, "a")
       })
 
-      it("Array", async () => {
-        const schema = Schema.Array(Schema.String)
-        const serializer = Serializer.json(schema)
-        strictEqual(serializer.ast, schema.ast)
+      it("Symbol", async () => {
+        const schema = Schema.Symbol
+
+        await assertions.serialization.json.schema.succeed(schema, Symbol.for("a"), "a")
+        await assertions.serialization.json.schema.fail(
+          schema,
+          Symbol("a"),
+          "cannot serialize to string, Symbol is not registered"
+        )
+        await assertions.serialization.json.schema.fail(
+          schema,
+          Symbol(),
+          "cannot serialize to string, Symbol has no description"
+        )
+
+        await assertions.deserialization.json.schema.succeed(schema, "a", Symbol.for("a"))
       })
 
-      it("Union", async () => {
-        const schema = Schema.Union([Schema.String, Schema.Number])
-        const serializer = Serializer.json(schema)
-        strictEqual(serializer.ast, schema.ast)
+      it("BigInt", async () => {
+        const schema = Schema.BigInt
+
+        await assertions.serialization.json.schema.succeed(schema, 1n, "1")
+        await assertions.deserialization.json.schema.succeed(schema, "1", 1n)
+      })
+
+      it("URL", async () => {
+        const schema = Schema.URL
+
+        await assertions.serialization.json.schema.succeed(
+          schema,
+          new URL("https://example.com"),
+          "https://example.com/"
+        )
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          "https://example.com",
+          new URL("https://example.com")
+        )
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          "https://example.com/",
+          new URL("https://example.com")
+        )
+        await assertions.deserialization.json.schema.fail(
+          schema,
+          "not a url",
+          `Invalid data "not a url"`
+        )
+      })
+
+      it("declareRefinement without annotation", async () => {
+        class A {
+          readonly _tag = "A"
+        }
+        const schema = Schema.declare((u): u is A => u instanceof A)
+        await assertions.serialization.json.schema.fail(
+          schema,
+          new A(),
+          "cannot serialize to JSON, required `defaultJsonSerializer` annotation"
+        )
+      })
+
+      it("Date", async () => {
+        const schema = Schema.Date
+
+        await assertions.serialization.json.schema.succeed(schema, new Date("2021-01-01"), "2021-01-01T00:00:00.000Z")
+      })
+
+      it("Option(Date)", async () => {
+        const schema = Schema.Option(Schema.Date)
+
+        await assertions.serialization.json.schema.succeed(schema, Option.some(new Date("2021-01-01")), [
+          "2021-01-01T00:00:00.000Z"
+        ])
+        await assertions.serialization.json.schema.succeed(schema, Option.none(), [])
+      })
+
+      it("Struct", async () => {
+        const schema = Schema.Struct({
+          a: Schema.Date,
+          b: Schema.Date
+        })
+
+        await assertions.serialization.json.schema.succeed(
+          schema,
+          { a: new Date("2021-01-01"), b: new Date("2021-01-01") },
+          { a: "2021-01-01T00:00:00.000Z", b: "2021-01-01T00:00:00.000Z" }
+        )
+      })
+
+      it("Record(Symbol, Date)", async () => {
+        const schema = Schema.Record(Schema.Symbol, Schema.Date)
+
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" },
+          { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") }
+        )
+
+        await assertions.serialization.json.schema.succeed(
+          schema,
+          { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") },
+          { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" }
+        )
+      })
+
+      it("Tuple(Date, Date)", async () => {
+        const schema = Schema.Tuple([Schema.Date, Schema.Date])
+
+        await assertions.serialization.json.schema.succeed(
+          schema,
+          [new Date("2021-01-01"), new Date("2021-01-01")],
+          ["2021-01-01T00:00:00.000Z", "2021-01-01T00:00:00.000Z"]
+        )
+      })
+
+      it("FiniteFromDate", async () => {
+        const schema = FiniteFromDate
+
+        await assertions.serialization.json.schema.succeed(schema, 0, 0)
+      })
+
+      it("Union(Schema.Date, Schema.Date)", async () => {
+        const schema = Schema.Union([Schema.Date, FiniteFromDate])
+
+        await assertions.serialization.json.schema.succeed(schema, new Date("2021-01-01"), "2021-01-01T00:00:00.000Z")
+        await assertions.serialization.json.schema.succeed(schema, 0, 0)
+      })
+
+      it("Map", async () => {
+        const schema = Schema.Map(Schema.Option(Schema.Date), FiniteFromDate)
+
+        await assertions.serialization.json.schema.succeed(
+          schema,
+          new Map([[Option.some(new Date("2021-01-01")), 0]]),
+          [[
+            ["2021-01-01T00:00:00.000Z"],
+            0
+          ]]
+        )
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          [[["2021-01-01T00:00:00.000Z"], 0]],
+          new Map([[Option.some(new Date("2021-01-01")), 0]])
+        )
+      })
+
+      it("Class", async () => {
+        class A extends Schema.Class<A>("A")(Schema.Struct({
+          a: FiniteFromDate
+        })) {}
+
+        await assertions.serialization.json.schema.succeed(A, new A({ a: 0 }), { a: 0 })
+        await assertions.deserialization.json.schema.succeed(A, { a: 0 }, new A({ a: 0 }))
+      })
+
+      it("ErrorClass", async () => {
+        class E extends Schema.ErrorClass<E>("E")({
+          a: FiniteFromDate
+        }) {}
+
+        await assertions.serialization.json.schema.succeed(E, new E({ a: 0 }), { a: 0 })
+        await assertions.deserialization.json.schema.succeed(E, { a: 0 }, new E({ a: 0 }))
+      })
+
+      it("Enums", async () => {
+        enum Fruits {
+          Apple,
+          Banana
+        }
+        const schema = Schema.Enums(Fruits)
+
+        await assertions.serialization.json.schema.succeed(schema, Fruits.Apple, 0)
+        await assertions.serialization.json.schema.succeed(schema, Fruits.Banana, 1)
+        await assertions.deserialization.json.schema.succeed(schema, 0, Fruits.Apple)
+        await assertions.deserialization.json.schema.succeed(schema, 1, Fruits.Banana)
       })
     })
 
-    it("should apply the construction process to the provided link in the annotations", async () => {
-      const schema = Schema.Struct({
-        a: Schema.Date.annotate({
-          defaultJsonSerializer: () =>
-            Schema.link<Date>()(
-              Schema.Date,
-              Transformation.passthrough()
-            )
-        }),
-        b: Schema.Number
-      })
-      await assertions.serialization.schema.succeed(schema, { a: new Date("2021-01-01"), b: 1 }, {
-        a: "2021-01-01T00:00:00.000Z",
-        b: 1
-      })
-    })
+    describe("custom serialization", () => {
+      it("FiniteFromDate", async () => {
+        const schema = FiniteFromDate
 
-    it("Undefined", async () => {
-      const schema = Schema.Undefined
-
-      await assertions.serialization.schema.fail(
-        schema,
-        undefined,
-        "cannot serialize to JSON, required `defaultJsonSerializer` annotation"
-      )
-    })
-
-    it("String", async () => {
-      const schema = Schema.String
-
-      await assertions.serialization.schema.succeed(schema, "a")
-    })
-
-    it("Symbol", async () => {
-      const schema = Schema.Symbol
-
-      await assertions.serialization.schema.succeed(schema, Symbol.for("a"), "a")
-      await assertions.serialization.schema.fail(
-        schema,
-        Symbol("a"),
-        "cannot serialize to JSON, Symbol is not registered"
-      )
-      await assertions.serialization.schema.fail(
-        schema,
-        Symbol(),
-        "cannot serialize to JSON, Symbol has no description"
-      )
-
-      await assertions.deserialization.schema.succeed(schema, "a", Symbol.for("a"))
-    })
-
-    it("BigInt", async () => {
-      const schema = Schema.BigInt
-
-      await assertions.serialization.schema.succeed(schema, 1n, "1")
-      await assertions.deserialization.schema.succeed(schema, "1", 1n)
-    })
-
-    it("URL", async () => {
-      const schema = Schema.URL
-
-      await assertions.serialization.schema.succeed(schema, new URL("https://example.com"), "https://example.com/")
-      await assertions.deserialization.schema.succeed(schema, "https://example.com", new URL("https://example.com"))
-      await assertions.deserialization.schema.succeed(schema, "https://example.com/", new URL("https://example.com"))
-      await assertions.deserialization.schema.fail(
-        schema,
-        "not a url",
-        `Invalid data "not a url"`
-      )
-    })
-
-    it("declareRefinement without annotation", async () => {
-      class A {
-        readonly _tag = "A"
-      }
-      const schema = Schema.declare((u): u is A => u instanceof A)
-      await assertions.serialization.schema.fail(
-        schema,
-        new A(),
-        "cannot serialize to JSON, required `defaultJsonSerializer` annotation"
-      )
-    })
-
-    it("Date", async () => {
-      const schema = Schema.Date
-
-      await assertions.serialization.schema.succeed(schema, new Date("2021-01-01"), "2021-01-01T00:00:00.000Z")
-    })
-
-    it("Option(Date)", async () => {
-      const schema = Schema.Option(Schema.Date)
-
-      await assertions.serialization.schema.succeed(schema, Option.some(new Date("2021-01-01")), [
-        "2021-01-01T00:00:00.000Z"
-      ])
-      await assertions.serialization.schema.succeed(schema, Option.none(), [])
-    })
-
-    it("Struct", async () => {
-      const schema = Schema.Struct({
-        a: Schema.Date,
-        b: Schema.Date
+        await assertions.serialization.json.codec.succeed(schema, 0, "1970-01-01T00:00:00.000Z")
       })
 
-      await assertions.serialization.schema.succeed(
-        schema,
-        { a: new Date("2021-01-01"), b: new Date("2021-01-01") },
-        { a: "2021-01-01T00:00:00.000Z", b: "2021-01-01T00:00:00.000Z" }
-      )
+      it("Struct", async () => {
+        const schema = Schema.Struct({
+          a: FiniteFromDate,
+          b: FiniteFromDate
+        })
+
+        await assertions.serialization.json.codec.succeed(
+          schema,
+          { a: 0, b: 0 },
+          { a: "1970-01-01T00:00:00.000Z", b: "1970-01-01T00:00:00.000Z" }
+        )
+      })
+
+      it("Tuple(Schema.Date, Schema.Date)", async () => {
+        const schema = Schema.Tuple([FiniteFromDate, FiniteFromDate])
+
+        await assertions.serialization.json.codec.succeed(
+          schema,
+          [0, 0],
+          ["1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"]
+        )
+      })
+
+      it("Option(Option(FiniteFromDate))", async () => {
+        const schema = Schema.Option(Schema.Option(FiniteFromDate))
+
+        await assertions.serialization.json.codec.succeed(schema, Option.some(Option.some(0)), [[
+          "1970-01-01T00:00:00.000Z"
+        ]])
+      })
+
+      it("Map(Option(Symbol), Date)", async () => {
+        const schema = Schema.Map(Schema.Option(Schema.Symbol), Schema.Date)
+
+        await assertions.serialization.json.codec.succeed(
+          schema,
+          new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]]),
+          [[
+            ["a"],
+            "2021-01-01T00:00:00.000Z"
+          ]]
+        )
+        await assertions.deserialization.json.codec.succeed(
+          schema,
+          [[["a"], "2021-01-01T00:00:00.000Z"]],
+          new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]])
+        )
+      })
     })
 
-    it("Record(Symbol, Date)", async () => {
-      const schema = Schema.Record(Schema.Symbol, Schema.Date)
+    describe("instanceOf", () => {
+      it("arg: message: string", async () => {
+        class MyError extends Error {
+          constructor(message?: string) {
+            super(message)
+            this.name = "MyError"
+            Object.setPrototypeOf(this, MyError.prototype)
+          }
+        }
 
-      await assertions.deserialization.schema.succeed(
-        schema,
-        { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" },
-        { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") }
-      )
+        const schema = Schema.instanceOf(
+          MyError,
+          {
+            title: "MyError",
+            defaultJsonSerializer: () =>
+              Schema.link<MyError>()(
+                Schema.String,
+                Transformation.transform({
+                  decode: (message) => new MyError(message),
+                  encode: (e) => e.message
+                })
+              )
+          }
+        )
 
-      await assertions.serialization.schema.succeed(
-        schema,
-        { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") },
-        { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" }
-      )
-    })
+        await assertions.serialization.json.schema.succeed(schema, new MyError("a"), "a")
+        await assertions.deserialization.json.schema.succeed(schema, "a", new MyError("a"))
+      })
 
-    it("Tuple(Date, Date)", async () => {
-      const schema = Schema.Tuple([Schema.Date, Schema.Date])
+      it("arg: struct", async () => {
+        class MyError extends Error {
+          static Props = Schema.Struct({
+            message: Schema.String,
+            cause: Schema.String
+          })
 
-      await assertions.serialization.schema.succeed(
-        schema,
-        [new Date("2021-01-01"), new Date("2021-01-01")],
-        ["2021-01-01T00:00:00.000Z", "2021-01-01T00:00:00.000Z"]
-      )
-    })
+          constructor(props: typeof MyError.Props["Type"]) {
+            super(props.message, { cause: props.cause })
+            this.name = "MyError"
+            Object.setPrototypeOf(this, MyError.prototype)
+          }
 
-    it("FiniteFromDate", async () => {
-      const schema = FiniteFromDate
+          static schema = Schema.instanceOf(
+            MyError,
+            {
+              title: "MyError",
+              defaultJsonSerializer: () =>
+                Schema.link<MyError>()(
+                  MyError.Props,
+                  Transformation.transform({
+                    decode: (props) => new MyError(props),
+                    encode: (e) => ({
+                      message: e.message,
+                      cause: typeof e.cause === "string" ? e.cause : String(e.cause)
+                    })
+                  })
+                )
+            }
+          )
+        }
 
-      await assertions.serialization.schema.succeed(schema, 0, 0)
-    })
+        const schema = MyError.schema
 
-    it("Union(Schema.Date, Schema.Date)", async () => {
-      const schema = Schema.Union([Schema.Date, FiniteFromDate])
-
-      await assertions.serialization.schema.succeed(schema, new Date("2021-01-01"), "2021-01-01T00:00:00.000Z")
-      await assertions.serialization.schema.succeed(schema, 0, 0)
-    })
-
-    it("Map", async () => {
-      const schema = Schema.Map(Schema.Option(Schema.Date), FiniteFromDate)
-
-      await assertions.serialization.schema.succeed(schema, new Map([[Option.some(new Date("2021-01-01")), 0]]), [[
-        ["2021-01-01T00:00:00.000Z"],
-        0
-      ]])
-      await assertions.deserialization.schema.succeed(
-        schema,
-        [[["2021-01-01T00:00:00.000Z"], 0]],
-        new Map([[Option.some(new Date("2021-01-01")), 0]])
-      )
+        await assertions.serialization.json.schema.succeed(schema, new MyError({ message: "a", cause: "b" }), {
+          message: "a",
+          cause: "b"
+        })
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          { message: "a", cause: "b" },
+          new MyError({ message: "a", cause: "b" })
+        )
+      })
     })
 
     it("Class", async () => {
@@ -218,17 +399,17 @@ describe("Serializer", () => {
         a: FiniteFromDate
       })) {}
 
-      await assertions.serialization.schema.succeed(A, new A({ a: 0 }), { a: 0 })
-      await assertions.deserialization.schema.succeed(A, { a: 0 }, new A({ a: 0 }))
+      await assertions.serialization.json.codec.succeed(A, new A({ a: 0 }), { a: "1970-01-01T00:00:00.000Z" })
+      await assertions.deserialization.json.codec.succeed(A, { a: "1970-01-01T00:00:00.000Z" }, new A({ a: 0 }))
     })
 
-    it("ErrorClass", async () => {
+    it("Error", async () => {
       class E extends Schema.ErrorClass<E>("E")({
         a: FiniteFromDate
       }) {}
 
-      await assertions.serialization.schema.succeed(E, new E({ a: 0 }), { a: 0 })
-      await assertions.deserialization.schema.succeed(E, { a: 0 }, new E({ a: 0 }))
+      await assertions.serialization.json.codec.succeed(E, new E({ a: 0 }), { a: "1970-01-01T00:00:00.000Z" })
+      await assertions.deserialization.json.codec.succeed(E, { a: "1970-01-01T00:00:00.000Z" }, new E({ a: 0 }))
     })
 
     it("Enums", async () => {
@@ -238,171 +419,125 @@ describe("Serializer", () => {
       }
       const schema = Schema.Enums(Fruits)
 
-      await assertions.serialization.schema.succeed(schema, Fruits.Apple, 0)
-      await assertions.serialization.schema.succeed(schema, Fruits.Banana, 1)
-      await assertions.deserialization.schema.succeed(schema, 0, Fruits.Apple)
-      await assertions.deserialization.schema.succeed(schema, 1, Fruits.Banana)
+      await assertions.serialization.json.codec.succeed(schema, Fruits.Apple, 0)
+      await assertions.serialization.json.codec.succeed(schema, Fruits.Banana, 1)
+      await assertions.deserialization.json.codec.succeed(schema, 0, Fruits.Apple)
+      await assertions.deserialization.json.codec.succeed(schema, 1, Fruits.Banana)
     })
   })
 
-  describe("custom serialization", () => {
-    it("FiniteFromDate", async () => {
-      const schema = FiniteFromDate
+  describe("stringLeafJson", () => {
+    describe("default serialization", () => {
+      it("Symbol", async () => {
+        const schema = Schema.Symbol
 
-      await assertions.serialization.codec.succeed(schema, 0, "1970-01-01T00:00:00.000Z")
-    })
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, Symbol.for("a"), "a")
+        await assertions.serialization.stringLeafJson.schema.fail(
+          schema,
+          Symbol("a"),
+          "cannot serialize to string, Symbol is not registered"
+        )
+        await assertions.serialization.stringLeafJson.schema.fail(
+          schema,
+          Symbol(),
+          "cannot serialize to string, Symbol has no description"
+        )
 
-    it("Struct", async () => {
-      const schema = Schema.Struct({
-        a: FiniteFromDate,
-        b: FiniteFromDate
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "a", Symbol.for("a"))
       })
 
-      await assertions.serialization.codec.succeed(
-        schema,
-        { a: 0, b: 0 },
-        { a: "1970-01-01T00:00:00.000Z", b: "1970-01-01T00:00:00.000Z" }
-      )
-    })
+      it("Number", async () => {
+        const schema = Schema.Number
 
-    it("Tuple(Schema.Date, Schema.Date)", async () => {
-      const schema = Schema.Tuple([FiniteFromDate, FiniteFromDate])
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, 1, "1")
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "1", 1)
+      })
 
-      await assertions.serialization.codec.succeed(
-        schema,
-        [0, 0],
-        ["1970-01-01T00:00:00.000Z", "1970-01-01T00:00:00.000Z"]
-      )
-    })
+      it("Boolean", async () => {
+        const schema = Schema.Boolean
 
-    it("Option(Option(FiniteFromDate))", async () => {
-      const schema = Schema.Option(Schema.Option(FiniteFromDate))
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, true, "true")
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, false, "false")
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "true", true)
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "false", false)
+      })
 
-      await assertions.serialization.codec.succeed(schema, Option.some(Option.some(0)), [["1970-01-01T00:00:00.000Z"]])
-    })
+      it("Null", async () => {
+        const schema = Schema.Null
 
-    it("Map(Option(Symbol), Date)", async () => {
-      const schema = Schema.Map(Schema.Option(Schema.Symbol), Schema.Date)
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, null, "")
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "", null)
+      })
 
-      await assertions.serialization.codec.succeed(
-        schema,
-        new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]]),
-        [[
-          ["a"],
-          "2021-01-01T00:00:00.000Z"
-        ]]
-      )
-      await assertions.deserialization.codec.succeed(
-        schema,
-        [[["a"], "2021-01-01T00:00:00.000Z"]],
-        new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]])
-      )
-    })
-  })
+      it("NullOr(Number)", async () => {
+        const schema = Schema.NullOr(Schema.Number)
 
-  describe("instanceOf", () => {
-    it("arg: message: string", async () => {
-      class MyError extends Error {
-        constructor(message?: string) {
-          super(message)
-          this.name = "MyError"
-          Object.setPrototypeOf(this, MyError.prototype)
-        }
-      }
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, 1, "1")
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, null, "")
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "", null)
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "1", 1)
+      })
 
-      const schema = Schema.instanceOf(
-        MyError,
-        {
-          title: "MyError",
-          defaultJsonSerializer: () =>
-            Schema.link<MyError>()(
-              Schema.String,
-              Transformation.transform({
-                decode: (message) => new MyError(message),
-                encode: (e) => e.message
-              })
-            )
-        }
-      )
+      it("Array(NullOr(Number))", async () => {
+        const schema = Schema.Array(Schema.NullOr(Schema.Number))
 
-      await assertions.serialization.schema.succeed(schema, new MyError("a"), "a")
-      await assertions.deserialization.schema.succeed(schema, "a", new MyError("a"))
-    })
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, [1, null], ["1", ""])
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, ["1", ""], [1, null])
+      })
 
-    it("arg: struct", async () => {
-      class MyError extends Error {
-        static Props = Schema.Struct({
-          message: Schema.String,
-          cause: Schema.String
+      it("Struct", async () => {
+        const schema = Schema.Struct({
+          a: Schema.NullOr(Schema.Number),
+          b: Schema.NullOr(Schema.Number)
         })
 
-        constructor(props: typeof MyError.Props["Type"]) {
-          super(props.message, { cause: props.cause })
-          this.name = "MyError"
-          Object.setPrototypeOf(this, MyError.prototype)
-        }
-
-        static schema = Schema.instanceOf(
-          MyError,
-          {
-            title: "MyError",
-            defaultJsonSerializer: () =>
-              Schema.link<MyError>()(
-                MyError.Props,
-                Transformation.transform({
-                  decode: (props) => new MyError(props),
-                  encode: (e) => ({
-                    message: e.message,
-                    cause: typeof e.cause === "string" ? e.cause : String(e.cause)
-                  })
-                })
-              )
-          }
-        )
-      }
-
-      const schema = MyError.schema
-
-      await assertions.serialization.schema.succeed(schema, new MyError({ message: "a", cause: "b" }), {
-        message: "a",
-        cause: "b"
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, { a: 1, b: null }, {
+          a: "1",
+          b: ""
+        })
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, {
+          a: "1",
+          b: ""
+        }, { a: 1, b: null })
       })
-      await assertions.deserialization.schema.succeed(
-        schema,
-        { message: "a", cause: "b" },
-        new MyError({ message: "a", cause: "b" })
-      )
+
+      it("Suspend", async () => {
+        interface Category<A, T> {
+          readonly a: A
+          readonly categories: ReadonlyArray<T>
+        }
+        interface CategoryType extends Category<number, CategoryType> {}
+        interface CategoryEncoded extends Category<string, CategoryEncoded> {}
+
+        const schema = Schema.Struct({
+          a: Schema.FiniteFromString.check(Check.greaterThan(0)),
+          categories: Schema.Array(Schema.suspend((): Schema.Codec<CategoryType, CategoryEncoded> => schema))
+        })
+
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, { a: 1, categories: [] }, {
+          a: "1",
+          categories: []
+        })
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, {
+          a: 1,
+          categories: [{ a: 2, categories: [] }]
+        }, {
+          a: "1",
+          categories: [
+            { a: "2", categories: [] }
+          ]
+        })
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, {
+          a: "1",
+          categories: []
+        }, { a: 1, categories: [] })
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, {
+          a: "1",
+          categories: [
+            { a: "2", categories: [] }
+          ]
+        }, { a: 1, categories: [{ a: 2, categories: [] }] })
+      })
     })
-  })
-
-  it("Class", async () => {
-    class A extends Schema.Class<A>("A")(Schema.Struct({
-      a: FiniteFromDate
-    })) {}
-
-    await assertions.serialization.codec.succeed(A, new A({ a: 0 }), { a: "1970-01-01T00:00:00.000Z" })
-    await assertions.deserialization.codec.succeed(A, { a: "1970-01-01T00:00:00.000Z" }, new A({ a: 0 }))
-  })
-
-  it("Error", async () => {
-    class E extends Schema.ErrorClass<E>("E")({
-      a: FiniteFromDate
-    }) {}
-
-    await assertions.serialization.codec.succeed(E, new E({ a: 0 }), { a: "1970-01-01T00:00:00.000Z" })
-    await assertions.deserialization.codec.succeed(E, { a: "1970-01-01T00:00:00.000Z" }, new E({ a: 0 }))
-  })
-
-  it("Enums", async () => {
-    enum Fruits {
-      Apple,
-      Banana
-    }
-    const schema = Schema.Enums(Fruits)
-
-    await assertions.serialization.codec.succeed(schema, Fruits.Apple, 0)
-    await assertions.serialization.codec.succeed(schema, Fruits.Banana, 1)
-    await assertions.deserialization.codec.succeed(schema, 0, Fruits.Apple)
-    await assertions.deserialization.codec.succeed(schema, 1, Fruits.Banana)
   })
 })

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -138,6 +138,22 @@ describe("Serializer", () => {
         })
       })
 
+      describe("TemplateLiteral", () => {
+        it("1n + string", async () => {
+          const schema = Schema.TemplateLiteral([1n, Schema.String])
+
+          await assertions.serialization.json.schema.succeed(schema, "1a")
+          await assertions.deserialization.json.schema.succeed(schema, "1a")
+        })
+
+        it(`"a" + bigint`, async () => {
+          const schema = Schema.TemplateLiteral(["a", Schema.BigInt])
+
+          await assertions.serialization.json.schema.succeed(schema, "a1")
+          await assertions.deserialization.json.schema.succeed(schema, "a1")
+        })
+      })
+
       it("URL", async () => {
         const schema = Schema.URL
 
@@ -580,6 +596,12 @@ describe("Serializer", () => {
           await assertions.deserialization.stringLeafJson.schema.succeed(schema, "0", Fruits.Apple)
           await assertions.deserialization.stringLeafJson.schema.succeed(schema, "banana", Fruits.Banana)
         })
+      })
+
+      it("TemplateLiteral", async () => {
+        const schema = Schema.TemplateLiteral(["a", Schema.Literal(1), "b"])
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, "a1b")
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "a1b")
       })
 
       it("NullOr(Number)", async () => {

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -108,6 +108,36 @@ describe("Serializer", () => {
         await assertions.deserialization.json.schema.succeed(schema, "1", 1n)
       })
 
+      describe("Literal", () => {
+        it("string", async () => {
+          const schema = Schema.Literal("a")
+
+          await assertions.serialization.json.schema.succeed(schema, "a", "a")
+          await assertions.deserialization.json.schema.succeed(schema, "a", "a")
+        })
+
+        it("number", async () => {
+          const schema = Schema.Literal(1)
+
+          await assertions.serialization.json.schema.succeed(schema, 1, 1)
+          await assertions.deserialization.json.schema.succeed(schema, 1, 1)
+        })
+
+        it("boolean", async () => {
+          const schema = Schema.Literal(true)
+
+          await assertions.serialization.json.schema.succeed(schema, true)
+          await assertions.deserialization.json.schema.succeed(schema, true)
+        })
+
+        it("bigint", async () => {
+          const schema = Schema.Literal(1n)
+
+          await assertions.serialization.json.schema.succeed(schema, 1n, "1")
+          await assertions.deserialization.json.schema.succeed(schema, "1", 1n)
+        })
+      })
+
       it("URL", async () => {
         const schema = Schema.URL
 
@@ -415,14 +445,14 @@ describe("Serializer", () => {
     it("Enums", async () => {
       enum Fruits {
         Apple,
-        Banana
+        Banana = "banana"
       }
       const schema = Schema.Enums(Fruits)
 
       await assertions.serialization.json.codec.succeed(schema, Fruits.Apple, 0)
-      await assertions.serialization.json.codec.succeed(schema, Fruits.Banana, 1)
+      await assertions.serialization.json.codec.succeed(schema, Fruits.Banana, "banana")
       await assertions.deserialization.json.codec.succeed(schema, 0, Fruits.Apple)
-      await assertions.deserialization.json.codec.succeed(schema, 1, Fruits.Banana)
+      await assertions.deserialization.json.codec.succeed(schema, "banana", Fruits.Banana)
     })
   })
 
@@ -505,6 +535,51 @@ describe("Serializer", () => {
 
         await assertions.serialization.stringLeafJson.schema.succeed(schema, null, "")
         await assertions.deserialization.stringLeafJson.schema.succeed(schema, "", null)
+      })
+
+      describe("Literal", () => {
+        it("string", async () => {
+          const schema = Schema.Literal("a")
+
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, "a", "a")
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "a", "a")
+        })
+
+        it("number", async () => {
+          const schema = Schema.Literal(1)
+
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, 1, "1")
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "1", 1)
+        })
+
+        it("boolean", async () => {
+          const schema = Schema.Literal(true)
+
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, true, "true")
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "true", true)
+        })
+
+        it("bigint", async () => {
+          const schema = Schema.Literal(1n)
+
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, 1n, "1")
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "1", 1n)
+        })
+      })
+
+      describe("Enums", () => {
+        it("should serialize the enum value", async () => {
+          enum Fruits {
+            Apple,
+            Banana = "banana"
+          }
+          const schema = Schema.Enums(Fruits)
+
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, Fruits.Apple, "0")
+          await assertions.serialization.stringLeafJson.schema.succeed(schema, Fruits.Banana, "banana")
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "0", Fruits.Apple)
+          await assertions.deserialization.stringLeafJson.schema.succeed(schema, "banana", Fruits.Banana)
+        })
       })
 
       it("NullOr(Number)", async () => {

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -427,6 +427,44 @@ describe("Serializer", () => {
   })
 
   describe("stringLeafJson", () => {
+    describe("should return the same reference if nothing changed", () => {
+      it("String", async () => {
+        const schema = Schema.String
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, schema.ast)
+      })
+
+      it("Array", async () => {
+        const schema = Schema.Array(Schema.String)
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, schema.ast)
+      })
+
+      it("Struct", async () => {
+        const schema = Schema.Struct({
+          a: Schema.String
+        })
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, schema.ast)
+      })
+    })
+
+    describe("should memoize the result", () => {
+      it("Struct", async () => {
+        const schema = Schema.Struct({
+          a: Schema.Finite
+        })
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, Serializer.stringLeafJson(serializer).ast)
+      })
+
+      it("Array", async () => {
+        const schema = Schema.Array(Schema.Finite)
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, Serializer.stringLeafJson(serializer).ast)
+      })
+    })
+
     describe("default serialization", () => {
       it("Symbol", async () => {
         const schema = Schema.Symbol

--- a/packages/effect/test/utils/schema.ts
+++ b/packages/effect/test/utils/schema.ts
@@ -146,101 +146,161 @@ function make(asserts: {
     },
 
     serialization: {
-      schema: {
-        async succeed<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: A,
-          expected?: unknown
-        ) {
-          return out.effect.succeed(
-            Schema.encodeEffect(Serializer.json(Schema.typeCodec(schema)))(input),
-            arguments.length > 2 ? expected : input
-          )
+      json: {
+        schema: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            expected?: unknown
+          ) {
+            return out.effect.succeed(
+              Schema.encodeEffect(Serializer.json(Schema.typeCodec(schema)))(input),
+              arguments.length > 2 ? expected : input
+            )
+          },
+
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            message: string
+          ) {
+            return out.effect.fail(
+              Schema.encodeEffect(Serializer.json(Schema.typeCodec(schema)))(input).pipe(
+                Effect.mapError((err) => err.issue)
+              ),
+              message
+            )
+          }
         },
 
-        async fail<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: A,
-          message: string
-        ) {
-          return out.effect.fail(
-            Schema.encodeEffect(Serializer.json(Schema.typeCodec(schema)))(input).pipe(
-              Effect.mapError((err) => err.issue)
-            ),
-            message
-          )
+        codec: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            expected?: unknown
+          ) {
+            return out.encoding.succeed(
+              Serializer.json(schema),
+              input,
+              { expected: arguments.length > 2 ? expected : input }
+            )
+          },
+
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            message: string
+          ) {
+            return out.encoding.fail(Serializer.json(schema), input, message)
+          }
         }
       },
 
-      codec: {
-        async succeed<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: A,
-          expected?: unknown
-        ) {
-          return out.encoding.succeed(
-            Serializer.json(schema),
-            input,
-            { expected: arguments.length > 2 ? expected : input }
-          )
-        },
+      stringLeafJson: {
+        schema: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            expected?: Serializer.StringLeafJson
+          ) {
+            return out.effect.succeed(
+              Schema.encodeEffect(Serializer.stringLeafJson(Schema.typeCodec(schema)))(input),
+              arguments.length > 2 ? expected : input
+            )
+          },
 
-        async fail<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: A,
-          message: string
-        ) {
-          return out.encoding.fail(Serializer.json(schema), input, message)
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: A,
+            message: string
+          ) {
+            return out.effect.fail(
+              Schema.encodeEffect(Serializer.stringLeafJson(Schema.typeCodec(schema)))(input).pipe(
+                Effect.mapError((err) => err.issue)
+              ),
+              message
+            )
+          }
         }
       }
     },
 
     deserialization: {
-      schema: {
-        async succeed<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: unknown,
-          expected?: A
-        ) {
-          return out.effect.succeed(
-            Schema.decodeEffect(Serializer.json(Schema.typeCodec(schema)))(input),
-            arguments.length > 2 ? expected : input
-          )
+      json: {
+        schema: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: unknown,
+            expected?: A
+          ) {
+            return out.effect.succeed(
+              Schema.decodeEffect(Serializer.json(Schema.typeCodec(schema)))(input),
+              arguments.length > 2 ? expected : input
+            )
+          },
+
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: unknown,
+            message: string
+          ) {
+            return out.effect.fail(
+              Schema.decodeEffect(Serializer.json(Schema.typeCodec(schema)))(input).pipe(
+                Effect.mapError((err) => err.issue)
+              ),
+              message
+            )
+          }
         },
 
-        async fail<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: unknown,
-          message: string
-        ) {
-          return out.effect.fail(
-            Schema.decodeEffect(Serializer.json(Schema.typeCodec(schema)))(input).pipe(
-              Effect.mapError((err) => err.issue)
-            ),
-            message
-          )
+        codec: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: unknown,
+            expected?: A
+          ) {
+            return out.decoding.succeed(
+              Serializer.json(schema),
+              input,
+              { expected: arguments.length > 2 ? expected : input }
+            )
+          },
+
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: unknown,
+            message: string
+          ) {
+            return out.decoding.fail(Serializer.json(schema), input, message)
+          }
         }
       },
 
-      codec: {
-        async succeed<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: unknown,
-          expected?: A
-        ) {
-          return out.decoding.succeed(
-            Serializer.json(schema),
-            input,
-            { expected: arguments.length > 2 ? expected : input }
-          )
-        },
+      stringLeafJson: {
+        schema: {
+          async succeed<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: Serializer.StringLeafJson,
+            expected?: A
+          ) {
+            return out.effect.succeed(
+              Schema.decodeEffect(Serializer.stringLeafJson(Schema.typeCodec(schema)))(input),
+              arguments.length > 2 ? expected : input
+            )
+          },
 
-        async fail<const A, const I, RD, RE>(
-          schema: Schema.Codec<A, I, RD, RE>,
-          input: unknown,
-          message: string
-        ) {
-          return out.decoding.fail(Serializer.json(schema), input, message)
+          async fail<const A, const I, RD, RE>(
+            schema: Schema.Codec<A, I, RD, RE>,
+            input: Serializer.StringLeafJson,
+            message: string
+          ) {
+            return out.effect.fail(
+              Schema.decodeEffect(Serializer.stringLeafJson(Schema.typeCodec(schema)))(input).pipe(
+                Effect.mapError((err) => err.issue)
+              ),
+              message
+            )
+          }
         }
       }
     },


### PR DESCRIPTION
## 🆕 String‑Leaf Serializer

`Serializer.stringLeafJson` lets you funnel many string‑based inputs—URL queries, form posts, CLI args—into any **Schema** without adding custom transformations.

The process has two steps:

1. **Format → tree**
   A short helper converts the raw data into a structure whose leaves are all strings.

   ```ts
   type StringLeafJson = string | { [key: PropertyKey]: StringLeafJson } | Array<StringLeafJson>
   ```

2. **Tree → value**
   A normal schema decodes that tree into your typed model.

Write the schema using the types you actually need: `Schema.Number`, `Schema.Boolean`, `Schema.Date`, and so on.
`Serializer.stringLeafJson` will convert the string leaves to these types while decoding, so you do **not** have to insert helpers like `numberFromString` or `booleanFromString`.

Below are two quick examples.

**Example** (Decode `URLSearchParams`)

```ts
import { Schema, Serializer } from "effect/schema"

// 1. URL params ➜ StringLeafJson
const toTree = (p: URLSearchParams) => Object.fromEntries(p)

// 2. schema
const Query = Schema.Struct({
  page: Schema.Finite,
  q: Schema.optionalKey(Schema.String)
})

const serializer = Serializer.stringLeafJson(Query)

const params = new URLSearchParams("?page=2&q=foo")

console.log(Schema.decodeSync(serializer)(toTree(params)))
// → { page: 2, q: "foo" }
```

**Example** (Decode `FormData`)

```ts
import * as Predicate from "effect/data/Predicate"
import { Schema, Serializer } from "effect/schema"

// 1. FormData ➜ StringLeafJson
const fdToTree = (fd: FormData) =>
  // exclude File values
  Object.fromEntries([...fd.entries()].filter(([_, v]) => Predicate.isString(v)) as Array<[string, string]>)

// 2. schema
const User = Schema.Struct({
  user: Schema.NonEmptyString,
  pass: Schema.NonEmptyString,
  age: Schema.Finite
})

const serializer = Serializer.stringLeafJson(User)

const fd = new FormData()
fd.set("user", "alice")
fd.set("pass", "secret")
fd.set("age", "30")

console.log(Schema.decodeSync(serializer)(fdToTree(fd)))
// → { user: "alice", pass: "secret", age: 30 }
```

### How it works

The `stringLeafJson` serializer first delegates to `Serializer.json` to obtain a plain JSON‑safe value, then converts every leaf (number, boolean, null) to a string so the whole tree matches `StringLeafJson`.

**Example** (Difference between the two serializers)

```ts
import { Schema, Serializer } from "effect/schema"

const schema = Schema.Struct({
  name: Schema.String,
  age: Schema.Number,
  isAdmin: Schema.Boolean,
  createdAt: Schema.Date
})

const json = Serializer.json(schema)

const stringLeafJson = Serializer.stringLeafJson(schema)

const value = {
  name: "John",
  age: 30,
  isAdmin: true,
  createdAt: new Date()
}

console.log(Schema.encodeSync(json)(value))
/*
{
  name: 'John',
  age: 30, // still a number
  isAdmin: true, // still a boolean
  createdAt: '2025-07-25T17:04:40.434Z' // Date represented as a string thanks to the `json` serializer
}
*/

console.log(Schema.encodeSync(stringLeafJson)(value))
/*
everything is a string
{
  name: 'John',
  age: '30',
  isAdmin: 'true',
  createdAt: '2025-07-25T17:04:40.434Z'
}
*/
```
