### PR TITLE
Bringing the Check Harness to the Brand Module

### DIFF
--- a/bundle/brand.ts
+++ b/bundle/brand.ts
@@ -1,0 +1,5 @@
+import * as Brand from "#dist/effect/data/Brand"
+import * as Check from "#dist/effect/schema/Check"
+
+type Positive = number & Brand.Brand<"Positive">
+const Positive = Brand.check<Positive>(Check.positive())

--- a/packages/effect/src/collections/Array.ts
+++ b/packages/effect/src/collections/Array.ts
@@ -2876,14 +2876,14 @@ export const getSomes: <T extends Iterable<Option.Option<X>>, X = any>(
  * import { Array } from "effect/collections"
  * import { Result } from "effect/data"
  *
- * const result = Array.getErrs([Result.succeed(1), Result.fail("err"), Result.succeed(2)])
+ * const result = Array.getFailures([Result.succeed(1), Result.fail("err"), Result.succeed(2)])
  * console.log(result) // ["err"]
  * ```
  *
  * @category filtering
  * @since 2.0.0
  */
-export const getErrs = <T extends Iterable<Result.Result<any, any>>>(
+export const getFailures = <T extends Iterable<Result.Result<any, any>>>(
   self: T
 ): Array<Result.Result.Failure<ReadonlyArray.Infer<T>>> => {
   const out: Array<any> = []
@@ -2905,14 +2905,14 @@ export const getErrs = <T extends Iterable<Result.Result<any, any>>>(
  * import { Array } from "effect/collections"
  * import { Result } from "effect/data"
  *
- * const result = Array.getOks([Result.succeed(1), Result.fail("err"), Result.succeed(2)])
+ * const result = Array.getSuccesses([Result.succeed(1), Result.fail("err"), Result.succeed(2)])
  * console.log(result) // [1, 2]
  * ```
  *
  * @category filtering
  * @since 2.0.0
  */
-export const getOks = <T extends Iterable<Result.Result<any, any>>>(
+export const getSuccesses = <T extends Iterable<Result.Result<any, any>>>(
   self: T
 ): Array<Result.Result.Success<ReadonlyArray.Infer<T>>> => {
   const out: Array<any> = []

--- a/packages/effect/src/collections/Iterable.ts
+++ b/packages/effect/src/collections/Iterable.ts
@@ -1620,7 +1620,7 @@ export const getSomes: <A>(self: Iterable<Option<A>>) => Iterable<A> = filterMap
 import * as Result from "effect/data/Result"
  *
  * assert.deepStrictEqual(
- *   Array.from(Iterable.getErrs([Result.succeed(1), Result.fail("err"), Result.succeed(2)])),
+ *   Array.from(Iterable.getFailures([Result.succeed(1), Result.fail("err"), Result.succeed(2)])),
  *   ["err"]
  * )
  * ```
@@ -1628,7 +1628,7 @@ import * as Result from "effect/data/Result"
  * @category filtering
  * @since 2.0.0
  */
-export const getErrs = <R, L>(self: Iterable<Result<R, L>>): Iterable<L> => filterMap(self, R.getFailure)
+export const getFailures = <R, L>(self: Iterable<Result<R, L>>): Iterable<L> => filterMap(self, R.getFailure)
 
 /**
  * Retrieves the `Ok` values from an `Iterable` of `Result`s.
@@ -1640,7 +1640,7 @@ export const getErrs = <R, L>(self: Iterable<Result<R, L>>): Iterable<L> => filt
 import * as Result from "effect/data/Result"
  *
  * assert.deepStrictEqual(
- *   Array.from(Iterable.getOks([Result.succeed(1), Result.fail("err"), Result.succeed(2)])),
+ *   Array.from(Iterable.getSuccesses([Result.succeed(1), Result.fail("err"), Result.succeed(2)])),
  *   [1, 2]
  * )
  * ```
@@ -1648,7 +1648,7 @@ import * as Result from "effect/data/Result"
  * @category filtering
  * @since 2.0.0
  */
-export const getOks = <R, L>(self: Iterable<Result<R, L>>): Iterable<R> => filterMap(self, R.getSuccess)
+export const getSuccesses = <R, L>(self: Iterable<Result<R, L>>): Iterable<R> => filterMap(self, R.getSuccess)
 
 /**
  * Filters an iterable to only include elements that match a predicate.

--- a/packages/effect/src/data/Brand.ts
+++ b/packages/effect/src/data/Brand.ts
@@ -47,18 +47,6 @@ export const TypeId: TypeId = "~effect/Brand"
 export type TypeId = "~effect/Brand"
 
 /**
- * @category symbols
- * @since 2.0.0
- */
-export const RefinedConstructorsTypeId: RefinedConstructorsTypeId = "~effect/Brand/Refined"
-
-/**
- * @category symbols
- * @since 2.0.0
- */
-export type RefinedConstructorsTypeId = "~effect/Brand/Refined"
-
-/**
  * A generic interface that defines a branded type.
  *
  * **Example**
@@ -107,7 +95,6 @@ export declare namespace Brand {
    * @since 2.0.0
    */
   export interface Constructor<in out A extends Brand<any>> {
-    readonly [RefinedConstructorsTypeId]: RefinedConstructorsTypeId
     /**
      * Constructs a branded type from a value of type `A`, throwing an error if
      * the provided `A` is not valid.
@@ -223,7 +210,6 @@ export function make<A extends Brand<any>>(
     return issue ? Result.fail(new BrandError({ issue })) : Result.succeed(input as A)
   }
   return Object.assign((input: Brand.Unbranded<A>) => Result.getOrThrowWith(result(input), identity), {
-    [RefinedConstructorsTypeId]: RefinedConstructorsTypeId,
     option: (input: Brand.Unbranded<A>) => Option.getSuccess(result(input)),
     result,
     is: (input: Brand.Unbranded<A>): input is Brand.Unbranded<A> & A => Result.isSuccess(result(input))
@@ -293,7 +279,6 @@ export function all<Brands extends readonly [Brand.Constructor<any>, ...Array<Br
       : Result.succeed(input)
   }
   return Object.assign((input: unknown) => Result.getOrThrow(result(input)), {
-    [RefinedConstructorsTypeId]: RefinedConstructorsTypeId,
     option: (input: unknown) => Option.getSuccess(result(input)),
     result,
     is: (input: unknown): input is any => Result.isSuccess(result(input))

--- a/packages/effect/src/data/Brand.ts
+++ b/packages/effect/src/data/Brand.ts
@@ -230,12 +230,11 @@ export function check<A extends Brand<any>>(
   const result = (input: Brand.Unbranded<A>): Result.Result<A, BrandError> => {
     const issues: Array<Issue.Issue> = []
     ToParser.runChecks(checks, input, issues, AST.unknownKeyword, { errors: "all" })
-    const issue = Arr.isNonEmptyArray(issues) ?
-      issues.length === 1 ?
-        issues[0] :
-        new Issue.Composite(AST.unknownKeyword, Option.some(input), issues) :
-      undefined
-    return issue ? Result.fail(new BrandError({ issue })) : Result.succeed(input as A)
+    if (Arr.isNonEmptyArray(issues)) {
+      const issue = new Issue.Composite(AST.unknownKeyword, Option.some(input), issues)
+      return Result.fail(new BrandError({ issue }))
+    }
+    return Result.succeed(input as A)
   }
   return Object.assign((input: Brand.Unbranded<A>) => Result.getOrThrowWith(result(input), identity), {
     option: (input: Brand.Unbranded<A>) => Option.getSuccess(result(input)),

--- a/packages/effect/src/data/Brand.ts
+++ b/packages/effect/src/data/Brand.ts
@@ -1,98 +1,73 @@
 /**
- * This module provides types and utility functions to create and work with branded types,
- * which are TypeScript types with an added type tag to prevent accidental usage of a value in the wrong context.
+ * This module provides types and utility functions to create and work with
+ * branded types, which are TypeScript types with an added type tag to prevent
+ * accidental usage of a value in the wrong context.
  *
- * The `refined` and `nominal` functions are both used to create branded types in TypeScript.
- * The main difference between them is that `refined` allows for validation of the data, while `nominal` does not.
+ * The `refined` and `nominal` functions are both used to create branded types
+ * in TypeScript. The main difference between them is that `refined` allows for
+ * validation of the data, while `nominal` does not.
  *
- * The `nominal` function is used to create a new branded type that has the same underlying type as the input, but with a different name.
- * This is useful when you want to distinguish between two values of the same type that have different meanings.
- * The `nominal` function does not perform any validation of the input data.
+ * The `nominal` function is used to create a new branded type that has the same
+ * underlying type as the input, but with a different name. This is useful when
+ * you want to distinguish between two values of the same type that have
+ * different meanings. The `nominal` function does not perform any validation of
+ * the input data.
  *
- * On the other hand, the `refined` function is used to create a new branded type that has the same underlying type as the input,
- * but with a different name, and it also allows for validation of the input data.
- * The `refined` function takes a predicate that is used to validate the input data.
- * If the input data fails the validation, a `BrandErrors` is returned, which provides information about the specific validation failure.
+ * On the other hand, the `refined` function is used to create a new branded
+ * type that has the same underlying type as the input, but with a different
+ * name, and it also allows for validation of the input data. The `refined`
+ * function takes a predicate that is used to validate the input data. If the
+ * input data fails the validation, a `BrandErrors` is returned, which provides
+ * information about the specific validation failure.
  *
  * @since 2.0.0
  */
 import * as Arr from "../collections/Array.ts"
-import * as Option from "../data/Option.ts"
-import type { Predicate } from "../data/Predicate.ts"
-import * as Result from "../data/Result.ts"
 import { identity } from "../Function.ts"
+import * as AST from "../schema/AST.ts"
+import type * as Check from "../schema/Check.ts"
+import * as Formatter from "../schema/Formatter.ts"
+import * as Issue from "../schema/Issue.ts"
+import * as ToParser from "../schema/ToParser.ts"
 import type * as Types from "../types/Types.ts"
+import * as Data from "./Data.ts"
+import * as Option from "./Option.ts"
+import * as Result from "./Result.ts"
 
 /**
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * // TypeId is used internally for branded type identification
- * console.log(Brand.TypeId) // "~effect/Brand"
- * ```
- *
- * @since 2.0.0
  * @category symbols
+ * @since 2.0.0
  */
 export const TypeId: TypeId = "~effect/Brand"
 
 /**
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * // TypeId represents the branded type identifier
- * type BrandTypeId = Brand.TypeId
- * ```
- *
- * @since 2.0.0
  * @category symbols
+ * @since 2.0.0
  */
 export type TypeId = "~effect/Brand"
 
 /**
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * // RefinedConstructorsTypeId is used internally for refined constructor identification
- * console.log(Brand.RefinedConstructorsTypeId) // "~effect/Brand/Refined"
- * ```
- *
- * @since 2.0.0
  * @category symbols
+ * @since 2.0.0
  */
 export const RefinedConstructorsTypeId: RefinedConstructorsTypeId = "~effect/Brand/Refined"
 
 /**
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * // RefinedConstructorsTypeId represents the refined constructor identifier
- * type RefineTypeId = Brand.RefinedConstructorsTypeId
- * ```
- *
- * @since 2.0.0
  * @category symbols
+ * @since 2.0.0
  */
 export type RefinedConstructorsTypeId = "~effect/Brand/Refined"
 
 /**
  * A generic interface that defines a branded type.
  *
- * @example
+ * **Example**
+ *
  * ```ts
  * import { Brand } from "effect/data"
  *
- * // Brand interface is used to create branded types
- * type UserId = string & Brand.Brand<"UserId">
+ * type UserId = number & Brand.Brand<"UserId">
  * type ProductId = number & Brand.Brand<"ProductId">
- *
- * // These types are now distinct from their base types
- * declare const userId: UserId
- * declare const productId: ProductId
  * ```
  *
  * @since 2.0.0
@@ -105,83 +80,31 @@ export interface Brand<in out K extends string | symbol> {
 }
 
 /**
- * A namespace providing utilities for working with branded types and their validation.
- *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * // Define a branded type
- * type UserId = string & Brand.Brand<"UserId">
- *
- * // Create a constructor with validation
- * const UserId = Brand.refined<UserId>(
- *   (s) => s.length > 0,
- *   () => Brand.error("UserId cannot be empty")
- * )
- * ```
- *
+ * @category models
+ * @since 4.0.0
+ */
+export class BrandError extends Data.TaggedError("BrandError")<{
+  readonly issue: Issue.Issue
+}> {
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return Formatter.makeDefault().format(this.issue)
+  }
+}
+
+/**
  * @category models
  * @since 2.0.0
  */
 export declare namespace Brand {
   /**
-   * Represents a list of refinement errors.
+   * A constructor for a branded type that provides validation and safe
+   * construction methods.
    *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * // BrandErrors represents validation failures
-   * const error1 = Brand.error("Invalid value", { value: 42 })
-   * const error2 = Brand.error("Out of range", { min: 0, max: 100 })
-   * const combined = Brand.errors(error1, error2)
-   * ```
-   *
-   * @since 2.0.0
    * @category models
-   */
-  export interface BrandErrors extends Array<RefinementError> {}
-
-  /**
-   * Represents an error that occurs when the provided value of the branded type does not pass the refinement predicate.
-   *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * // RefinementError represents a validation failure
-   * const error = Brand.error("Value must be positive", { value: -5, expected: "> 0" })
-   * console.log(error[0].message) // "Value must be positive"
-   * ```
-   *
    * @since 2.0.0
-   * @category models
-   */
-  export interface RefinementError {
-    readonly meta: unknown
-    readonly message: string
-  }
-
-  /**
-   * A constructor for a branded type that provides validation and safe construction methods.
-   *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * type PositiveNumber = number & Brand.Brand<"Positive">
-   * const PositiveNumber = Brand.refined<PositiveNumber>(
-   *   (n) => n > 0,
-   *   (n) => Brand.error(`Expected ${n} to be positive`)
-   * )
-   *
-   * const result = PositiveNumber(5) // PositiveNumber
-   * const optional = PositiveNumber.option(-1) // None
-   * ```
-   *
-   * @since 2.0.0
-   * @category models
    */
   export interface Constructor<in out A extends Brand<any>> {
     readonly [RefinedConstructorsTypeId]: RefinedConstructorsTypeId
@@ -196,10 +119,10 @@ export declare namespace Brand {
      */
     option(args: Brand.Unbranded<A>): Option.Option<A>
     /**
-     * Constructs a branded type from a value of type `A`, returning `Ok<A>`
-     * if the provided `A` is valid, `Err<BrandError>` otherwise.
+     * Constructs a branded type from a value of type `A`, returning `Ok<A>` if
+     * the provided `A` is valid, `Err<BrandError>` otherwise.
      */
-    result(args: Brand.Unbranded<A>): Result.Result<A, Brand.BrandErrors>
+    result(args: Brand.Unbranded<A>): Result.Result<A, BrandError>
     /**
      * Attempts to refine the provided value of type `A`, returning `true` if
      * the provided `A` is valid, `false` otherwise.
@@ -210,60 +133,24 @@ export declare namespace Brand {
   /**
    * A utility type to extract a branded type from a `Brand.Constructor`.
    *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * type PositiveNumber = number & Brand.Brand<"Positive">
-   * const PositiveNumber = Brand.refined<PositiveNumber>(
-   *   (n) => n > 0,
-   *   (n) => Brand.error(`Expected ${n} to be positive`)
-   * )
-   *
-   * // FromConstructor utility is used internally for type operations
-   * const validNumber = PositiveNumber(5)
-   * ```
-   *
-   * @since 2.0.0
    * @category models
+   * @since 2.0.0
    */
   export type FromConstructor<A> = A extends Brand.Constructor<infer B> ? B : never
 
   /**
    * A utility type to extract the value type from a brand.
    *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * type UserId = string & Brand.Brand<"UserId">
-   * const UserId = Brand.nominal<UserId>()
-   *
-   * // Unbranded utility extracts the base type
-   * const id: string = UserId("user-123")
-   * ```
-   *
-   * @since 2.0.0
    * @category models
+   * @since 2.0.0
    */
   export type Unbranded<P> = P extends infer Q & Brands<P> ? Q : P
 
   /**
    * A utility type to extract the brands from a branded type.
    *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * type UserId = string & Brand.Brand<"UserId">
-   * const UserId = Brand.nominal<UserId>()
-   *
-   * // Brands utility extracts brand information
-   * const id = UserId("user-123")
-   * ```
-   *
-   * @since 2.0.0
    * @category models
+   * @since 2.0.0
    */
   export type Brands<P> = P extends Brand<any> ? Types.UnionToIntersection<
       {
@@ -276,21 +163,8 @@ export declare namespace Brand {
   /**
    * A utility type that checks that all brands have the same base type.
    *
-   * @example
-   * ```ts
-   * import { Brand } from "effect/data"
-   *
-   * type Int = number & Brand.Brand<"Int">
-   * type Positive = number & Brand.Brand<"Positive">
-   * const Int = Brand.refined<Int>((n) => Number.isInteger(n), (n) => Brand.error("Not an integer"))
-   * const Positive = Brand.refined<Positive>((n) => n > 0, (n) => Brand.error("Not positive"))
-   *
-   * // This ensures both constructors have same base type
-   * const both = Brand.all(Int, Positive)
-   * ```
-   *
-   * @since 2.0.0
    * @category models
+   * @since 2.0.0
    */
   export type EnsureCommonBase<
     Brands extends readonly [Brand.Constructor<any>, ...Array<Brand.Constructor<any>>]
@@ -307,222 +181,119 @@ export declare namespace Brand {
 /**
  * A type alias for creating branded types more concisely.
  *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * type UserId = Brand.Branded<string, "UserId">
- * // Equivalent to: string & Brand.Brand<"UserId">
- * ```
- *
  * @category alias
  * @since 2.0.0
  */
 export type Branded<A, K extends string | symbol> = A & Brand<K>
 
 /**
- * Returns a `BrandErrors` that contains a single `RefinementError`.
+ * This function returns a `Brand.Constructor` that **does not apply any runtime
+ * checks**, it just returns the provided value. It can be used to create
+ * nominal types that allow distinguishing between two values of the same type
+ * but with different meanings.
  *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
+ * If you also want to perform some validation, see {@link make} or
+ * {@link check} or {@link refine}.
  *
- * const validationError = Brand.error("Value must be positive", { value: -5 })
- * console.log(validationError)
- * // [{ message: "Value must be positive", meta: { value: -5 } }]
- * ```
- *
- * @since 2.0.0
  * @category constructors
- */
-export const error = (message: string, meta?: unknown): Brand.BrandErrors => [{
-  message,
-  meta
-}]
-
-/**
- * Takes a variable number of `BrandErrors` and returns a single `BrandErrors` that contains all refinement errors.
- *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * const error1 = Brand.error("Must be positive")
- * const error2 = Brand.error("Must be integer")
- * const combined = Brand.errors(error1, error2)
- * console.log(combined)
- * // [
- * //   { message: "Must be positive", meta: undefined },
- * //   { message: "Must be integer", meta: undefined }
- * // ]
- * ```
- *
  * @since 2.0.0
- * @category constructors
  */
-export const errors: (...errors: Array<Brand.BrandErrors>) => Brand.BrandErrors = (
-  ...errors: Array<Brand.BrandErrors>
-): Brand.BrandErrors => Arr.flatten(errors)
-
-/**
- * Returns a `Brand.Constructor` that can construct a branded type from an unbranded value using the provided `refinement`
- * predicate as validation of the input data.
- *
- * If you don't want to perform any validation but only distinguish between two values of the same type but with different meanings,
- * see {@link nominal}.
- *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * type Int = number & Brand.Brand<"Int">
- *
- * const Int = Brand.refined<Int>(
- *   (n) => Number.isInteger(n),
- *   (n) => Brand.error(`Expected ${n} to be an integer`)
- * )
- *
- * console.log(Int(1)) // 1
- * console.log(Int.option(1.1)) // { _tag: "None" }
- * ```
- *
- * @since 2.0.0
- * @category constructors
- */
-export function refined<A extends Brand<any>>(
-  f: (unbranded: Brand.Unbranded<A>) => Option.Option<Brand.BrandErrors>
-): Brand.Constructor<A>
-export function refined<A extends Brand<any>>(
-  refinement: Predicate<Brand.Unbranded<A>>,
-  onFailure: (unbranded: Brand.Unbranded<A>) => Brand.BrandErrors
-): Brand.Constructor<A>
-export function refined<A extends Brand<any>>(
-  ...args: [(unbranded: Brand.Unbranded<A>) => Option.Option<Brand.BrandErrors>] | [
-    Predicate<Brand.Unbranded<A>>,
-    (unbranded: Brand.Unbranded<A>) => Brand.BrandErrors
-  ]
-): Brand.Constructor<A> {
-  const result: (unbranded: Brand.Unbranded<A>) => Result.Result<A, Brand.BrandErrors> = args.length === 2 ?
-    (unbranded) => args[0](unbranded) ? Result.succeed(unbranded as A) : Result.fail(args[1](unbranded)) :
-    (unbranded) => {
-      return Option.match(args[0](unbranded), {
-        onNone: () => Result.succeed(unbranded as A),
-        onSome: Result.fail
-      })
-    }
-  return Object.assign((unbranded: Brand.Unbranded<A>) => Result.getOrThrowWith(result(unbranded), identity), {
-    [RefinedConstructorsTypeId]: RefinedConstructorsTypeId,
-    option: (args: any) => Option.getOk(result(args)),
-    result,
-    is: (args: any): args is Brand.Unbranded<A> & A => Result.isSuccess(result(args))
-  }) as any
+export function nominal<A extends Brand<any>>(): Brand.Constructor<A> {
+  return make(() => undefined)
 }
 
 /**
- * This function returns a `Brand.Constructor` that **does not apply any runtime checks**, it just returns the provided value.
- * It can be used to create nominal types that allow distinguishing between two values of the same type but with different meanings.
+ * Returns a `Brand.Constructor` that can construct a branded type from an
+ * unbranded value using the provided `refinement` predicate as validation of
+ * the input data.
  *
- * If you also want to perform some validation, see {@link refined}.
+ * If you don't want to perform any validation but only distinguish between two
+ * values of the same type but with different meanings, see {@link nominal}.
  *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * type UserId = string & Brand.Brand<"UserId">
- * type ProductId = string & Brand.Brand<"ProductId">
- *
- * const UserId = Brand.nominal<UserId>()
- * const ProductId = Brand.nominal<ProductId>()
- *
- * const userId = UserId("user-123")
- * const productId = ProductId("prod-456")
- *
- * // These are now distinct types at compile time
- * console.log(userId) // "user-123"
- * console.log(productId) // "prod-456"
- * ```
- *
- * @since 2.0.0
  * @category constructors
+ * @since 2.0.0
  */
-export const nominal = <A extends Brand<any>>(): Brand.Constructor<
-  A
-> => {
-  // @ts-expect-error
-  return Object.assign((args) => args, {
+export function make<A extends Brand<any>>(
+  f: (unbranded: Brand.Unbranded<A>) => Issue.Issue | undefined
+): Brand.Constructor<A> {
+  const result = (input: Brand.Unbranded<A>): Result.Result<A, BrandError> => {
+    const issue = f(input)
+    return issue ? Result.fail(new BrandError({ issue })) : Result.succeed(input as A)
+  }
+  return Object.assign((input: Brand.Unbranded<A>) => Result.getOrThrowWith(result(input), identity), {
     [RefinedConstructorsTypeId]: RefinedConstructorsTypeId,
-    option: (args: any) => Option.some(args),
-    result: (args: any) => Result.succeed(args),
-    is: (_args: any): _args is Brand.Unbranded<A> & A => true
+    option: (input: Brand.Unbranded<A>) => Option.getSuccess(result(input)),
+    result,
+    is: (input: Brand.Unbranded<A>): input is Brand.Unbranded<A> & A => Result.isSuccess(result(input))
   })
 }
 
 /**
- * Combines two or more brands together to form a single branded type.
- * This API is useful when you want to validate that the input data passes multiple brand validators.
- *
- * @example
- * ```ts
- * import { Brand } from "effect/data"
- *
- * type Int = number & Brand.Brand<"Int">
- * const Int = Brand.refined<Int>(
- *   (n) => Number.isInteger(n),
- *   (n) => Brand.error(`Expected ${n} to be an integer`)
- * )
- * type Positive = number & Brand.Brand<"Positive">
- * const Positive = Brand.refined<Positive>(
- *   (n) => n > 0,
- *   (n) => Brand.error(`Expected ${n} to be positive`)
- * )
- *
- * const PositiveInt = Brand.all(Int, Positive)
- *
- * console.log(PositiveInt(1)) // 1
- * console.log(PositiveInt.option(-1)) // { _tag: "None" }
- * console.log(PositiveInt.option(1.1)) // { _tag: "None" }
- * ```
- *
- * @since 2.0.0
- * @category combining
+ * @since 4.0.0
  */
-export const all: <Brands extends readonly [Brand.Constructor<any>, ...Array<Brand.Constructor<any>>]>(
+export function check<A extends Brand<any>>(
+  ...checks: readonly [
+    Check.Check<Brand.Unbranded<A>>,
+    ...ReadonlyArray<Check.Check<Brand.Unbranded<A>>>
+  ]
+): Brand.Constructor<A> {
+  return make((input) => {
+    const issues: Array<Issue.Issue> = []
+    ToParser.runChecks(checks, input, issues, AST.unknownKeyword, { errors: "all" })
+    const issue = Arr.isNonEmptyArray(issues) ?
+      issues.length === 1 ?
+        issues[0] :
+        new Issue.Composite(AST.unknownKeyword, Option.some(input), issues) :
+      undefined
+    return issue
+  })
+}
+
+/**
+ * @since 4.0.0
+ */
+export function refine<B extends string | symbol, T>(
+  refine: Check.Refine<T & Brand<B>, T>
+): Brand.Constructor<T & Brand<B>> {
+  return check(refine as Check.Filter<Brand.Unbranded<T & Brand<B>>>)
+}
+
+/**
+ * Combines two or more brands together to form a single branded type. This API
+ * is useful when you want to validate that the input data passes multiple brand
+ * validators.
+ *
+ * @category combining
+ * @since 2.0.0
+ */
+export function all<Brands extends readonly [Brand.Constructor<any>, ...Array<Brand.Constructor<any>>]>(
   ...brands: Brand.EnsureCommonBase<Brands>
-) => Brand.Constructor<
+): Brand.Constructor<
   Types.UnionToIntersection<{ [B in keyof Brands]: Brand.FromConstructor<Brands[B]> }[number]> extends
     infer X extends Brand<any> ? X : Brand<any>
-> = <
-  Brands extends readonly [Brand.Constructor<any>, ...Array<Brand.Constructor<any>>]
->(...brands: Brand.EnsureCommonBase<Brands>): Brand.Constructor<
-  Types.UnionToIntersection<
-    {
-      [B in keyof Brands]: Brand.FromConstructor<Brands[B]>
-    }[number]
-  > extends infer X extends Brand<any> ? X : Brand<any>
-> => {
-  const result = (args: any): Result.Result<any, Brand.BrandErrors> => {
-    let result: Result.Result<any, Brand.BrandErrors> = Result.succeed(args)
+> {
+  const result = (input: unknown): Result.Result<any, BrandError> => {
+    const issues: Array<Issue.Issue> = []
     for (const brand of brands) {
-      const nextResult = brand.result(args)
-      if (Result.isFailure(result) && Result.isFailure(nextResult)) {
-        result = Result.fail([...result.failure, ...nextResult.failure])
-      } else {
-        result = Result.isFailure(result) ? result : nextResult
+      const r = brand.result(input)
+      if (Result.isFailure(r)) {
+        issues.push(r.failure.issue)
       }
     }
-    return result
+    return Arr.isNonEmptyArray(issues)
+      ? Result.fail(
+        new BrandError({
+          issue: issues.length === 1 ?
+            issues[0] :
+            new Issue.Composite(AST.unknownKeyword, Option.some(input), issues)
+        })
+      )
+      : Result.succeed(input)
   }
-  // @ts-expect-error
-  return Object.assign((args) =>
-    Result.match(result(args), {
-      onFailure: (e) => {
-        throw e
-      },
-      onSuccess: identity
-    }), {
+  return Object.assign((input: unknown) => Result.getOrThrow(result(input)), {
     [RefinedConstructorsTypeId]: RefinedConstructorsTypeId,
-    option: (args: any) => Option.getOk(result(args)),
+    option: (input: unknown) => Option.getSuccess(result(input)),
     result,
-    is: (args: any): args is any => Result.isSuccess(result(args))
+    is: (input: unknown): input is any => Result.isSuccess(result(input))
   })
 }

--- a/packages/effect/src/data/Brand.ts
+++ b/packages/effect/src/data/Brand.ts
@@ -186,6 +186,8 @@ export declare namespace Brand {
  */
 export type Branded<A, K extends string | symbol> = A & Brand<K>
 
+const nominal_ = make<any>(() => undefined)
+
 /**
  * This function returns a `Brand.Constructor` that **does not apply any runtime
  * checks**, it just returns the provided value. It can be used to create
@@ -199,7 +201,7 @@ export type Branded<A, K extends string | symbol> = A & Brand<K>
  * @since 2.0.0
  */
 export function nominal<A extends Brand<any>>(): Brand.Constructor<A> {
-  return make(() => undefined)
+  return nominal_
 }
 
 /**

--- a/packages/effect/src/data/Option.ts
+++ b/packages/effect/src/data/Option.ts
@@ -522,10 +522,10 @@ export const fromIterable = <A>(collection: Iterable<A>): Option<A> => {
  * import { Result } from "effect/data"
  * import { Option } from "effect/data"
  *
- * console.log(Option.getOk(Result.succeed("ok")))
+ * console.log(Option.getSuccess(Result.succeed("ok")))
  * // Output: { _id: 'Option', _tag: 'Some', value: 'ok' }
  *
- * console.log(Option.getOk(Result.fail("err")))
+ * console.log(Option.getSuccess(Result.fail("err")))
  * // Output: { _id: 'Option', _tag: 'None' }
  * ```
  *
@@ -557,10 +557,10 @@ export const getSuccess: <A, E>(self: Result<A, E>) => Option<A> = result.getSuc
  * import { Result } from "effect/data"
  * import { Option } from "effect/data"
  *
- * console.log(Option.getErr(Result.succeed("ok")))
+ * console.log(Option.getFailure(Result.succeed("ok")))
  * // Output: { _id: 'Option', _tag: 'None' }
  *
- * console.log(Option.getErr(Result.fail("err")))
+ * console.log(Option.getFailure(Result.fail("err")))
  * // Output: { _id: 'Option', _tag: 'Some', value: 'err' }
  * ```
  *

--- a/packages/effect/src/data/Option.ts
+++ b/packages/effect/src/data/Option.ts
@@ -529,12 +529,12 @@ export const fromIterable = <A>(collection: Iterable<A>): Option<A> => {
  * // Output: { _id: 'Option', _tag: 'None' }
  * ```
  *
- * @see {@link getErr} for the opposite operation.
+ * @see {@link getFailure} for the opposite operation.
  *
  * @category Conversions
  * @since 2.0.0
  */
-export const getOk: <A, E>(self: Result<A, E>) => Option<A> = result.getSuccess
+export const getSuccess: <A, E>(self: Result<A, E>) => Option<A> = result.getSuccess
 
 /**
  * Converts a `Result` into an `Option` by discarding the right value and
@@ -564,12 +564,12 @@ export const getOk: <A, E>(self: Result<A, E>) => Option<A> = result.getSuccess
  * // Output: { _id: 'Option', _tag: 'Some', value: 'err' }
  * ```
  *
- * @see {@link getOk} for the opposite operation.
+ * @see {@link getSuccess} for the opposite operation.
  *
  * @category Conversions
  * @since 2.0.0
  */
-export const getErr: <A, E>(self: Result<A, E>) => Option<E> = result.getFailure
+export const getFailure: <A, E>(self: Result<A, E>) => Option<E> = result.getFailure
 
 /**
  * Returns the value contained in the `Option` if it is `Some`, otherwise

--- a/packages/effect/src/data/Record.ts
+++ b/packages/effect/src/data/Record.ts
@@ -830,7 +830,7 @@ export const getSomes: <K extends string, A>(
  * import { Result } from "effect/data"
  *
  * assert.deepStrictEqual(
- *   Record.getErrs({ a: Result.succeed(1), b: Result.fail("err"), c: Result.succeed(2) }),
+ *   Record.getFailures({ a: Result.succeed(1), b: Result.fail("err"), c: Result.succeed(2) }),
  *   { b: "err" }
  * )
  * ```
@@ -838,10 +838,10 @@ export const getSomes: <K extends string, A>(
  * @category filtering
  * @since 2.0.0
  */
-export const getErrs = <K extends string, R, L>(
-  self: ReadonlyRecord<K, Result<R, L>>
-): Record<ReadonlyRecord.NonLiteralKey<K>, L> => {
-  const out: Record<string, L> = empty()
+export const getFailures = <K extends string, A, E>(
+  self: ReadonlyRecord<K, Result<A, E>>
+): Record<ReadonlyRecord.NonLiteralKey<K>, E> => {
+  const out: Record<string, E> = empty()
   for (const key of keys(self)) {
     const value = self[key]
     if (R.isFailure(value)) {
@@ -862,7 +862,7 @@ export const getErrs = <K extends string, R, L>(
  * import { Result } from "effect/data"
  *
  * assert.deepStrictEqual(
- *   Record.getOks({ a: Result.succeed(1), b: Result.fail("err"), c: Result.succeed(2) }),
+ *   Record.getSuccesses({ a: Result.succeed(1), b: Result.fail("err"), c: Result.succeed(2) }),
  *   { a: 1, c: 2 }
  * )
  * ```
@@ -870,10 +870,10 @@ export const getErrs = <K extends string, R, L>(
  * @category filtering
  * @since 2.0.0
  */
-export const getOks = <K extends string, R, L>(
-  self: ReadonlyRecord<K, Result<R, L>>
-): Record<string, R> => {
-  const out: Record<string, R> = empty()
+export const getSuccesses = <K extends string, A, E>(
+  self: ReadonlyRecord<K, Result<A, E>>
+): Record<string, A> => {
+  const out: Record<string, A> = empty()
   for (const key of keys(self)) {
     const value = self[key]
     if (R.isSuccess(value)) {

--- a/packages/effect/src/data/index.ts
+++ b/packages/effect/src/data/index.ts
@@ -3,20 +3,26 @@
  */
 
 /**
- * This module provides types and utility functions to create and work with branded types,
- * which are TypeScript types with an added type tag to prevent accidental usage of a value in the wrong context.
+ * This module provides types and utility functions to create and work with
+ * branded types, which are TypeScript types with an added type tag to prevent
+ * accidental usage of a value in the wrong context.
  *
- * The `refined` and `nominal` functions are both used to create branded types in TypeScript.
- * The main difference between them is that `refined` allows for validation of the data, while `nominal` does not.
+ * The `refined` and `nominal` functions are both used to create branded types
+ * in TypeScript. The main difference between them is that `refined` allows for
+ * validation of the data, while `nominal` does not.
  *
- * The `nominal` function is used to create a new branded type that has the same underlying type as the input, but with a different name.
- * This is useful when you want to distinguish between two values of the same type that have different meanings.
- * The `nominal` function does not perform any validation of the input data.
+ * The `nominal` function is used to create a new branded type that has the same
+ * underlying type as the input, but with a different name. This is useful when
+ * you want to distinguish between two values of the same type that have
+ * different meanings. The `nominal` function does not perform any validation of
+ * the input data.
  *
- * On the other hand, the `refined` function is used to create a new branded type that has the same underlying type as the input,
- * but with a different name, and it also allows for validation of the input data.
- * The `refined` function takes a predicate that is used to validate the input data.
- * If the input data fails the validation, a `BrandErrors` is returned, which provides information about the specific validation failure.
+ * On the other hand, the `refined` function is used to create a new branded
+ * type that has the same underlying type as the input, but with a different
+ * name, and it also allows for validation of the input data. The `refined`
+ * function takes a predicate that is used to validate the input data. If the
+ * input data fails the validation, a `BrandErrors` is returned, which provides
+ * information about the specific validation failure.
  *
  * @since 2.0.0
  */

--- a/packages/effect/src/schema/Check.ts
+++ b/packages/effect/src/schema/Check.ts
@@ -138,14 +138,14 @@ export function getBrand<T>(check: Check<T>): string | symbol | undefined {
   if (Predicate.isString(brand) || Predicate.isSymbol(brand)) return brand
 }
 
-const baseBrand = makeGuard((u): u is any => true)
+const brand_ = makeGuard((_u): _u is any => true)
 
 /** @internal */
 export function makeBrand<B extends string | symbol, T>(
   brand: B,
   annotations?: Annotations.Filter
 ): Refinement<T & Brand<B>, T> {
-  return baseBrand.annotate(Annotations.merge({ [BRAND_KEY]: brand }, annotations))
+  return brand_.annotate(Annotations.merge({ [BRAND_KEY]: brand }, annotations))
 }
 
 /**
@@ -169,32 +169,6 @@ export function brand<B extends string | symbol>(brand: B, annotations?: Annotat
   }
 }
 
-/** @internal */
-export function makeIssue(
-  input: unknown,
-  out: undefined | boolean | string | Issue.Issue | {
-    readonly path: ReadonlyArray<PropertyKey>
-    readonly message: string
-  }
-) {
-  if (Issue.isIssue(out)) {
-    return out
-  }
-  if (out === undefined) {
-    return undefined
-  }
-  if (Predicate.isBoolean(out)) {
-    return out ? undefined : new Issue.InvalidValue(Option.some(input))
-  }
-  if (Predicate.isString(out)) {
-    return new Issue.InvalidValue(Option.some(input), { message: out })
-  }
-  return new Issue.Pointer(
-    out.path,
-    new Issue.InvalidValue(Option.some(input), { message: out.message })
-  )
-}
-
 /**
  * @category Constructors
  * @since 4.0.0
@@ -212,7 +186,7 @@ export function make<T>(
   abort: boolean = false
 ): Filter<T> {
   return new Filter(
-    (input, ast, options) => makeIssue(input, filter(input, ast, options)),
+    (input, ast, options) => Issue.make(input, filter(input, ast, options)),
     annotations,
     abort
   )

--- a/packages/effect/src/schema/Formatter.ts
+++ b/packages/effect/src/schema/Formatter.ts
@@ -126,7 +126,7 @@ function toDefaultIssues(
         return [{
           path,
           message: findMessage(issue) ??
-            getExpectedMessage(AST.getExpected(AST.encodedAST(issue.ast)), formatUnknownOption(issue.actual))
+            getExpectedMessage(AST.getExpected(issue.ast), formatUnknownOption(issue.actual))
         }]
       }
       return issue.issues.flatMap((issue) => toDefaultIssues(issue, path, leafHook, checkHook))

--- a/packages/effect/src/schema/Getter.ts
+++ b/packages/effect/src/schema/Getter.ts
@@ -8,7 +8,6 @@ import { PipeableClass } from "../internal/schema/util.ts"
 import * as Str from "../primitives/String.ts"
 import type * as Annotations from "./Annotations.ts"
 import type * as AST from "./AST.ts"
-import * as Check from "./Check.ts"
 import * as Issue from "./Issue.ts"
 
 /**
@@ -151,7 +150,7 @@ export function checkEffect<T, R = never>(
 ): Getter<T, T, R> {
   return onSome((t, options) => {
     return f(t, options).pipe(Effect.flatMapEager((out) => {
-      const issue = Check.makeIssue(t, out)
+      const issue = Issue.make(t, out)
       return issue ?
         Effect.fail(issue) :
         Effect.succeed(Option.some(t))

--- a/packages/effect/src/schema/Issue.ts
+++ b/packages/effect/src/schema/Issue.ts
@@ -3,6 +3,7 @@
  */
 import * as Option from "../data/Option.ts"
 import { hasProperty } from "../data/Predicate.ts"
+import * as Predicate from "../data/Predicate.ts"
 import type * as Annotations from "./Annotations.ts"
 import type * as AST from "./AST.ts"
 import type * as Check from "./Check.ts"
@@ -479,4 +480,30 @@ export function getActual(issue: Issue): Option.Option<unknown> {
     case "Filter":
       return Option.some(issue.actual)
   }
+}
+
+/** @internal */
+export function make(
+  input: unknown,
+  out: undefined | boolean | string | Issue | {
+    readonly path: ReadonlyArray<PropertyKey>
+    readonly message: string
+  }
+) {
+  if (isIssue(out)) {
+    return out
+  }
+  if (out === undefined) {
+    return undefined
+  }
+  if (Predicate.isBoolean(out)) {
+    return out ? undefined : new InvalidValue(Option.some(input))
+  }
+  if (Predicate.isString(out)) {
+    return new InvalidValue(Option.some(input), { message: out })
+  }
+  return new Pointer(
+    out.path,
+    new InvalidValue(Option.some(input), { message: out.message })
+  )
 }

--- a/packages/effect/src/schema/Issue.ts
+++ b/packages/effect/src/schema/Issue.ts
@@ -84,7 +84,7 @@ export class Filter extends Base {
     /**
      * The filter that failed.
      */
-    filter: Check.Filter<unknown>,
+    filter: Check.Filter<any>,
     /**
      * The issue that occurred.
      */

--- a/packages/effect/test/data/Brand.test.ts
+++ b/packages/effect/test/data/Brand.test.ts
@@ -9,15 +9,15 @@ import {
   strictEqual,
   throws
 } from "@effect/vitest/utils"
-import { Brand, Option, Result } from "effect/data"
-import { Check, Issue } from "effect/schema"
+import { Brand, Result } from "effect/data"
+import { Check } from "effect/schema"
 
-function assertSuccess<T extends Brand.Brand<any>>(ctor: Brand.Brand.Constructor<T>, value: Brand.Brand.Unbranded<T>) {
+function assertSuccess<T extends Brand.Brand<any>>(ctor: Brand.Constructor<T>, value: Brand.Brand.Unbranded<T>) {
   assertOk(ctor.result(value), value as T)
 }
 
 function assertFailure<T extends Brand.Brand<any>>(
-  ctor: Brand.Brand.Constructor<T>,
+  ctor: Brand.Constructor<T>,
   value: Brand.Brand.Unbranded<T>,
   message: string
 ) {
@@ -49,10 +49,7 @@ describe("Brand", () => {
   it("make", () => {
     type Int = number & Brand.Brand<"Int">
     const Int = Brand.make<Int>(
-      (n) =>
-        Number.isInteger(n) ?
-          undefined :
-          new Issue.InvalidValue(Option.some(n), { message: `Expected ${n} to be an integer` })
+      (n) => Number.isInteger(n) || `Expected ${n} to be an integer`
     )
 
     strictEqual(Int(1), 1)

--- a/packages/effect/test/data/Brand.test.ts
+++ b/packages/effect/test/data/Brand.test.ts
@@ -1,0 +1,163 @@
+import { describe, it } from "@effect/vitest"
+import {
+  assertErr,
+  assertFalse,
+  assertNone,
+  assertOk,
+  assertSome,
+  assertTrue,
+  strictEqual,
+  throws
+} from "@effect/vitest/utils"
+import { Brand, Option, Result } from "effect/data"
+import { Check, Issue } from "effect/schema"
+
+function assertSuccess<T extends Brand.Brand<any>>(ctor: Brand.Brand.Constructor<T>, value: Brand.Brand.Unbranded<T>) {
+  assertOk(ctor.result(value), value as T)
+}
+
+function assertFailure<T extends Brand.Brand<any>>(
+  ctor: Brand.Brand.Constructor<T>,
+  value: Brand.Brand.Unbranded<T>,
+  message: string
+) {
+  assertErr(ctor.result(value).pipe(Result.mapError((e) => e.message)), message)
+}
+
+describe("Brand", () => {
+  it("nominal", () => {
+    type MyNumber = number & Brand.Brand<"MyNumber">
+    const MyNumber = Brand.nominal<MyNumber>()
+
+    strictEqual(MyNumber(1), 1)
+    strictEqual(MyNumber(1.1), 1.1)
+    strictEqual(MyNumber(-1), -1)
+
+    assertTrue(MyNumber.is(1))
+    assertTrue(MyNumber.is(1.1))
+    assertTrue(MyNumber.is(-1))
+
+    assertSome(MyNumber.option(1), 1 as MyNumber)
+    assertSome(MyNumber.option(1.1), 1.1 as MyNumber)
+    assertSome(MyNumber.option(-1), -1 as MyNumber)
+
+    assertSuccess(MyNumber, 1)
+    assertSuccess(MyNumber, 1.1)
+    assertSuccess(MyNumber, -1)
+  })
+
+  it("make", () => {
+    type Int = number & Brand.Brand<"Int">
+    const Int = Brand.make<Int>(
+      (n) =>
+        Number.isInteger(n) ?
+          undefined :
+          new Issue.InvalidValue(Option.some(n), { message: `Expected ${n} to be an integer` })
+    )
+
+    strictEqual(Int(1), 1)
+    throws(() => Int(1.1))
+    strictEqual(Int(-1), -1)
+
+    assertTrue(Int.is(1))
+    assertFalse(Int.is(1.1))
+    assertTrue(Int.is(-1))
+
+    assertSome(Int.option(1), 1 as Int)
+    assertNone(Int.option(1.1))
+    assertSome(Int.option(-1), -1 as Int)
+
+    assertSuccess(Int, 1)
+    assertFailure(Int, 1.1, "Expected 1.1 to be an integer")
+    assertSuccess(Int, -1)
+  })
+
+  describe("check", () => {
+    it("single check", () => {
+      type Int = number & Brand.Brand<"Int">
+      const Int = Brand.check<Int>(Check.int())
+
+      strictEqual(Int(1), 1)
+      throws(() => Int(1.1))
+      strictEqual(Int(-1), -1)
+
+      assertTrue(Int.is(1))
+      assertFalse(Int.is(1.1))
+      assertTrue(Int.is(-1))
+
+      assertSome(Int.option(1), 1 as Int)
+      assertNone(Int.option(1.1))
+      assertSome(Int.option(-1), -1 as Int)
+
+      assertSuccess(Int, 1)
+      assertFailure(Int, 1.1, "Expected an integer, got 1.1")
+      assertSuccess(Int, -1)
+    })
+
+    it("multiple checks", () => {
+      type PositiveInt = number & Brand.Brand<"PositiveInt">
+      const PositiveInt = Brand.check<PositiveInt>(Check.int(), Check.positive())
+
+      assertSuccess(PositiveInt, 1)
+      assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
+      assertFailure(PositiveInt, -1, "Expected a value greater than 0, got -1")
+      assertFailure(
+        PositiveInt,
+        -1.1,
+        `Expected an integer, got -1.1
+Expected a value greater than 0, got -1.1`
+      )
+    })
+
+    it("multiple checks + abort", () => {
+      type PositiveInt = number & Brand.Brand<"PositiveInt">
+      const PositiveInt = Brand.check<PositiveInt>(
+        Check.int().pipe(Check.abort), // abort the first check
+        Check.positive()
+      )
+
+      assertSuccess(PositiveInt, 1)
+      assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
+      assertFailure(PositiveInt, -1, "Expected a value greater than 0, got -1")
+      assertFailure(PositiveInt, -1.1, `Expected an integer, got -1.1`)
+    })
+  })
+
+  it("refine", () => {
+    const Int = Brand.refine(Check.int().pipe(Check.brand("Int")))
+
+    assertSuccess(Int, 1)
+    assertFailure(Int, 1.1, "Expected an integer, got 1.1")
+    assertSuccess(Int, -1)
+  })
+
+  it("intersection", () => {
+    const Int = Brand.refine(Check.int().pipe(Check.brand("Int")))
+
+    type Positive = number & Brand.Brand<"Positive">
+    const Positive = Brand.check<Positive>(Check.positive())
+
+    const PositiveInt = Brand.all(Int, Positive)
+
+    strictEqual(PositiveInt(1), 1)
+    throws(() => PositiveInt(1.1))
+    throws(() => PositiveInt(-1))
+
+    assertTrue(PositiveInt.is(1))
+    assertFalse(PositiveInt.is(1.1))
+    assertFalse(PositiveInt.is(-1))
+
+    assertSome(PositiveInt.option(1), 1 as any)
+    assertNone(PositiveInt.option(1.1))
+    assertNone(PositiveInt.option(-1))
+
+    assertSuccess(PositiveInt, 1)
+    assertFailure(PositiveInt, 1.1, "Expected an integer, got 1.1")
+    assertFailure(
+      PositiveInt,
+      -1.1,
+      `Expected an integer, got -1.1
+Expected a value greater than 0, got -1.1`
+    )
+  })
+})

--- a/packages/effect/test/schema/Serializer.test.ts
+++ b/packages/effect/test/schema/Serializer.test.ts
@@ -306,7 +306,7 @@ describe("Serializer", () => {
         await assertions.deserialization.json.typeCodec.fail(
           schema,
           "-",
-          `Expected "a" | 1 | "2" | true, got "-"`
+          `Expected "a" | 1 | 2 | true, got "-"`
         )
       })
 
@@ -1087,7 +1087,7 @@ describe("Serializer", () => {
         await assertions.deserialization.stringLeafJson.typeCodec.fail(
           schema,
           "-",
-          `Expected "a" | "1" | "2" | "true", got "-"`
+          `Expected "a" | 1 | 2 | true, got "-"`
         )
       })
 


### PR DESCRIPTION
This PR introduces the features of the `Check` module into the `Brand` module.  

**What's included**

- Errors are now expressed as `Issue`s
- Support for filters and filter groups (`check` API, similar to `Schema.check`)
  - Ability to reuse built-in filters
- Option to abort filter execution
- Branded filters (`refine` API, similar to `Schema.refine`)
- Automatic error messages inherited from the `Check` harness (produced by the standard Effect formatter)

**Example**

```ts
import { Brand } from "effect/data"
import { Check } from "effect/schema"

// Either specify the brand explicitly...
type Int32 = number & Brand.Brand<"Int32">
const Int32 = Brand.check<Int32>(Check.int32() /* other filters...*/) // you can pass n filters / filter groups here

// ...or use refine to create a new brand
const Positive = Brand.refine(Check.positive().pipe(Check.brand("Positive")))

// const PositiveInt32: Constructor<number & Brand.Brand<"Positive"> & Brand.Brand<"Int32">>
const PositiveInt32 = Brand.all(Int32, Positive)

try {
  PositiveInt32(-1.1)
} catch (e: any) {
  console.error(e.message)
}

console.log("--------------------------------")

try {
  PositiveInt32(100000000000)
} catch (e: any) {
  console.error(e.message)
}

/*
Output:
Expected an integer, got -1.1
Expected a value greater than 0, got -1.1
--------------------------------
Expected a value between -2147483648 and 2147483647, got 100000000000
*/
````
