### PR TITLE
Add URLFromString schema

### DIFF
--- a/packages/effect/src/schema/Transformation.ts
+++ b/packages/effect/src/schema/Transformation.ts
@@ -334,7 +334,7 @@ export const urlFromString = transformOrFail<URL, string>({
   decode: (s) =>
     Effect.try({
       try: () => new URL(s),
-      catch: () => new Issue.InvalidValue(Option.some(s), { message: `Invalid URL: "${s}"` })
+      catch: (e) => new Issue.InvalidValue(Option.some(s), { message: globalThis.String(e) })
     }),
   encode: (url) => Effect.succeed(url.href)
 })

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -8,6 +8,8 @@ import { deepStrictEqual, fail, ok, strictEqual } from "node:assert"
 import { describe, it } from "vitest"
 import { assertFalse, assertInclude, assertTrue, throws } from "../utils/assert.ts"
 
+const isDeno = "Deno" in globalThis
+
 const verifyGeneration = true
 
 const equals = TestSchema.Asserts.ast.fields.equals
@@ -3632,7 +3634,10 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
 
     const decoding = asserts.decoding()
     await decoding.succeed("https://effect.website", new URL("https://effect.website"))
-    await decoding.fail("123", `Invalid URL: "123"`)
+    await decoding.fail(
+      "123",
+      isDeno ? `TypeError: Invalid URL: '123'` : `TypeError: Invalid URL`
+    )
 
     const encoding = asserts.encoding()
     await encoding.succeed(new URL("https://effect.website"), "https://effect.website/")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

~~@gcanti - just as an FYI, I had to change the error message we provide when attempting to parse an invalid URL due to platform inconsistencies:~~

~~- Deno renders `TypeError: Invalid URL '123'`~~
~~- NodeJS renders `TypeError: Invalid URL`~~

~~So I just made it consistent.~~

Nevermind - I see what was done in the `Serializer` tests - I'll copy that.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
