### PR TITLE
add StandardSchemaV1FailureResult schema

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -4886,6 +4886,47 @@ logIssues(Person, { name: "" })
 // [ { path: [ 'name' ], message: 'Please enter at least 1 character(s)' } ]
 ```
 
+#### Sending a FailureResult over the wire
+
+You can use the `Schema.FailureResult` schema to send a `FailureResult` over the wire.
+
+**Example** (Sending a FailureResult over the wire)
+
+```ts
+import { Formatter, Schema, Serializer, ToParser } from "effect/schema"
+
+const b = Symbol.for("b")
+
+const schema = Schema.Struct({
+  a: Schema.NonEmptyString,
+  [b]: Schema.Finite,
+  c: Schema.Tuple([Schema.String])
+})
+
+const r = ToParser.decodeUnknownResult(schema)({ a: "", c: [] }, { errors: "all" })
+
+if (r._tag === "Failure") {
+  const failureResult = Formatter.makeStandardSchemaV1({
+    leafHook: Formatter.treeLeafHook,
+    checkHook: Formatter.verboseCheckHook
+  }).format(r.failure)
+  const serializer = Serializer.json(Schema.FailureResult)
+  console.dir(Schema.encodeSync(serializer)(failureResult), { depth: null })
+}
+/*
+{
+  issues: [
+    {
+      message: 'Expected a value with a length of at least 1, actual ""',
+      path: [ 'a' ]
+    },
+    { message: 'Missing key', path: [ 'c', 0 ] },
+    { message: 'Missing key', path: [ 'Symbol(b)' ] }
+  ]
+}
+*/
+```
+
 ### Structured formatter
 
 The Structured formatter is for **post-processing** purposes.

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -253,7 +253,7 @@ For use cases like RPC or messaging systems, the JSON format only needs to suppo
 **Example** (Serializing and deserializing a Map with complex keys and values)
 
 ```ts
-import { Option } from "effect"
+import { Option } from "effect/data"
 import { Schema, Serializer } from "effect/schema"
 
 // A schema for Map<Option<symbol>, Date>
@@ -269,12 +269,12 @@ const data = new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]])
 const serialized = JSON.stringify(Schema.encodeUnknownSync(serializer)(data))
 
 console.log(serialized)
-// → [[["a"],"2021-01-01T00:00:00.000Z"]]
+// → [[["Symbol(a)"],"2021-01-01T00:00:00.000Z"]]
 
 // Deserialize and decode the value
 console.log(Schema.decodeUnknownSync(serializer)(JSON.parse(serialized)))
 // → Map(1) {
-//     Some(Symbol(a)) => 2021-01-01T00:00:00.000Z
+//     { _id: 'Option', _tag: 'Some', value: Symbol(a) } => 2021-01-01T00:00:00.000Z
 //   }
 ```
 
@@ -300,18 +300,15 @@ This is done by attaching a `defaultJsonSerializer` annotation when defining the
 import { Schema, Serializer, Transformation } from "effect/schema"
 
 // Custom Date schema with a default serializer
-const MyDate = Schema.instanceOf({
-  constructor: Date,
-  annotations: {
-    defaultJsonSerializer: () =>
-      Schema.link<Date>()(
-        Schema.String, // JSON representation
-        Transformation.transform({
-          decode: (s) => new Date(s),
-          encode: (date) => date.toISOString()
-        })
-      )
-  }
+const MyDate = Schema.instanceOf(Date, {
+  defaultJsonSerializer: () =>
+    Schema.link<Date>()(
+      Schema.String, // JSON representation
+      Transformation.transform({
+        decode: (s) => new Date(s),
+        encode: (date) => date.toISOString()
+      })
+    )
 })
 
 const serializer = Serializer.json(MyDate)
@@ -760,7 +757,8 @@ Default values can also be computed using effects, as long as the environment is
 **Example** (Using an effect to provide a default)
 
 ```ts
