### PR TITLE
POC: add Config.schema API

### DIFF
--- a/bundle/config-schema.ts
+++ b/bundle/config-schema.ts
@@ -1,0 +1,5 @@
+import * as Config from "#dist/effect/config/Config"
+import * as Effect from "#dist/effect/Effect"
+import * as Schema from "#dist/effect/schema/Schema"
+
+Effect.runFork(Config.schema({ ENV: Schema.String }).asEffect())

--- a/bundle/config-withSchema.ts
+++ b/bundle/config-withSchema.ts
@@ -1,0 +1,5 @@
+import * as Config from "#dist/effect/config/Config"
+import * as Effect from "#dist/effect/Effect"
+import * as Schema from "#dist/effect/schema/Schema"
+
+Effect.runFork(Config.String("ENV").pipe(Config.withSchema(Schema.Trim)).asEffect())

--- a/bundle/schema-formatter-tree.ts
+++ b/bundle/schema-formatter-tree.ts
@@ -1,0 +1,15 @@
+import * as Effect from "#dist/effect/Effect"
+import * as Formatter from "#dist/effect/schema/Formatter"
+import * as Schema from "#dist/effect/schema/Schema"
+
+const schema = Schema.Struct({
+  a: Schema.NonEmptyString,
+  b: Schema.optional(Schema.Number),
+  c: Schema.Array(Schema.String),
+  d: Schema.Trim
+})
+
+Schema.decodeUnknownEffect(schema)({ a: "a", b: 1, c: ["c"] }).pipe(
+  Effect.mapError((e) => Formatter.makeTree().format(e.issue)),
+  Effect.runPromise
+).then(console.log)

