### PR TITLE
chore: update TSTyche config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: latest
       - run: pnpm check
-      # - run: pnpm test-types --target '>=5.4'
+      - run: pnpm test-types --target '>=5.4'
 
   types-deno:
     name: Types on Deno

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "checkSuppressedErrors": true,
-  "testFileMatch": ["packages/*/dtslint/**/*.tst.*"]
+  "checkSourceFiles": false,
+  "testFileMatch": ["packages/*/dtslint/**/*.tst.*"],
+  "tsconfig": "ignore"
 }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

An alternative to #426.

The `tsconfig: "ignore"` tells to TSTyche to use its [default compiler options](https://tstyche.org/project/compiler-options#default-compiler-options) instead of resolving the nearest `tsconfig.json`. The default are rather strict.

This way type testing would be independent from any options set in the TSConfig files. And that will always work between TypeScript versions.

## Related

- Closes #426
