### PR TITLE
Inconsistency in Duration.divide

### DIFF
--- a/packages/effect/test/time/Duration.test.ts
+++ b/packages/effect/test/time/Duration.test.ts
@@ -189,6 +189,10 @@ describe("Duration", () => {
     deepStrictEqual(Duration.divide(Duration.nanos(1n), 0), undefined)
     deepStrictEqual(Duration.divide(Duration.nanos(1n), -0), undefined)
 
+    // divide by negative
+    deepStrictEqual(Duration.divide(Duration.minutes(1), -1), Duration.zero)
+    deepStrictEqual(Duration.divide(Duration.nanos(1n), -1), undefined)
+
     // bad by
     deepStrictEqual(Duration.divide(Duration.minutes(1), NaN), undefined)
     deepStrictEqual(Duration.divide(Duration.nanos(1n), NaN), undefined)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I found that when divided by a negative number, the behavior differs.
which way should this inconsistency be resolved? If it should
The same in v3 (codename bigg)
```ts
    return match(self, {
      onMillis: (millis) => {
        if (by === 0) return undefined // ===
        return make(millis / by)
      },
      onNanos: (nanos) => {
        if (by <= 0) return undefined // <=
        try {
          return make(nanos / BigInt(by))
        } catch {
          return undefined
        }
      },
      onInfinity: () => infinity
    })
```
<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
