### PR TITLE
add Optic.optionalKey

### DIFF
--- a/packages/effect/OPTIC.md
+++ b/packages/effect/OPTIC.md
@@ -149,29 +149,80 @@ console.log(_0.replace(3, [1, 2]))
 
 ### Accessing an optional key in a struct or a tuple
 
-When using `replace`, passing `undefined` will remove the key from the struct or the tuple.
+There are two ways to handle an optional key in a struct or a tuple, depending on how you want to treat the `undefined` value:
 
-**Example** (Accessing an optional key in a struct)
+1. when setting `undefined`, the key is preserved
+2. when setting `undefined`, the key is removed
+
+**Example** (Preserving the key when setting `undefined`)
+
+```ts
+import { Optic } from "effect/optic"
+
+type S = {
+  readonly a?: number | undefined
+}
+
+// Lens<S, number | undefined>
+const _a = Optic.id<S>().key("a")
+
+console.log(_a.getResult({ a: 1 }))
+// { _id: 'Result', _tag: 'Success', value: 1 }
+
+console.log(_a.getResult({}))
+// { _id: 'Result', _tag: 'Success', value: undefined }
+
+console.log(_a.getResult({ a: undefined }))
+// { _id: 'Result', _tag: 'Success', value: undefined }
+
+console.log(_a.replace(2, { a: 1 }))
+// { a: 2 }
+
+console.log(_a.replace(2, {}))
+// { a: 2 }
+
+console.log(_a.replace(undefined, { a: 1 }))
+// { a: undefined }
+
+console.log(_a.replace(undefined, {}))
+// { a: undefined }
+
+console.log(_a.replace(2, { a: undefined }))
+// { a: 2 }
+```
+
+**Example** (Removing the key when setting `undefined`)
 
 ```ts
 import { Optic } from "effect/optic"
 
 type S = {
   readonly a?: number
-  readonly b: number
 }
 
-// Build an optic to access the optional key "a"
+// Lens<S, number | undefined>
 const _a = Optic.id<S>().optionalKey("a")
 
-console.log(_a.replace(3, { a: 1, b: 2 }))
-// { a: 3, b: 2 }
+console.log(_a.getResult({ a: 1 }))
+// { _id: 'Result', _tag: 'Success', value: 1 }
 
-console.log(_a.replace(undefined, { a: 1, b: 2 }))
-// { b: 2 }
+console.log(_a.getResult({}))
+// { _id: 'Result', _tag: 'Success', value: undefined }
+
+console.log(_a.replace(2, { a: 1 }))
+// { a: 2 }
+
+console.log(_a.replace(2, {}))
+// { a: 2 }
+
+console.log(_a.replace(undefined, { a: 1 }))
+// {}
+
+console.log(_a.replace(undefined, {}))
+// {}
 ```
 
-**Example** (Accessing an optional key in a tuple)
+**Example** (Removing the element when setting `undefined`)
 
 ```ts
 import { Optic } from "effect/optic"
@@ -179,12 +230,18 @@ import { Optic } from "effect/optic"
 type S = readonly [number, number?]
 
 // Build an optic to access the optional second element
-const _0 = Optic.id<S>().optionalKey(1)
+const _1 = Optic.id<S>().optionalKey(1)
 
-console.log(_0.replace(3, [1, 2]))
+console.log(_1.get([1, 2]))
+// 2
+
+console.log(_1.get([1]))
+// undefined
+
+console.log(_1.replace(3, [1, 2]))
 // [1, 3]
 
-console.log(_0.replace(undefined, [1, 2]))
+console.log(_1.replace(undefined, [1, 2]))
 // [1]
 ```
 

--- a/packages/effect/dtslint/optic/Optic.tst.ts
+++ b/packages/effect/dtslint/optic/Optic.tst.ts
@@ -1,0 +1,18 @@
+import { Optic } from "effect/optic"
+import { describe, expect, it } from "tstyche"
+
+describe("Optic", () => {
+  it("optional key", () => {
+    type S = { readonly a?: number | undefined }
+    const optic = Optic.id<S>().key("a")
+
+    expect(optic).type.toBe<Optic.Lens<S, number | undefined>>()
+  })
+
+  it("exact optional key", () => {
+    type S = { readonly a?: number }
+    const optic = Optic.id<S>().optionalKey("a")
+
+    expect(optic).type.toBe<Optic.Lens<S, number | undefined>>()
+  })
+})

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -126,7 +126,6 @@
   "scripts": {
     "codegen": "build-utils prepare-v4",
     "build": "tsc -b tsconfig.build.json && babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
-    "test-types": "tstyche",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
     "coverage": "vitest --coverage"

--- a/packages/effect/test/optic/Optic.test.ts
+++ b/packages/effect/test/optic/Optic.test.ts
@@ -71,6 +71,58 @@ describe("Optic", () => {
         })
       })
 
