### PR TITLE
Allow inclusion of `HttpClientResponse` in generated client output

### DIFF
--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -181,6 +181,7 @@ export const make = Effect.gen(function*() {
 
               if (status === "default") {
                 defaultSchema = schemaName
+                return
               }
 
               const statusLower = status.toLowerCase()
@@ -196,7 +197,9 @@ export const make = Effect.gen(function*() {
             }
 
             if (Predicate.isUndefined(response.content)) {
-              op.voidSchemas.add(status.toLowerCase())
+              if (status !== "default") {
+                op.voidSchemas.add(status.toLowerCase())
+              }
             }
           }
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In certain cases, it can be desirable to have access to the `HttpClientResponse` after executing an operation from the generated OpenAPI client. For example, perhaps downstream code needs to make use of headers or other information only available on the `HttpClientResponse`.

To accommodate this use case, the generated `Client` now always accepts an object as its last parameter, and that object can optionally accept a `config` key under which various configuration options can be added. For now, only the `includeResponse` configuration option has been added, which forces the `Client` to return a tuple of `[Success, HttpClientResponse]` from the called operation.

```ts
import { Effect } from "effect"
import { HttpClient } from "effect/unstable/http"
import { make } from "./my-generated-client.ts"

const program = Effect.gen(function*() {
  const httpClient = yield* HttpClient.HttpClient
  const client = make(httpClient)

  // Without response inclusion
  const result = yield* client.someOperation({ 
    params: { ... }, 
    payload: { ... }
  })

  // With response inclusion
  const [result, response] = yield* client.someOperation({ 
    params: { ... }, 
    payload: { ... }, 
    config: { includeResponse: true } 
  })
})
```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
