### PR TITLE
EFF-181: Refactor Stream.filter predicates

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -19,11 +19,20 @@
 
 ## 2026-01-15
 
-- Task EFF-176: shift Channel.filterArrayEffect to effectful predicate; rename filter test variable
+### Task EFF-176: shift Channel.filterArrayEffect to effectful predicate; rename filter test variable
+
 - Files: packages/effect/src/Channel.ts, packages/effect/test/Effect.test.ts, PROGRESS.md
 - Notes: filterArrayEffect uses Effect.filter predicate; ran pnpm lint-fix/test/check/build/docgen
 - Blockers: none
-- Task EFF-198: update Channel.filterArray to Predicate/Refinement
+
+### Task EFF-198: update Channel.filterArray to Predicate/Refinement
+
 - Files: packages/effect/src/Channel.ts, packages/effect/src/Stream.ts, packages/effect/src/unstable/encoding/Ndjson.ts, .lalph/prd.json, PROGRESS.md
 - Notes: filterArray uses Array.filter + non-empty guard; Stream.filter keeps Filter.Filter via partitionFilter; Ndjson uses predicate; ran pnpm lint-fix/test/check/build/docgen
+- Blockers: none
+
+### Task EFF-181: refactor Stream.filter to Predicate/Refinement
+
+- Files: packages/effect/src/Stream.ts, packages/effect/src/unstable/reactivity/AtomRegistry.ts, packages/effect/test/Stream.test.ts, packages/platform-node/test/HttpApi.test.ts, PROGRESS.md
+- Notes: Stream.filter uses Predicate/Refinement via Filter.fromPredicate; updated callers to use guards; ran pnpm lint-fix/test/check/build/docgen
 - Blockers: none

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -4,7 +4,6 @@
 import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
-import * as Filter from "../../Filter.ts"
 import { constVoid, dual } from "../../Function.ts"
 import * as Layer from "../../Layer.ts"
 import * as Option from "../../Option.ts"
@@ -159,7 +158,7 @@ export const toStreamResult: {
   2,
   <A, E>(self: AtomRegistry, atom: Atom.Atom<Result.AsyncResult<A, E>>): Stream.Stream<A, E> =>
     toStream(self, atom).pipe(
-      Stream.filter(Filter.fromPredicate(Result.isNotInitial)),
+      Stream.filter(Result.isNotInitial),
       Stream.mapEffect((result) =>
         result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
       )
@@ -882,7 +881,7 @@ const LifetimeProto: Omit<Lifetime<any>, "node" | "finalizers" | "disposed" | "i
     readonly bufferSize?: number
   }): Stream.Stream<A, E> {
     return this.stream(atom, options).pipe(
-      Stream.filter(Filter.fromPredicate(Result.isNotInitial)),
+      Stream.filter(Result.isNotInitial),
       Stream.mapEffect((result) =>
         result._tag === "Success" ? Effect.succeed(result.value) : Effect.failCause(result.cause)
       )

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -303,7 +303,7 @@ describe("Stream", () => {
     },
     Effect.fnUntraced(function*({ chunks, size }) {
       const actual = yield* Stream.fromArray(chunks).pipe(
-        Stream.filter((a) => isReadonlyArrayNonEmpty(a) ? a : Filter.fail(a)),
+        Stream.filter((chunk): chunk is NonEmptyArray<number> => isReadonlyArrayNonEmpty(chunk)),
         Stream.flattenArray,
         Stream.rechunk(size),
         Stream.chunks,

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -5,7 +5,6 @@ import {
   DateTime,
   Effect,
   FileSystem,
-  Filter,
   Layer,
   Redacted,
   Ref,
@@ -1092,7 +1091,7 @@ const HttpUsersLive = HttpApiBuilder.group(
       .handle("uploadStream", (_) =>
         Effect.gen(function*() {
           const { content, file } = yield* _.payload.pipe(
-            Stream.filter((part) => part._tag === "File" ? part : Filter.fail(part)),
+            Stream.filter(Multipart.isFile),
             Stream.mapEffect((file) =>
               file.contentEffect.pipe(
                 Effect.map((content) => ({ file, content }))


### PR DESCRIPTION
## Summary
- update `Stream.filter` overloads to predicate/refinement signatures
- wrap predicate usage via `Filter.fromPredicate`
- adjust call sites in AtomRegistry and HttpApi stream handling
- update Stream test for non-empty array refinement

## Testing
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Stream.test.ts`
- `pnpm test packages/platform-node/test/HttpApi.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`