+      describe("optional key", () => {
+        it("undefined = undefined", () => {
+          type S = { readonly a?: number | undefined }
+          const optic = Optic.id<S>().key("a")
+          const f = (n: number | undefined) => n !== undefined ? n + 1 : undefined
+
+          strictEqual(optic.get({ a: 1 }), 1)
+          strictEqual(optic.get({}), undefined)
+          strictEqual(optic.get({ a: undefined }), undefined)
+          deepStrictEqual(optic.replace(2, { a: 1 }), { a: 2 })
+          deepStrictEqual(optic.replace(2, {}), { a: 2 })
+          deepStrictEqual(optic.replace(2, { a: undefined }), { a: 2 })
+          deepStrictEqual(optic.replace(undefined, { a: 1 }), { a: undefined })
+          deepStrictEqual(optic.replace(undefined, {}), { a: undefined })
+          deepStrictEqual(optic.modify(f)({ a: 1 }), { a: 2 })
+          deepStrictEqual(optic.modify(f)({}), { a: undefined })
+          deepStrictEqual(optic.modify(f)({ a: undefined }), { a: undefined })
+        })
+
+        it("undefined = missing key", () => {
+          type S = { readonly a?: number }
+          const optic = Optic.id<S>().optionalKey("a")
+          const f = (n: number | undefined) => n !== undefined ? n + 1 : undefined
+
+          strictEqual(optic.get({ a: 1 }), 1)
+          strictEqual(optic.get({}), undefined)
+          deepStrictEqual(optic.replace(2, { a: 1 }), { a: 2 })
+          deepStrictEqual(optic.replace(2, {}), { a: 2 })
+          deepStrictEqual(optic.replace(undefined, { a: 1 }), {})
+          deepStrictEqual(optic.replace(undefined, {}), {})
+          deepStrictEqual(optic.modify(f)({ a: 1 }), { a: 2 })
+          deepStrictEqual(optic.modify(f)({}), {})
+        })
+      })
+
+      describe("optional element", () => {
+        it("undefined = missing key", () => {
+          type S = readonly [number, number?]
+          const optic = Optic.id<S>().optionalKey(1)
+          const f = (n: number | undefined) => n !== undefined ? n + 1 : undefined
+
+          strictEqual(optic.get([1, 2]), 2)
+          strictEqual(optic.get([1]), undefined)
+          deepStrictEqual(optic.replace(3, [1, 2]), [1, 3])
+          deepStrictEqual(optic.replace(3, [1]), [1, 3])
+          deepStrictEqual(optic.replace(undefined, [1, 2]), [1])
+          deepStrictEqual(optic.replace(undefined, [1]), [1])
+          deepStrictEqual(optic.modify(f)([1, 2]), [1, 3])
+          deepStrictEqual(optic.modify(f)([1]), [1])
+        })
+      })
+
       describe("Tuple", () => {
         it("required element", () => {
           type S = readonly [number]


### PR DESCRIPTION
### Accessing an optional key in a struct or a tuple

There are two ways to handle an optional key in a struct or a tuple, depending on how you want to treat the `undefined` value:

1. when setting `undefined`, the key is preserved
2. when setting `undefined`, the key is removed

**Example** (Preserving the key when setting `undefined`)

```ts
import { Optic } from "effect/optic"

type S = {
  readonly a?: number | undefined
}

// Lens<S, number | undefined>
const _a = Optic.id<S>().key("a")

console.log(_a.getResult({ a: 1 }))
// { _id: 'Result', _tag: 'Success', value: 1 }

console.log(_a.getResult({}))
// { _id: 'Result', _tag: 'Success', value: undefined }

console.log(_a.getResult({ a: undefined }))
// { _id: 'Result', _tag: 'Success', value: undefined }

console.log(_a.replace(2, { a: 1 }))
// { a: 2 }

console.log(_a.replace(2, {}))
// { a: 2 }

console.log(_a.replace(undefined, { a: 1 }))
// { a: undefined }

console.log(_a.replace(undefined, {}))
// { a: undefined }

console.log(_a.replace(2, { a: undefined }))
// { a: 2 }
```

**Example** (Removing the key when setting `undefined`)

```ts
import { Optic } from "effect/optic"

type S = {
  readonly a?: number
}

// Lens<S, number | undefined>
const _a = Optic.id<S>().optionalKey("a")

console.log(_a.getResult({ a: 1 }))
// { _id: 'Result', _tag: 'Success', value: 1 }

console.log(_a.getResult({}))
// { _id: 'Result', _tag: 'Success', value: undefined }

console.log(_a.replace(2, { a: 1 }))
// { a: 2 }

console.log(_a.replace(2, {}))
// { a: 2 }

console.log(_a.replace(undefined, { a: 1 }))
// {}

console.log(_a.replace(undefined, {}))
// {}
```

**Example** (Removing the element when setting `undefined`)

```ts
import { Optic } from "effect/optic"

type S = readonly [number, number?]

// Build an optic to access the optional second element
const _1 = Optic.id<S>().optionalKey(1)

console.log(_1.get([1, 2]))
// 2

console.log(_1.get([1]))
// undefined

console.log(_1.replace(3, [1, 2]))
// [1, 3]

console.log(_1.replace(undefined, [1, 2]))
// [1]
```
