### PR TITLE
Schema: add URLSearchParams Support

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -4355,43 +4355,37 @@ console.log(String(Schema.decodeUnknownExit(provided)(null)))
 
 ## FormData Support
 
-`Schema.fromFormData` lets you decode and encode `FormData` values to and from your schema.
+`Schema.fromFormData` returns a schema that reads a `FormData` instance,
+converts it into a tree record using bracket notation, and then decodes the
+resulting structure using the provided schema.
 
-**Example** (Decoding and encoding `FormData` values)
+The decoding process has two steps:
+
+1. Parse `FormData` into a nested tree record.
+2. Decode the parsed value with the given schema.
+
+**Example** (Decoding a flat structure)
 
 ```ts
 import { Schema } from "effect/schema"
 
 const schema = Schema.fromFormData(
   Schema.Struct({
-    a: Schema.NonEmptyString,
-    b: Schema.Struct({
-      c: Schema.String,
-      d: Schema.String
-    }),
-    e: Schema.Array(Schema.String)
+    a: Schema.String
   })
 )
 
 const formData = new FormData()
-formData.append("a", "a")
-formData.append("b[c]", "bc")
-formData.append("b[d]", "bd")
-formData.append("e[0]", "e0")
-formData.append("e[1]", "e1")
+formData.append("a", "1")
+formData.append("b", "2")
 
 console.log(String(Schema.decodeUnknownExit(schema)(formData)))
-// Success({"a":"a","b":{"c":"bc","d":"bd"},"e":["e0","e1"]})
-
-console.log(String(Schema.encodeUnknownExit(schema)({ a: "a", b: { c: "bc", d: "bd" }, e: ["e0", "e1"] })))
-// Success(FormData([["a","a"],["b[c]","bc"],["b[d]","bd"],["e[0]","e0"],["e[1]","e1"]]))
+// Success({"a":"1"})
 ```
 
-### Parsing FormData values
+You can express nested values using bracket notation.
 
