### PR TITLE
fix remaining references to `ServiceMap.Key`

### DIFF
--- a/.patterns/platform-integration.md
+++ b/.patterns/platform-integration.md
@@ -23,8 +23,8 @@ export interface FileSystem {
 }
 
 // Service key for dependency injection
-export const FileSystem: ServiceMap.Key<FileSystem, FileSystem> = 
-  ServiceMap.Key("effect/platform/FileSystem")
+export const FileSystem: ServiceMap.Service<FileSystem, FileSystem> =
+  ServiceMap.Service("effect/platform/FileSystem")
 
 // Type identification
 const TypeId: unique symbol = Symbol.for("effect/platform/FileSystem")
@@ -36,14 +36,14 @@ Use service classes for type-safe dependency injection:
 
 ```typescript
 // HTTP platform service
-export class HttpPlatform extends ServiceMap.Key<HttpPlatform, {
+export class HttpPlatform extends ServiceMap.Service<HttpPlatform, {
   readonly fileResponse: (path: string, options?: FileResponseOptions) => Effect.Effect<Response>
   readonly fileWebResponse: (file: FileLike, options?: FileWebResponseOptions) => Effect.Effect<Response>
   readonly formData: (source: Readable) => Effect.Effect<FormData>
 }>()("effect/http/HttpPlatform") {}
 
 // Socket service
-export class NetSocket extends ServiceMap.Key<NetSocket, Net.Socket>()(
+export class NetSocket extends ServiceMap.Service<NetSocket, Net.Socket>()(
   "@effect/platform-node/NodeSocket/NetSocket"
 ) {}
 ```

--- a/packages/effect/src/Cause.ts
+++ b/packages/effect/src/Cause.ts
@@ -925,7 +925,7 @@ export interface UnknownError extends YieldableError {
 export const UnknownError: new(cause: unknown, message?: string) => UnknownError = effect.UnknownError
 
 /**
- * Adds annotations to a `Cause` using a `ServiceMap.Key` to store metadata
+ * Adds annotations to a `Cause` using a `ServiceMap.Service` to store metadata
  * that can be retrieved later for debugging or tracing purposes.
  *
  * @example


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Following #642 and #643, there are still a few references to the old `ServiceMap.Key`. I've been playing with Effect 4.0 and ran into this when trying to read [tim-smart/stremio-effect](https://github.com/tim-smart/stremio-effect).

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
