### PR TITLE
fix StringLeafJson definition

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -331,7 +331,7 @@ The process has two steps:
    A short helper converts the raw data into a structure whose leaves are all strings.
 
    ```ts
-   type StringLeafJson = string | { [key: string]: StringLeafJson } | Array<StringLeafJson>
+   type StringLeafJson = string | undefined | { [key: string]: StringLeafJson } | Array<StringLeafJson>
    ```
 
 2. **Tree → value**
@@ -358,9 +358,10 @@ const Query = Schema.Struct({
 
 const serializer = Serializer.stringLeafJson(Query)
 
-const params = new URLSearchParams("?page=2&q=foo")
+console.log(Schema.decodeSync(serializer)(toTree(new URLSearchParams("?page=1&q=foo"))))
+// => { page: 1, q: "foo" }
 
-console.log(Schema.decodeSync(serializer)(toTree(params)))
+console.log(Schema.decodeSync(serializer)(toTree(new URLSearchParams("?page=2"))))
 // => { page: 2, q: "foo" }
 ```
 

--- a/packages/effect/src/config/Config.ts
+++ b/packages/effect/src/config/Config.ts
@@ -154,7 +154,7 @@ export const unwrap = <T>(wrapped: Wrap<T>): Config<T> => {
 const dump: (
   provider: ConfigProvider.ConfigProvider,
   path: Path
-) => Effect.Effect<Serializer.StringLeafJson | undefined, SourceError> = Effect.fnUntraced(function*(
+) => Effect.Effect<Serializer.StringLeafJson, SourceError> = Effect.fnUntraced(function*(
   provider,
   path
 ) {
@@ -194,7 +194,7 @@ const go: (
   ast: AST.AST,
   provider: ConfigProvider.ConfigProvider,
   path: Path
-) => Effect.Effect<Serializer.StringLeafJson | undefined, Schema.SchemaError | SourceError> = Effect.fnUntraced(
+) => Effect.Effect<Serializer.StringLeafJson, Schema.SchemaError | SourceError> = Effect.fnUntraced(
   function*(ast, provider, path) {
     switch (ast._tag) {
       case "TypeLiteral": {

--- a/packages/effect/src/schema/AST.ts
+++ b/packages/effect/src/schema/AST.ts
@@ -442,6 +442,10 @@ export class UndefinedKeyword extends AbstractParser {
     return fromRefinement(this, Predicate.isUndefined)
   }
   /** @internal */
+  goJson() {
+    return this
+  }
+  /** @internal */
   getExpected(): string {
     return "undefined"
   }

--- a/packages/effect/src/schema/Serializer.ts
+++ b/packages/effect/src/schema/Serializer.ts
@@ -39,11 +39,11 @@ const goJson = AST.memoize((ast: AST.AST): AST.AST => {
 })
 
 /**
- * A subtype of `Json` whose leaves are always strings.
+ * A subtype of `Json` whose leaves are always strings (or `undefined`).
  *
  * @since 4.0.0
  */
-export type StringLeafJson = string | { [x: string]: StringLeafJson } | Array<StringLeafJson>
+export type StringLeafJson = string | undefined | { [x: string]: StringLeafJson } | Array<StringLeafJson>
 
 /**
  * The `stringLeafJson` serializer is a wrapper around the `json` serializer. It

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -72,17 +72,13 @@ describe("Serializer", () => {
       it("Undefined", async () => {
         const schema = Schema.Undefined
 
-        await assertions.serialization.json.schema.fail(
-          schema,
-          undefined,
-          "cannot serialize to JSON, required `defaultJsonSerializer` annotation"
-        )
+        await assertions.serialization.json.schema.succeed(schema, undefined)
       })
 
       it("Null", async () => {
         const schema = Schema.Null
 
-        await assertions.serialization.json.schema.succeed(schema, null, null)
+        await assertions.serialization.json.schema.succeed(schema, null)
       })
 
       it("String", async () => {
@@ -531,13 +527,19 @@ describe("Serializer", () => {
         strictEqual(serializer.ast, schema.ast)
       })
 
-      it("Array", async () => {
+      it("Undefined", async () => {
+        const schema = Schema.Undefined
+        const serializer = Serializer.stringLeafJson(schema)
+        strictEqual(serializer.ast, schema.ast)
+      })
+
+      it("Array(String)", async () => {
         const schema = Schema.Array(Schema.String)
         const serializer = Serializer.stringLeafJson(schema)
         strictEqual(serializer.ast, schema.ast)
       })
 
-      it("Struct", async () => {
+      it("Struct({ a: String })", async () => {
         const schema = Schema.Struct({
           a: Schema.String
         })


### PR DESCRIPTION
This now works as expected:

```ts
import { Effect } from "effect"
import { Config, ConfigProvider } from "effect/config"
import { Schema } from "effect/schema"

const ProviderLayer = ConfigProvider.layer(
  ConfigProvider.fromEnv({
    env: {
      // OTEL_SERVICE_NAME: "my-service"
    }
  })
)

const config = Config.schema(
  Schema.UndefinedOr(Schema.String),
  "OTEL_SERVICE_NAME"
)

Effect.gen(function*() {
  console.log(yield* config)
}).pipe(
  Effect.provide(ProviderLayer),
  Effect.runPromise
)
// => undefined
```