-You can use `Schema.toSerializerStringTreeLoose` to parse `FormData` values into your schema without having to specify a custom transformation.
-
-**Example** (Parsing `FormData` values into your schema using `Schema.toSerializerStringTreeLoose`)
+**Example** (Nested fields)
 
 ```ts
 import { Schema } from "effect/schema"
@@ -4399,18 +4393,118 @@ import { Schema } from "effect/schema"
 const schema = Schema.fromFormData(
   Schema.toSerializerStringTreeLoose(
     Schema.Struct({
-      a: Schema.Int,
-      b: Schema.instanceOf(Blob)
+      a: Schema.String,
+      b: Schema.Struct({
+        c: Schema.String,
+        d: Schema.String
+      })
     })
   )
 )
 
 const formData = new FormData()
 formData.append("a", "1")
-formData.append("b", new Blob(["b"]))
+formData.append("b[c]", "2")
+formData.append("b[d]", "3")
 
 console.log(String(Schema.decodeUnknownExit(schema)(formData)))
-// Success({"a":1,"b":File({Symbol(kHandle):Blob({}),Symbol(kLength):1,Symbol(kType):"",Symbol(state):FileState({"name":"blob","lastModified":1763657398386})})})
+// Success({"a":"1","b":{"c":"2","d":"3"}})
+```
+
+If you want to decode values that are not strings, use `Schema.toSerializerStringTreeLoose`. This serializer preserves values such
+as numbers and `Blob` objects when compatible with the schema.
+
+**Example** (Parsing non-string values)
+
+```ts
+import { Schema } from "effect/schema"
+
+const schema = Schema.fromFormData(
+  Schema.toSerializerStringTreeLoose(
+    Schema.Struct({
+      a: Schema.Int
+    })
+  )
+)
+
+const formData = new FormData()
+formData.append("a", "1")
+
+console.log(String(Schema.decodeUnknownExit(schema)(formData)))
+// Success({"a":1}) // Note: the value is a number
+```
+
+## URLSearchParams Support
+
+`Schema.fromURLSearchParams` returns a schema that reads a `URLSearchParams`
+instance, converts it into a tree record using bracket notation, and then decodes
+the resulting structure using the provided schema.
+
+The decoding process has two steps:
+
+1. Parse `URLSearchParams` into a nested tree record.
+2. Decode the parsed value with the given schema.
+
+**Example** (Decoding a flat structure)
+
+```ts
+import { Schema } from "effect/schema"
+
+const schema = Schema.fromURLSearchParams(
+  Schema.Struct({
+    a: Schema.String
+  })
+)
+
+const urlSearchParams = new URLSearchParams("a=1&b=2")
+
+console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+// Success({"a":"1"})
+```
+
+You can express nested values using bracket notation.
+
+**Example** (Nested fields)
+
+```ts
+import { Schema } from "effect/schema"
+
+const schema = Schema.fromURLSearchParams(
+  Schema.Struct({
+    a: Schema.String,
+    b: Schema.Struct({
+      c: Schema.String,
+      d: Schema.String
+    })
+  })
+)
+
+const urlSearchParams = new URLSearchParams("a=1&b[c]=2&b[d]=3")
+
+console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+// Success({"a":"1","b":{"c":"2","d":"3"}})
+```
+
+If you want to decode values that are not strings, use `Schema.toSerializerStringTree`. This serializer preserves values such as
+numbers when compatible with the schema.
+
+**Example** (Parsing non-string values)
+
+```ts
+import { Schema } from "effect/schema"
+
+const schema = Schema.fromURLSearchParams(
+  Schema.toSerializerStringTree(
+    Schema.Struct({
+      a: Schema.Int
+    })
+  )
+)
+
+const urlSearchParams = new URLSearchParams("a=1&b=2")
+
+console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+// Success({"a":1}) // Note: the value is a number
 ```
 
 ## Generating a JSON Schema from a Schema

--- a/packages/effect/src/schema/Getter.ts
+++ b/packages/effect/src/schema/Getter.ts
@@ -591,6 +591,29 @@ export function encodeFormData(): Getter<FormData, unknown> {
   })
 }
 
