### PR TITLE
EFF-178: switch filterOrFail predicates

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -42,3 +42,9 @@
 - Files: packages/effect/src/Channel.ts, packages/effect/src/Stream.ts, .lalph/prd.json, PROGRESS.md
 - Notes: Channel.filter uses Predicate/Refinement via Filter.fromPredicate; filterArray uses Arr.filter with non-empty guard; zipLatestAll filters undefined via refinement; tapError uses Effect.as to normalize; ran pnpm lint-fix/test/check/build/docgen
 - Blockers: none
+
+### Task EFF-178: refactor Effect.filterOrFail
+
+- Files: packages/effect/src/Effect.ts, packages/effect/src/internal/effect.ts, packages/effect/src/unstable/http/HttpClient.ts, packages/effect/src/unstable/sql/Migrator.ts, PROGRESS.md
+- Notes: filterOrFail now accepts predicate/refinement; internal impl checks predicate directly; Migrator uses Effect.isEffect; HttpClient filterOrFail updated; ran pnpm lint-fix/test/check/build/docgen
+- Blockers: none

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4081,7 +4081,7 @@ export const filterOrElse: {
  *
  * @example
  * ```ts
- * import { Effect, Filter } from "effect"
+ * import { Effect } from "effect"
  *
  * // An effect that produces a number
  * const program = Effect.succeed(5)
@@ -4089,7 +4089,7 @@ export const filterOrElse: {
  * // Filter for even numbers, fail for odd numbers
  * const filtered = Effect.filterOrFail(
  *   program,
- *   (n) => n % 2 === 0 ? n : Filter.fail(n),
+ *   (n) => n % 2 === 0,
  *   (n) => `Expected even number, got ${n}`
  * )
  *
@@ -4100,22 +4100,38 @@ export const filterOrElse: {
  * @category Filtering
  */
 export const filterOrFail: {
-  <A, E2, B, X>(
-    filter: Filter.Filter<NoInfer<A>, B, X>,
-    orFailWith: (a: X) => E2
+  <A, E2, B extends A>(
+    refinement: Predicate.Refinement<NoInfer<A>, B>,
+    orFailWith: (a: NoInfer<A>) => E2
   ): <E, R>(self: Effect<A, E, R>) => Effect<B, E2 | E, R>
-  <A, E, R, E2, B, X>(
-    self: Effect<A, E, R>,
-    filter: Filter.Filter<NoInfer<A>, B, X>,
-    orFailWith: (a: X) => E2
-  ): Effect<B, E2 | E, R>
-  <A, B, X>(
-    filter: Filter.Filter<NoInfer<A>, B, X>
+  <A, E2>(
+    predicate: Predicate.Predicate<NoInfer<A>>,
+    orFailWith: (a: NoInfer<A>) => E2
+  ): <E, R>(self: Effect<A, E, R>) => Effect<A, E2 | E, R>
+  <A, B extends A>(
+    refinement: Predicate.Refinement<NoInfer<A>, B>
   ): <E, R>(self: Effect<A, E, R>) => Effect<B, Cause.NoSuchElementError | E, R>
-  <A, E, R, B, X>(
+  <A>(
+    predicate: Predicate.Predicate<NoInfer<A>>
+  ): <E, R>(self: Effect<A, E, R>) => Effect<A, Cause.NoSuchElementError | E, R>
+  <A, E, R, E2, B extends A>(
     self: Effect<A, E, R>,
-    filter: Filter.Filter<NoInfer<A>, B, X>
+    refinement: Predicate.Refinement<NoInfer<A>, B>,
+    orFailWith: (a: NoInfer<A>) => E2
+  ): Effect<B, E2 | E, R>
+  <A, E, R, E2>(
+    self: Effect<A, E, R>,
+    predicate: Predicate.Predicate<NoInfer<A>>,
+    orFailWith: (a: NoInfer<A>) => E2
+  ): Effect<A, E2 | E, R>
+  <A, E, R, B extends A>(
+    self: Effect<A, E, R>,
+    refinement: Predicate.Refinement<NoInfer<A>, B>
   ): Effect<B, E | Cause.NoSuchElementError, R>
+  <A, E, R>(
+    self: Effect<A, E, R>,
+    predicate: Predicate.Predicate<NoInfer<A>>
+  ): Effect<A, E | Cause.NoSuchElementError, R>
 } = internal.filterOrFail
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -429,14 +429,23 @@ export const filterOrElse: {
  * @category filters
  */
 export const filterOrFail: {
-  <B, E2>(
-    filter: Filter.Filter<HttpClientResponse.HttpClientResponse, B>,
-    orFailWith: (response: B) => E2
+  <B extends HttpClientResponse.HttpClientResponse, E2>(
+    refinement: Predicate.Refinement<NoInfer<HttpClientResponse.HttpClientResponse>, B>,
+    orFailWith: (response: NoInfer<HttpClientResponse.HttpClientResponse>) => E2
   ): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E2 | E, R>
-  <E, R, B, E2>(
+  <E2>(
+    predicate: Predicate.Predicate<NoInfer<HttpClientResponse.HttpClientResponse>>,
+    orFailWith: (response: NoInfer<HttpClientResponse.HttpClientResponse>) => E2
+  ): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E2 | E, R>
+  <E, R, B extends HttpClientResponse.HttpClientResponse, E2>(
     self: HttpClient.With<E, R>,
-    filter: Filter.Filter<HttpClientResponse.HttpClientResponse, B>,
-    orFailWith: (response: B) => E2
+    refinement: Predicate.Refinement<NoInfer<HttpClientResponse.HttpClientResponse>, B>,
+    orFailWith: (response: NoInfer<HttpClientResponse.HttpClientResponse>) => E2
+  ): HttpClient.With<E2 | E, R>
+  <E, R, E2>(
+    self: HttpClient.With<E, R>,
+    predicate: Predicate.Predicate<NoInfer<HttpClientResponse.HttpClientResponse>>,
+    orFailWith: (response: NoInfer<HttpClientResponse.HttpClientResponse>) => E2
   ): HttpClient.With<E2 | E, R>
 } = dual(3, (self, f, orFailWith) => transformResponse(self, Effect.filterOrFail(f, orFailWith)))
 

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -5,7 +5,6 @@ import * as Arr from "../../Array.ts"
 import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
 import { FileSystem } from "../../FileSystem.ts"
-import * as Filter from "../../Filter.ts"
 import { pipe } from "../../Function.ts"
 import * as Option from "../../Option.ts"
 import * as Order from "../../Order.ts"
@@ -170,7 +169,7 @@ export const make = <RD = never>({
               )
           ),
           Effect.filterOrFail(
-            (_) => Effect.isEffect(_) ? _ as Effect.Effect<unknown> : Filter.failVoid,
+            Effect.isEffect,
             () =>
               new MigrationError({
                 reason: "import-error",


### PR DESCRIPTION
## Summary
- update Effect.filterOrFail overloads to predicate/refinement and refresh docs
- replace internal filterOrFail implementation with predicate checks
- update HttpClient and Migrator call sites to use predicates

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check
- pnpm build
- pnpm docgen