-import { Effect, Option } from "effect"
+import { Effect } from "effect"
+import { Option } from "effect/data"
 import { Schema, SchemaResult, ToParser } from "effect/schema"
 
 const schema = Schema.Struct({
@@ -781,7 +779,8 @@ SchemaResult.asEffect(ToParser.makeSchemaResult(schema)({})).pipe(Effect.runProm
 **Example** (Providing a default from an optional service)
 
 ```ts
-import { ServiceMap, Effect, Option } from "effect"
+import { ServiceMap, Effect } from "effect"
+import { Option } from "effect/data"
 import { Schema, SchemaResult, ToParser } from "effect/schema"
 
 // Define a service that may provide a default value
@@ -1196,7 +1195,8 @@ For more advanced scenarios, such as performing asynchronous validation or acces
 **Example** (Asynchronous validation of a numeric value)
 
 ```ts
-import { Effect, Option, Result } from "effect"
+import { Effect } from "effect"
+import { Option, Result } from "effect/data"
 import { Getter, Issue, Schema } from "effect/schema"
 
 // Simulated API call that fails when userId is 0
@@ -1327,7 +1327,7 @@ type Type = typeof schema.Type
 #### Omitting Values When Transforming Optional Fields
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Getter, Schema } from "effect/schema"
 
 export const schema = Schema.Struct({
@@ -1477,7 +1477,7 @@ This is useful when you need to account for values like `null` or other invalid 
 **Example** (Providing a fallback when value is `null` or missing)
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Getter, Schema } from "effect/schema"
 
 const schema = Schema.Struct({
@@ -1520,7 +1520,7 @@ console.log(Schema.decodeUnknownSync(schema)({ a: "2" }))
 **Example** (Providing a fallback when value is `null`, `undefined`, or missing)
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Getter, Schema } from "effect/schema"
 
 const schema = Schema.Struct({
@@ -1607,7 +1607,7 @@ console.log(Schema.encodeSync(Product)({ quantity: Option.none() }))
 #### Optional Property
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Schema, Transformation } from "effect/schema"
 
 const Product = Schema.Struct({
@@ -1649,7 +1649,7 @@ console.log(Schema.encodeSync(Product)({ quantity: Option.none() }))
 #### Exact Optional Property with Nullability
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Schema, Transformation } from "effect/schema"
 
 const Product = Schema.Struct({
@@ -1688,7 +1688,7 @@ console.log(Schema.decodeUnknownSync(Product)({ quantity: "2" }))
 #### Optional Property with Nullability
 
 ```ts
-import { Option, Predicate } from "effect"
+import { Option, Predicate } from "effect/data"
 import { Schema, Transformation } from "effect/schema"
 
 const Product = Schema.Struct({
@@ -2961,20 +2961,17 @@ class Person {
   ) {}
 }
 
-const PersonSchema = Schema.instanceOf({
-  constructor: Person,
-  annotations: {
-    title: "Person",
-    // optional: default JSON serialization
-    defaultJsonSerializer: () =>
-      Schema.link<Person>()(
-        Schema.Tuple([Schema.String, Schema.Number]),
-        Transformation.transform({
-          decode: (args) => new Person(...args),
-          encode: (instance) => [instance.name, instance.age] as const
-        })
-      )
-  }
+const PersonSchema = Schema.instanceOf(Person, {
+  title: "Person",
+  // optional: default JSON serialization
+  defaultJsonSerializer: () =>
+    Schema.link<Person>()(
+      Schema.Tuple([Schema.String, Schema.Number]),
+      Transformation.transform({
+        decode: (args) => new Person(...args),
+        encode: (instance) => [instance.name, instance.age] as const
+      })
+    )
 })
   // optional: explicit encoding
   .pipe(
@@ -3003,20 +3000,17 @@ class Person {
   ) {}
 }
 
-const PersonSchema = Schema.instanceOf({
-  constructor: Person,
-  annotations: {
-    title: "Person",
-    // optional: default JSON serialization
-    defaultJsonSerializer: () =>
-      Schema.link<Person>()(
-        Schema.Tuple([Schema.String, Schema.Number]),
-        Transformation.transform({
-          decode: (args) => new Person(...args),
-          encode: (instance) => [instance.name, instance.age] as const
-        })
-      )
-  }
+const PersonSchema = Schema.instanceOf(Person, {
+  title: "Person",
+  // optional: default JSON serialization
+  defaultJsonSerializer: () =>
+    Schema.link<Person>()(
+      Schema.Tuple([Schema.String, Schema.Number]),
+      Transformation.transform({
+        decode: (args) => new Person(...args),
+        encode: (instance) => [instance.name, instance.age] as const
+      })
+    )
 })
   // optional: explicit encoding
   .pipe(
@@ -3050,7 +3044,8 @@ class PersonWithEmail extends Person {
 **Example** (Extending Data.Error)
 
 ```ts
-import { Data, Effect, identity } from "effect"
+import { Effect, identity } from "effect"
+import { Data } from "effect/data"
 import { Schema, Transformation, Util } from "effect/schema"
 
 const Props = Schema.Struct({
@@ -3091,13 +3086,10 @@ const transformation = Transformation.transform<Err, (typeof Props)["Type"]>({
   encode: identity
 })
 
-const schema = Schema.instanceOf({
-  constructor: Err,
-  annotations: {
-    title: "Err",
-    serialization: {
-      json: () => Schema.link<Err>()(Props, transformation)
-    }
+const schema = Schema.instanceOf(Err, {
+  title: "Err",
+  serialization: {
+    json: () => Schema.link<Err>()(Props, transformation)
   }
 }).pipe(Schema.encodeTo(Props, transformation))
 
@@ -3874,12 +3866,13 @@ This is useful when you need to validate input or enforce rules that may not alw
 **Example** (Converting a string URL into a `URL` object)
 
 ```ts
-import { Effect, Option } from "effect"
+import { Effect } from "effect"
+import { Option } from "effect/data"
 import { Issue, Schema, Transformation } from "effect/schema"
 
 const URLFromString = Schema.String.pipe(
   Schema.decodeTo(
-    Schema.instanceOf({ constructor: URL }),
+    Schema.instanceOf(URL),
     Transformation.transformOrFail({
       decode: (s) =>
         Effect.try({
@@ -4115,7 +4108,8 @@ b
 ### Providing a Service
 
 ```ts
-import { ServiceMap, Effect, Option } from "effect"
+import { ServiceMap, Effect } from "effect"
+import { Option } from "effect/data"
 import { Formatter, Schema } from "effect/schema"
 
 class Service extends ServiceMap.Key<Service, { fallback: Effect.Effect<string> }>()("Service") {}
@@ -4530,13 +4524,10 @@ class MyClass {
   constructor(readonly a: string) {}
 }
 
-const schema = Schema.instanceOf({
-  constructor: MyClass,
-  annotations: {
-    equivalence: {
-      _tag: "Declaration",
-      declaration: () => (x, y) => x.a === y.a
-    }
+const schema = Schema.instanceOf(MyClass, {
+  equivalence: {
+    _tag: "Declaration",
+    declaration: () => (x, y) => x.a === y.a
   }
 })
 
@@ -4604,7 +4595,8 @@ The `getTitle` annotation allows you to add dynamic context to error messages by
 **Example** (Generating a title based on the value being validated)
 
 ```ts
-import { Effect, Option } from "effect"
+import { Effect } from "effect"
+import { Option } from "effect/data"
 import { Formatter, Issue, Schema } from "effect/schema"
 
 const getOrderId = (issue: Issue.Issue) => {

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -4888,7 +4888,7 @@ logIssues(Person, { name: "" })
 
 #### Sending a FailureResult over the wire
 
-You can use the `Schema.FailureResult` schema to send a `FailureResult` over the wire.
+You can use the `Schema.StandardSchemaV1FailureResult` schema to send a `StandardSchemaV1.FailureResult` over the wire.
 
 **Example** (Sending a FailureResult over the wire)
 
@@ -4910,7 +4910,7 @@ if (r._tag === "Failure") {
     leafHook: Formatter.treeLeafHook,
     checkHook: Formatter.verboseCheckHook
   }).format(r.failure)
-  const serializer = Serializer.json(Schema.FailureResult)
+  const serializer = Serializer.json(Schema.StandardSchemaV1FailureResult)
   console.dir(Schema.encodeSync(serializer)(failureResult), { depth: null })
 }
 /*

--- a/packages/effect/src/schema/Issue.ts
+++ b/packages/effect/src/schema/Issue.ts
@@ -30,14 +30,20 @@ export function isIssue(u: unknown): u is Issue {
  * @category model
  * @since 4.0.0
  */
-export type Issue =
-  // leaf
+export type Leaf =
   | InvalidType
   | InvalidValue
   | MissingKey
   | UnexpectedKey
   | Forbidden
   | OneOf
+
+/**
+ * @category model
+ * @since 4.0.0
+ */
+export type Issue =
+  | Leaf
   // composite
   | Filter
   | Encoding

--- a/packages/effect/src/schema/Schema.ts
+++ b/packages/effect/src/schema/Schema.ts
@@ -4008,7 +4008,7 @@ export const PropertyKey = Union([Symbol, String, Finite])
 export const FailureResult = Struct({
   issues: Array(Struct({
     message: String,
-    path: optional(Array(PropertyKey))
+    path: optional(Array(Union([PropertyKey, Struct({ key: PropertyKey })])))
   }))
 })
 

--- a/packages/effect/src/schema/Schema.ts
+++ b/packages/effect/src/schema/Schema.ts
@@ -4005,7 +4005,7 @@ export const PropertyKey = Union([Symbol, String, Finite])
 /**
  * @since 4.0.0
  */
-export const FailureResult = Struct({
+export const StandardSchemaV1FailureResult = Struct({
   issues: Array(Struct({
     message: String,
     path: optional(Array(Union([PropertyKey, Struct({ key: PropertyKey })])))

--- a/packages/effect/src/schema/Schema.ts
+++ b/packages/effect/src/schema/Schema.ts
@@ -3998,6 +3998,21 @@ export const RequestClass =
   }
 
 /**
+ * @since 4.0.0
+ */
+export const PropertyKey = Union([Symbol, String, Finite])
+
+/**
+ * @since 4.0.0
+ */
+export const FailureResult = Struct({
+  issues: Array(Struct({
+    message: String,
+    path: optional(Array(PropertyKey))
+  }))
+})
+
+/**
  * @category Constructors
  * @since 4.0.0
  */

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -482,27 +482,31 @@ describe("Serializer", () => {
       await assertions.deserialization.json.codec.succeed(schema, "banana", Fruits.Banana)
     })
 
-    it("FailureResult", async () => {
+    it("StandardSchemaV1FailureResult", async () => {
       const b = Symbol.for("b")
+
       const schema = Schema.Struct({
         a: Schema.NonEmptyString,
         [b]: Schema.Finite,
         c: Schema.Tuple([Schema.String])
       })
+
       const r = ToParser.decodeUnknownResult(schema)({ a: "", c: [] }, { errors: "all" })
+
       assertTrue(r._tag === "Failure")
+
       const failureResult = Formatter.makeStandardSchemaV1({
         leafHook: Formatter.treeLeafHook,
         checkHook: Formatter.verboseCheckHook
       }).format(r.failure)
-      await assertions.serialization.json.codec.succeed(Schema.FailureResult, failureResult, {
+      await assertions.serialization.json.codec.succeed(Schema.StandardSchemaV1FailureResult, failureResult, {
         issues: [
           { path: ["a"], message: `Expected a value with a length of at least 1, actual ""` },
           { path: ["c", 0], message: "Missing key" },
           { path: ["Symbol(b)"], message: "Missing key" }
         ]
       })
-      await assertions.deserialization.json.codec.succeed(Schema.FailureResult, {
+      await assertions.deserialization.json.codec.succeed(Schema.StandardSchemaV1FailureResult, {
         issues: [
           { path: ["a"], message: `Expected a value with a length of at least 1, actual ""` },
           { path: ["c", 0], message: "Missing key" },

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -1,7 +1,7 @@
 import { Option } from "effect/data"
-import { Check, Schema, Serializer, Transformation } from "effect/schema"
+import { Check, Formatter, Schema, Serializer, ToParser, Transformation } from "effect/schema"
 import { describe, it } from "vitest"
-import { strictEqual } from "../utils/assert.ts"
+import { assertTrue, strictEqual } from "../utils/assert.ts"
 import { assertions } from "../utils/schema.ts"
 
 const FiniteFromDate = Schema.Date.pipe(Schema.decodeTo(
@@ -86,7 +86,7 @@ describe("Serializer", () => {
       it("Symbol", async () => {
         const schema = Schema.Symbol
 
-        await assertions.serialization.json.schema.succeed(schema, Symbol.for("a"), "a")
+        await assertions.serialization.json.schema.succeed(schema, Symbol.for("a"), "Symbol(a)")
         await assertions.serialization.json.schema.fail(
           schema,
           Symbol("a"),
@@ -98,7 +98,7 @@ describe("Serializer", () => {
           "cannot serialize to string, Symbol has no description"
         )
 
-        await assertions.deserialization.json.schema.succeed(schema, "a", Symbol.for("a"))
+        await assertions.deserialization.json.schema.succeed(schema, "Symbol(a)", Symbol.for("a"))
       })
 
       it("BigInt", async () => {
@@ -106,6 +106,17 @@ describe("Serializer", () => {
 
         await assertions.serialization.json.schema.succeed(schema, 1n, "1")
         await assertions.deserialization.json.schema.succeed(schema, "1", 1n)
+      })
+
+      it("PropertyKey", async () => {
+        const schema = Schema.PropertyKey
+        await assertions.serialization.json.schema.succeed(schema, "a", "a")
+        await assertions.serialization.json.schema.succeed(schema, 1, 1)
+        await assertions.serialization.json.schema.succeed(schema, Symbol.for("a"), "Symbol(a)")
+
+        await assertions.deserialization.json.schema.succeed(schema, "a", "a")
+        await assertions.deserialization.json.schema.succeed(schema, 1, 1)
+        await assertions.deserialization.json.schema.succeed(schema, "Symbol(a)", Symbol.for("a"))
       })
 
       describe("Literal", () => {
@@ -222,16 +233,16 @@ describe("Serializer", () => {
       it("Record(Symbol, Date)", async () => {
         const schema = Schema.Record(Schema.Symbol, Schema.Date)
 
-        await assertions.deserialization.json.schema.succeed(
-          schema,
-          { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" },
-          { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") }
-        )
-
         await assertions.serialization.json.schema.succeed(
           schema,
           { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") },
-          { "a": "2021-01-01T00:00:00.000Z", "b": "2021-01-01T00:00:00.000Z" }
+          { "Symbol(a)": "2021-01-01T00:00:00.000Z", "Symbol(b)": "2021-01-01T00:00:00.000Z" }
+        )
+
+        await assertions.deserialization.json.schema.succeed(
+          schema,
+          { "Symbol(a)": "2021-01-01T00:00:00.000Z", "Symbol(b)": "2021-01-01T00:00:00.000Z" },
+          { [Symbol.for("a")]: new Date("2021-01-01"), [Symbol.for("b")]: new Date("2021-01-01") }
         )
       })
 
@@ -353,13 +364,13 @@ describe("Serializer", () => {
           schema,
           new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]]),
           [[
-            ["a"],
+            ["Symbol(a)"],
             "2021-01-01T00:00:00.000Z"
           ]]
         )
         await assertions.deserialization.json.codec.succeed(
           schema,
-          [[["a"], "2021-01-01T00:00:00.000Z"]],
+          [[["Symbol(a)"], "2021-01-01T00:00:00.000Z"]],
           new Map([[Option.some(Symbol.for("a")), new Date("2021-01-01")]])
         )
       })
@@ -470,6 +481,35 @@ describe("Serializer", () => {
       await assertions.deserialization.json.codec.succeed(schema, 0, Fruits.Apple)
       await assertions.deserialization.json.codec.succeed(schema, "banana", Fruits.Banana)
     })
+
+    it("FailureResult", async () => {
+      const b = Symbol.for("b")
+      const schema = Schema.Struct({
+        a: Schema.NonEmptyString,
+        [b]: Schema.Finite,
+        c: Schema.Tuple([Schema.String])
+      })
+      const r = ToParser.decodeUnknownResult(schema)({ a: "", c: [] }, { errors: "all" })
+      assertTrue(r._tag === "Failure")
+      const failureResult = Formatter.makeStandardSchemaV1({
+        leafHook: Formatter.treeLeafHook,
+        checkHook: Formatter.verboseCheckHook
+      }).format(r.failure)
+      await assertions.serialization.json.codec.succeed(Schema.FailureResult, failureResult, {
+        issues: [
+          { path: ["a"], message: `Expected a value with a length of at least 1, actual ""` },
+          { path: ["c", 0], message: "Missing key" },
+          { path: ["Symbol(b)"], message: "Missing key" }
+        ]
+      })
+      await assertions.deserialization.json.codec.succeed(Schema.FailureResult, {
+        issues: [
+          { path: ["a"], message: `Expected a value with a length of at least 1, actual ""` },
+          { path: ["c", 0], message: "Missing key" },
+          { path: ["Symbol(b)"], message: "Missing key" }
+        ]
+      }, failureResult)
+    })
   })
 
   describe("stringLeafJson", () => {
@@ -515,7 +555,7 @@ describe("Serializer", () => {
       it("Symbol", async () => {
         const schema = Schema.Symbol
 
-        await assertions.serialization.stringLeafJson.schema.succeed(schema, Symbol.for("a"), "a")
+        await assertions.serialization.stringLeafJson.schema.succeed(schema, Symbol.for("a"), "Symbol(a)")
         await assertions.serialization.stringLeafJson.schema.fail(
           schema,
           Symbol("a"),
@@ -527,7 +567,7 @@ describe("Serializer", () => {
           "cannot serialize to string, Symbol has no description"
         )
 
-        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "a", Symbol.for("a"))
+        await assertions.deserialization.stringLeafJson.schema.succeed(schema, "Symbol(a)", Symbol.for("a"))
       })
 
       it("Number", async () => {

--- a/packages/effect/test/schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/schema/standardSchemaV1.test.ts
@@ -348,7 +348,7 @@ describe("standardSchemaV1", () => {
     })
   })
 
-  describe("Tree hooks", () => {
+  describe("treeLeafHook & verboseCheckHook", () => {
     it("String", () => {
       const schema = Schema.String
       const standardSchema = Schema.standardSchemaV1(schema, {

--- a/packages/effect/test/schema/standardSchemaV1.test.ts
+++ b/packages/effect/test/schema/standardSchemaV1.test.ts
@@ -1,7 +1,7 @@
 import { assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Effect, ServiceMap } from "effect"
 import { Option } from "effect/data"
-import { Check, Getter, Schema } from "effect/schema"
+import { Check, Formatter, Getter, Schema } from "effect/schema"
 import { describe, it } from "vitest"
 import { standard } from "../utils/schema.ts"
 
@@ -345,6 +345,36 @@ describe("standardSchemaV1", () => {
           }
         ])
       })
+    })
+  })
+
+  describe("Tree hooks", () => {
+    it("String", () => {
+      const schema = Schema.String
+      const standardSchema = Schema.standardSchemaV1(schema, {
+        leafHook: Formatter.treeLeafHook,
+        checkHook: Formatter.verboseCheckHook
+      })
+      standard.expectSyncFailure(standardSchema, null, [
+        {
+          message: "Expected string, actual null",
+          path: []
+        }
+      ])
+    })
+
+    it("NonEmptyString", () => {
+      const schema = Schema.NonEmptyString
+      const standardSchema = Schema.standardSchemaV1(schema, {
+        leafHook: Formatter.treeLeafHook,
+        checkHook: Formatter.verboseCheckHook
+      })
+      standard.expectSyncFailure(standardSchema, "", [
+        {
+          message: `Expected a value with a length of at least 1, actual ""`,
+          path: []
+        }
+      ])
     })
   })
 })


### PR DESCRIPTION
#### Sending a FailureResult over the wire

You can use the `Schema.StandardSchemaV1FailureResult` schema to send a `StandardSchemaV1.FailureResult` over the wire.

**Example** (Sending a FailureResult over the wire)

```ts
import { Formatter, Schema, Serializer, ToParser } from "effect/schema"

const b = Symbol.for("b")

const schema = Schema.Struct({
  a: Schema.NonEmptyString,
  [b]: Schema.Finite,
  c: Schema.Tuple([Schema.String])
})

const r = ToParser.decodeUnknownResult(schema)({ a: "", c: [] }, { errors: "all" })

if (r._tag === "Failure") {
  const failureResult = Formatter.makeStandardSchemaV1({
    leafHook: Formatter.treeLeafHook,
    checkHook: Formatter.verboseCheckHook
  }).format(r.failure)
  const serializer = Serializer.json(Schema.StandardSchemaV1FailureResult)
  console.dir(Schema.encodeSync(serializer)(failureResult), { depth: null })
}
/*
{
  issues: [
    {
      message: 'Expected a value with a length of at least 1, actual ""',
      path: [ 'a' ]
    },
    { message: 'Missing key', path: [ 'c', 0 ] },
    { message: 'Missing key', path: [ 'Symbol(b)' ] }
  ]
}
*/
```
