### PR TITLE
EFF-167 Fix Prompt.text cursor gap

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,1 @@
+- 2026-01-14 EFF-167: adjust Prompt.text cursor offset to remove end-gap (only text type); files: packages/effect/src/unstable/cli/Prompt.ts; notes: `pnpm lint --fix packages/effect/src/unstable/cli/Prompt.ts` fails because `dprint check` rejects `--fix`, ran `pnpm lint-fix -- packages/effect/src/unstable/cli/Prompt.ts` after `pnpm install`.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2791,7 +2791,10 @@ const renderTextNextFrame = Effect.fnUntraced(function*(state: TextState, option
   const promptMsg = renderTextOutput(state, leadingSymbol, trailingSymbol, options)
   const errorMsg = renderTextError(state, figures.pointerSmall)
   const offset = state.cursor - state.value.length
-  return promptMsg + errorMsg + Ansi.cursorMove(offset)
+  const cursorOffset = options.type === "text" && state.cursor === state.value.length && state.value.length > 0
+    ? offset - 1
+    : offset
+  return promptMsg + errorMsg + Ansi.cursorMove(cursorOffset)
 })
 
 const renderTextSubmission = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {


### PR DESCRIPTION
## Summary
- adjust cursor placement at end of `Prompt.text` input to eliminate the extra gap
- record progress notes for the task

## Testing
- `pnpm test packages/effect/test/unstable/cli/Primitive.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`