### PR TITLE
add catchReason, catchReasons, unwrapReason combinators

### DIFF
--- a/packages/effect/dtslint/Types.tst.ts
+++ b/packages/effect/dtslint/Types.tst.ts
@@ -322,4 +322,47 @@ describe("Types", () => {
       expect<Types.MatchRecord<{ a: number }, 1, 0>>().type.toBe<0>()
     })
   })
+
+  describe("ReasonOf", () => {
+    it("extracts reason type from error with reason field", () => {
+      type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+      type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+      type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+      expect<Types.ReasonOf<AiError>>().type.toBe<RateLimitError | QuotaError>()
+    })
+
+    it("returns never for error without reason field", () => {
+      type SimpleError = { readonly _tag: "SimpleError"; readonly code: number }
+      expect<Types.ReasonOf<SimpleError>>().type.toBe<never>()
+    })
+  })
+
+  describe("ReasonTags", () => {
+    it("extracts reason tags from error", () => {
+      type RateLimitError = { readonly _tag: "RateLimitError" }
+      type QuotaError = { readonly _tag: "QuotaError" }
+      type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+      expect<Types.ReasonTags<AiError> & unknown>().type.toBe<"RateLimitError" | "QuotaError">()
+    })
+
+    it("returns never for error without reason field", () => {
+      type SimpleError = { readonly _tag: "SimpleError"; readonly code: number }
+      expect<Types.ReasonTags<SimpleError>>().type.toBe<never>()
+    })
+  })
+
+  describe("ExtractReason", () => {
+    it("extracts specific reason variant by tag", () => {
+      type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+      type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+      type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+      expect<Types.ExtractReason<AiError, "RateLimitError">>().type.toBe<RateLimitError>()
+    })
+
+    it("returns never for non-matching tag", () => {
+      type RateLimitError = { readonly _tag: "RateLimitError" }
+      type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError }
+      expect<Types.ExtractReason<AiError, "Invalid">>().type.toBe<never>()
+    })
+  })
 })

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -549,3 +549,63 @@ export interface unhandled {
  * @category types
  */
 export type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true
+
+/**
+ * Extracts the reason type from an error that has a `reason` field.
+ * @example
+ * ```ts
+ * import type * as Types from "effect/Types"
+ *
+ * type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+ * type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+ *
+ * type Res = Types.ReasonOf<AiError>
+ * // RateLimitError | QuotaError
+ * ```
+ *
+ * @since 4.0.0
+ * @category types
+ */
+export type ReasonOf<E> = E extends { readonly reason: infer R } ? R : never
+
+/**
+ * Extracts the `_tag` values from nested reason types.
+ * @example
+ * ```ts
+ * import type * as Types from "effect/Types"
+ *
+ * type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+ * type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+ *
+ * type Res = Types.ReasonTags<AiError>
+ * // "RateLimitError" | "QuotaError"
+ * ```
+ *
+ * @since 4.0.0
+ * @category types
+ */
+export type ReasonTags<E> = E extends { readonly reason: { readonly _tag: string } } ? E["reason"]["_tag"]
+  : never
+
+/**
+ * Extracts a specific reason variant by its `_tag`.
+ * @example
+ * ```ts
+ * import type * as Types from "effect/Types"
+ *
+ * type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+ * type AiError = { readonly _tag: "AiError"; readonly reason: RateLimitError | QuotaError }
+ *
+ * type Res = Types.ExtractReason<AiError, "RateLimitError">
+ * // { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * ```
+ *
+ * @since 4.0.0
+ * @category types
+ */
+export type ExtractReason<E, K extends string> = E extends { readonly reason: infer R }
+  ? Extract<R, { readonly _tag: K }>
+  : never


### PR DESCRIPTION
## Summary

Add three new error handling combinators for working with nested error types that have a `reason` field:

- **`catchReason(errorTag, reasonTag, handler)`** - Catch a specific reason within a tagged error
- **`catchReasons(errorTag, cases)`** - Catch multiple reasons with an object of handlers
- **`unwrapReason(errorTag)`** - Promote nested reasons into the error channel

## Rationale

These combinators support a domain modeling pattern where errors contain a `reason` field with nested tagged variants. This pattern is useful when:

1. **Avoiding error channel explosion** - Instead of `Effect<A, RateLimitError | QuotaExceededError | NetworkError | AuthError | ...>`, you expose `Effect<A, AiError>` where `AiError.reason` contains the granular details

2. **Providing granular error info** - End users can still access specific error cases and their data (e.g., `retryAfter` on rate limits) without the error channel becoming unwieldy

3. **Grouping related errors** - Errors from a specific domain (AI, database, HTTP) stay grouped under a single parent type while maintaining full type safety for the nested reasons

4. **Enabling selective handling** - Callers can handle specific reasons (`catchReason`) or let the parent error propagate, choosing their level of granularity

## Type Utilities

Added to `Types.ts`:
- `ReasonOf<E>` - Extract reason type from error with `reason` field
- `ReasonTags<E>` - Extract `_tag` values from nested reason types
- `ExtractReason<E, K>` - Extract specific reason variant by tag

## Example Usage

```ts
class RateLimitError extends Data.TaggedError("RateLimitError")<{
  retryAfter: number
}> {}

class QuotaExceededError extends Data.TaggedError("QuotaExceededError")<{
  limit: number
}> {}

class AiError extends Data.TaggedError("AiError")<{
  reason: RateLimitError | QuotaExceededError
}> {}

// catchReason - handle specific reason
effect.pipe(
  Effect.catchReason("AiError", "RateLimitError", (reason) =>
    Effect.succeed(`Retry after ${reason.retryAfter}s`)
  )
)

// catchReasons - handle multiple reasons
effect.pipe(
  Effect.catchReasons("AiError", {
    RateLimitError: (r) => Effect.succeed(`Retry: ${r.retryAfter}`),
    QuotaExceededError: (r) => Effect.fail(new BillingError())
  })
)

// unwrapReason - promote reasons to error channel
// Effect<string, AiError> -> Effect<string, RateLimitError | QuotaExceededError>
effect.pipe(Effect.unwrapReason("AiError"))
```