+/**
+ * @category URLSearchParams
+ * @since 4.0.0
+ */
+export function decodeURLSearchParams(): Getter<TreeRecord<string>, URLSearchParams> {
+  return transform((input) => makeTreeRecord(Array.from(input.entries())))
+}
+
+const collectURLSearchParamsEntries = collectBracketPathEntries(Predicate.isString)
+
+/**
+ * @category URLSearchParams
+ * @since 4.0.0
+ */
+export function encodeURLSearchParams(): Getter<URLSearchParams, unknown> {
+  return transform((input) => {
+    if (typeof input === "object" && input !== null) {
+      return new URLSearchParams(collectURLSearchParamsEntries(input))
+    }
+    return new URLSearchParams()
+  })
+}
+
 // -----------------------------------------------------------------------------
 // Tree and TreeRecord
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/schema/Schema.ts
+++ b/packages/effect/src/schema/Schema.ts
@@ -5682,29 +5682,183 @@ export const FormData: FormData = instanceOf(globalThis.FormData)
 export interface fromFormData<S extends Top> extends decodeTo<S, FormData> {}
 
 /**
- * Returns a schema that decodes a `FormData` and then decodes the parsed value
- * using the given schema.
+ * `Schema.fromFormData` returns a schema that reads a `FormData` instance,
+ * converts it into a tree record using bracket notation, and then decodes the
+ * resulting structure using the provided schema.
  *
- * The resulting schema first parses the input `FormData` as a `string` key-value pairs, and then runs the
- * provided schema on the parsed result.
+ * The decoding process has two steps:
  *
- * **Example**
+ * 1. Parse `FormData` into a nested tree record.
+ * 2. Decode the parsed value with the given schema.
+ *
+ * **Example** (Decoding a flat structure)
  *
  * ```ts
  * import { Schema } from "effect/schema"
  *
- * const schema = Schema.fromFormData(Schema.Struct({ a: Schema.String }))
+ * const schema = Schema.fromFormData(
+ *   Schema.Struct({
+ *     a: Schema.String
+ *   })
+ * )
+ *
+ * const formData = new FormData()
+ * formData.append("a", "1")
+ * formData.append("b", "2")
+ *
+ * console.log(String(Schema.decodeUnknownExit(schema)(formData)))
+ * // Success({"a":"1"})
+ * ```
+ *
+ * You can express nested values using bracket notation.
+ *
+ * **Example** (Nested fields)
+ *
+ * ```ts
+ * import { Schema } from "effect/schema"
+ *
+ * const schema = Schema.fromFormData(
+ *   Schema.toSerializerStringTreeLoose(
+ *     Schema.Struct({
+ *       a: Schema.String,
+ *       b: Schema.Struct({
+ *         c: Schema.String,
+ *         d: Schema.String
+ *       })
+ *     })
+ *   )
+ * )
+ *
+ * const formData = new FormData()
+ * formData.append("a", "1")
+ * formData.append("b[c]", "2")
+ * formData.append("b[d]", "3")
+ *
+ * console.log(String(Schema.decodeUnknownExit(schema)(formData)))
+ * // Success({"a":"1","b":{"c":"2","d":"3"}})
+ * ```
+ *
+ * If you want to decode values that are not strings, use
+ * `Schema.toSerializerStringTreeLoose`. This serializer preserves values such
+ * as numbers and `Blob` objects when compatible with the schema.
+ *
+ * **Example** (Parsing non-string values)
+ *
+ * ```ts
+ * import { Schema } from "effect/schema"
+ *
+ * const schema = Schema.fromFormData(
+ *   Schema.toSerializerStringTreeLoose(
+ *     Schema.Struct({
+ *       a: Schema.Int
+ *     })
+ *   )
+ * )
+ *
  * const formData = new FormData()
  * formData.append("a", "1")
  *
  * console.log(String(Schema.decodeUnknownExit(schema)(formData)))
- * // Success({"a":"1"})
+ * // Success({"a":1}) // Note: the value is a number
  * ```
  *
  * @since 4.0.0
  */
 export function fromFormData<S extends Top>(schema: S): fromFormData<S> {
   return FormData.pipe(decodeTo(schema, Transformation.fromFormData))
+}
+
+/**
+ * @since 4.0.0
+ */
+export interface URLSearchParams extends instanceOf<globalThis.URLSearchParams> {}
+
+/**
+ * @since 4.0.0
+ */
+export const URLSearchParams: URLSearchParams = instanceOf(globalThis.URLSearchParams)
+
+/**
+ * @since 4.0.0
+ */
+export interface fromURLSearchParams<S extends Top> extends decodeTo<S, URLSearchParams> {}
+
+/**
+ * `Schema.fromURLSearchParams` returns a schema that reads a `URLSearchParams`
+ * instance, converts it into a tree record using bracket notation, and then
+ * decodes the resulting structure using the provided schema.
+ *
+ * The decoding process has two steps:
+ *
+ * 1. Parse `URLSearchParams` into a nested tree record.
+ * 2. Decode the parsed value with the given schema.
+ *
+ * **Example** (Decoding a flat structure)
+ *
+ * ```ts
+ * import { Schema } from "effect/schema"
+ *
+ * const schema = Schema.fromURLSearchParams(
+ *   Schema.Struct({
+ *     a: Schema.String
+ *   })
+ * )
+ *
+ * const urlSearchParams = new URLSearchParams("a=1&b=2")
+ *
+ * console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+ * // Success({"a":"1"})
+ * ```
+ * You can express nested values using bracket notation.
+ *
+ * **Example** (Nested fields)
+ *
+ * ```ts
+ * import { Schema } from "effect/schema"
+ *
+ * const schema = Schema.fromURLSearchParams(
+ *   Schema.Struct({
+ *     a: Schema.String,
+ *     b: Schema.Struct({
+ *       c: Schema.String,
+ *       d: Schema.String
+ *     })
+ *   })
+ * )
+ *
+ * const urlSearchParams = new URLSearchParams("a=1&b[c]=2&b[d]=3")
+ *
+ * console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+ * // Success({"a":"1","b":{"c":"2","d":"3"}})
+ * ```
+ *
+ * If you want to decode values that are not strings, use
+ * `Schema.toSerializerStringTree`. This serializer preserves values such as
+ * numbers when compatible with the schema.
+ *
+ * **Example** (Parsing non-string values)
+ *
+ * ```ts
+ * import { Schema } from "effect/schema"
+ *
+ * const schema = Schema.fromURLSearchParams(
+ *   Schema.toSerializerStringTree(
+ *     Schema.Struct({
+ *       a: Schema.Int
+ *     })
+ *   )
+ * )
+ *
+ * const urlSearchParams = new URLSearchParams("a=1&b=2")
+ *
+ * console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
+ * // Success({"a":1}) // Note: the value is a number
+ * ```
+ *
+ * @since 4.0.0
+ */
+export function fromURLSearchParams<S extends Top>(schema: S): fromURLSearchParams<S> {
+  return URLSearchParams.pipe(decodeTo(schema, Transformation.fromURLSearchParams))
 }
 
 /**

--- a/packages/effect/src/schema/Transformation.ts
+++ b/packages/effect/src/schema/Transformation.ts
@@ -368,3 +368,11 @@ export const fromFormData = new Transformation<unknown, FormData>(
   Getter.decodeFormData(),
   Getter.encodeFormData()
 )
+
+/**
+ * @since 4.0.0
+ */
+export const fromURLSearchParams = new Transformation<unknown, URLSearchParams>(
+  Getter.decodeURLSearchParams(),
+  Getter.encodeURLSearchParams()
+)


