### PR TITLE
chore: enable type tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: latest
       - run: pnpm check
-      # - run: pnpm test-types --target '>=5.4'
+      - run: pnpm test-types --target '>=5.4'
 
   types-deno:
     name: Types on Deno

--- a/packages/effect/tsconfig.src.json
+++ b/packages/effect/tsconfig.src.json
@@ -6,6 +6,8 @@
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
     "outDir": ".tsbuildinfo/src",
     "types": ["node"],
-    "rootDir": "src"
+    "rootDir": "src",
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/packages/effect/tsconfig.test.json
+++ b/packages/effect/tsconfig.test.json
@@ -7,8 +7,8 @@
     "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
     "outDir": ".tsbuildinfo/test",
     "noEmit": true,
-    "erasableSyntaxOnly": false,
     "baseUrl": ".",
+    "allowImportingTsExtensions": true,
     "paths": {
       "effect": ["src/index.ts"],
       "effect/*": ["src/*/index.ts", "src/*.ts"]

--- a/packages/platform-bun/tsconfig.src.json
+++ b/packages/platform-bun/tsconfig.src.json
@@ -7,6 +7,8 @@
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
     "outDir": ".tsbuildinfo/src",
     "rootDir": "src",
-    "types": ["bun"]
+    "types": ["bun"],
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/packages/platform-node-shared/tsconfig.src.json
+++ b/packages/platform-node-shared/tsconfig.src.json
@@ -7,6 +7,8 @@
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
     "outDir": ".tsbuildinfo/src",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/packages/platform-node-shared/tsconfig.test.json
+++ b/packages/platform-node-shared/tsconfig.test.json
@@ -8,8 +8,8 @@
     "outDir": ".tsbuildinfo/test",
     "rootDir": "test",
     "noEmit": true,
-    "erasableSyntaxOnly": false,
     "baseUrl": ".",
+    "allowImportingTsExtensions": true,
     "paths": {
       "@effect/platform-node-shared": ["src/index.ts"],
       "@effect/platform-node-shared/*": ["src/*/index.ts", "src/*.ts"]

--- a/packages/platform-node/tsconfig.src.json
+++ b/packages/platform-node/tsconfig.src.json
@@ -7,6 +7,8 @@
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
     "outDir": ".tsbuildinfo/src",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/packages/platform-node/tsconfig.test.json
+++ b/packages/platform-node/tsconfig.test.json
@@ -8,9 +8,9 @@
     "outDir": ".tsbuildinfo/test",
     "rootDir": "test",
     "noEmit": true,
-    "erasableSyntaxOnly": false,
     "resolveJsonModule": true,
     "baseUrl": ".",
+    "allowImportingTsExtensions": true,
     "paths": {
       "@effect/platform-node": ["src/index.ts"],
       "@effect/platform-node/*": ["src/*/index.ts", "src/*.ts"]

--- a/packages/vitest/tsconfig.src.json
+++ b/packages/vitest/tsconfig.src.json
@@ -6,6 +6,8 @@
   "compilerOptions": {
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
     "outDir": ".tsbuildinfo/src",
-    "rootDir": "src"
+    "rootDir": "src",
+    "erasableSyntaxOnly": true,
+    "rewriteRelativeImportExtensions": true
   }
 }

--- a/packages/vitest/tsconfig.test.json
+++ b/packages/vitest/tsconfig.test.json
@@ -9,6 +9,7 @@
     "rootDir": "test",
     "noEmit": true,
     "baseUrl": ".",
+    "allowImportingTsExtensions": true,
     "paths": {
       "@effect/vitest": ["src/index.ts"],
       "@effect/vitest/*": ["src/*/index.ts", "src/*.ts"]

--- a/tsconfig.base.jsonc
+++ b/tsconfig.base.jsonc
@@ -11,8 +11,6 @@
     "esModuleInterop": false, // Do not fiddle with import/export statements
     "verbatimModuleSyntax": true, // Only transform/eliminate type-only import/export statements.
     "allowJs": false, // If you touch this, a puppy dies.
-    "rewriteRelativeImportExtensions": true, // Rewrite `.ts` imports to `.js` at build time.
-    "erasableSyntaxOnly": true, // Allows to run directly with node and type removal
     // Emit source- & declaration maps.
     "declarationMap": true,
     "sourceMap": true,

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "checkSuppressedErrors": true,
+  "checkSourceFiles": false,
   "testFileMatch": ["packages/*/dtslint/**/*.tst.*"]
 }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR makes it possible to run the type tests again.

@gcanti Seems like the errors you saw were caused by the `rewriteRelativeImportExtensions` option. It works fine when `tsc` is compiling, but language service throws "This import path is unsafe to rewrite..." when it tries to handle `references`. TSTyche is using the language service API.

The solution could be to move `rewriteRelativeImportExtensions` (added in TS 5.7) and `erasableSyntaxOnly` (added in TS 5.8) to `tsconfig.src.json` files. Probably these are not so important for `tsconfig.test.json`. That way you can also test types targeting TypeScript `>=5.4`. The unknown options are out of the way.

Some test files import using `.ts` extension. To make that work, I enabled `allowImportingTsExtensions` (added in TS 5.0) to `tsconfig.test.json`.

---

Might be there is cleaner way to organise the TSConfig files, of course.