### PR TITLE
EFF-166 add lalph test TODO

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,5 @@
+- EFF-166: add "Add test lalph" item under Alpha
+- Decision: place in Alpha list to track current work
+- Files: `TODOS.md`
+- Checks: `pnpm check` failed (missing `node_modules` / `tspc`)
+- Next: install deps and rerun checks if needed

--- a/TODOS.md
+++ b/TODOS.md
@@ -17,6 +17,7 @@ Releases are snapshot only
 - [ ] Consider adding stack trace info to tracing / cause
 - [ ] Use Predicate for filtering functions
 - [ ] Add AI provider packages
+- [ ] Add test lalph
 
 ## Beta
 


### PR DESCRIPTION
## Summary
- add Alpha TODO entry for lalph test work
- log progress and check failure in PROGRESS.md