### PR DESCRIPTION
## URLSearchParams Support

`Schema.fromURLSearchParams` returns a schema that reads a `URLSearchParams`
instance, converts it into a tree record using bracket notation, and then decodes
the resulting structure using the provided schema.

The decoding process has two steps:

1. Parse `URLSearchParams` into a nested tree record.
2. Decode the parsed value with the given schema.

**Example** (Decoding a flat structure)

```ts
import { Schema } from "effect/schema"

const schema = Schema.fromURLSearchParams(
  Schema.Struct({
    a: Schema.String
  })
)

const urlSearchParams = new URLSearchParams("a=1&b=2")

console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
// Success({"a":"1"})
```

You can express nested values using bracket notation.

**Example** (Nested fields)

```ts
import { Schema } from "effect/schema"

const schema = Schema.fromURLSearchParams(
  Schema.Struct({
    a: Schema.String,
    b: Schema.Struct({
      c: Schema.String,
      d: Schema.String
    })
  })
)

const urlSearchParams = new URLSearchParams("a=1&b[c]=2&b[d]=3")

console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
// Success({"a":"1","b":{"c":"2","d":"3"}})
```

If you want to decode values that are not strings, use `Schema.toSerializerStringTree`. This serializer preserves values such as
numbers when compatible with the schema.

**Example** (Parsing non-string values)

```ts
import { Schema } from "effect/schema"

const schema = Schema.fromURLSearchParams(
  Schema.toSerializerStringTree(
    Schema.Struct({
      a: Schema.Int
    })
  )
)

const urlSearchParams = new URLSearchParams("a=1&b=2")

console.log(String(Schema.decodeUnknownExit(schema)(urlSearchParams)))
// Success({"a":1}) // Note: the value is a number
```