--- a/packages/effect/src/config/ConfigError.ts
+++ b/packages/effect/src/config/ConfigError.ts
@@ -106,7 +106,7 @@ export class SourceError extends Data.TaggedError("ConfigError")<{
  * @category Models
  */
 export class InvalidData extends Data.TaggedError("ConfigError")<{
-  readonly path: ReadonlyArray<string>
+  readonly path: ReadonlyArray<string | number>
   readonly description: string
   readonly cause?: unknown
 }> {

--- a/packages/effect/src/config/ConfigError.ts
+++ b/packages/effect/src/config/ConfigError.ts
@@ -106,7 +106,7 @@ export class SourceError extends Data.TaggedError("ConfigError")<{
  * @category Models
  */
 export class InvalidData extends Data.TaggedError("ConfigError")<{
-  readonly path: ReadonlyArray<string | number>
+  readonly path: ReadonlyArray<PropertyKey>
   readonly description: string
   readonly cause?: unknown
 }> {

--- a/packages/effect/src/schema/AST.ts
+++ b/packages/effect/src/schema/AST.ts
@@ -742,18 +742,7 @@ export class LiteralType extends AbstractParser {
   }
   /** @internal */
   goStringLeafJson() {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const ast = this
-    switch (typeof ast.literal) {
-      case "number":
-        return coerceLiteral(ast)
-      case "boolean":
-        return coerceLiteral(ast)
-      case "bigint":
-        return coerceLiteral(ast)
-      default:
-    }
-    return ast
+    return Predicate.isString(this.literal) ? this : coerceLiteral(this)
   }
 }
 

--- a/packages/effect/src/schema/Formatter.ts
+++ b/packages/effect/src/schema/Formatter.ts
@@ -65,8 +65,10 @@ function getMessageAnnotation(
 
 /**
  * Tries to find a message in the annotations of the issue.
+ *
+ * @internal
  */
-function findMessage(issue: Issue.Leaf | Issue.Filter): string | undefined {
+export function findMessage(issue: Issue.Leaf | Issue.Filter): string | undefined {
   switch (issue._tag) {
     case "InvalidType":
     case "OneOf":
@@ -235,13 +237,6 @@ function formatTree(
   checkHook: CheckHook
 ): Tree {
   switch (issue._tag) {
-    case "MissingKey":
-    case "UnexpectedKey":
-    case "InvalidType":
-    case "InvalidValue":
-    case "Forbidden":
-    case "OneOf":
-      return new Tree(leafHook(issue))
     case "Filter": {
       const message = checkHook(issue)
       if (message !== undefined) {
@@ -272,6 +267,8 @@ function formatTree(
         issue.issues.map((issue) => formatTree(issue, path, leafHook, checkHook))
       )
     }
+    default:
+      return new Tree(leafHook(issue))
   }
 }
 
@@ -342,13 +339,6 @@ function formatStandardV1(
   checkHook: CheckHook
 ): Array<StandardSchemaV1.Issue> {
   switch (issue._tag) {
-    case "InvalidType":
-    case "InvalidValue":
-    case "MissingKey":
-    case "UnexpectedKey":
-    case "Forbidden":
-    case "OneOf":
-      return [{ path, message: leafHook(issue) }]
     case "Filter": {
       const message = checkHook(issue)
       if (message !== undefined) {
@@ -363,6 +353,8 @@ function formatStandardV1(
     case "Composite":
     case "AnyOf":
       return issue.issues.flatMap((issue) => formatStandardV1(issue, path, leafHook, checkHook))
+    default:
+      return [{ path, message: leafHook(issue) }]
   }
 }
 

--- a/packages/effect/test/config/Config.test.ts
+++ b/packages/effect/test/config/Config.test.ts
@@ -1345,13 +1345,19 @@ describe("Config.schema (old tests)", () => {
       )
       assertConfig(config, {}, { key1: 0, key2: 0 })
       assertConfig(config, { key1: "1", key2: "2" }, { key1: 1, key2: 2 })
-      assertConfigError(
+      assertConfigErrors(
         config,
         { key1: "invalid", key2: "value" },
-        new ConfigError.InvalidData({
-          path: ["key1"],
-          description: `Expected a string representing a number, actual "invalid"`
-        })
+        [
+          new ConfigError.InvalidData({
+            path: ["key1"],
+            description: `Expected a string representing a number, actual "invalid"`
+          }),
+          new ConfigError.InvalidData({
+            path: ["key2"],
+            description: `Expected a string representing a number, actual "value"`
+          })
+        ]
       )
     })
 
@@ -1628,15 +1634,6 @@ describe("Config.schema (old tests)", () => {
             enabled: true,
             debug: false
           }
-        })
-      })
-
-      it.todo("should parse with custom config", () => {
-        const dateConfig = Config.map(Config.String(), (str) => new Date(str))
-        const config = Config.Record("RECORD", dateConfig)
-        assertConfig(config, { RECORD: "start=2024-01-01,end=2024-12-31" }, {
-          start: new Date("2024-01-01"),
-          end: new Date("2024-12-31")
         })
       })
     })


### PR DESCRIPTION
## Goal

The goal is to provide a single API that leverages the Schema module for all validation and decoding needs.

## How it works

1. Reads the keys from the struct fields
2. Uses these keys to load the corresponding values (as strings) from the `ConfigProvider`
3. Collects all key/value pairs into a `Serializer.StringLeafJson` struct
4. Generates a deserializer schema using `Serializer.stringLeafJson`
5. Calls `ToParser.decodeUnknownEffect`

**Example**

```ts
import { Effect } from "effect"
import { Config, ConfigProvider } from "effect/config"
import { Schema } from "effect/schema"

const config = Config.schema({
  a: Schema.String,
  b: Schema.Finite,
  c: Schema.Int,
  d: Schema.BigInt,
  e: Schema.Trim
})

const r = Effect.runSyncExit(
  config.parse(
    ConfigProvider.fromEnv({ environment: { a: "a", b: "1.2", c: "1", d: "2", e: "  e  " } }).context()
  )
)

if (r._tag === "Success") {
  console.log(r.value)
} else {
  console.dir(r.cause, { depth: null })
}
// => { a: 'a', b: 1.2, c: 1, d: 2n, e: 'e' }
```