### PR TITLE
EFF-208: add tapErrorTag export and docs

### DIFF
--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -120,6 +120,35 @@ describe("Effect.catchReasons", () => {
   })
 })
 
+describe("Effect.tapErrorTag", () => {
+  it("narrows tagged errors", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.tapErrorTag("AiError", (error) => {
+        expect(error).type.toBe<AiError>()
+        return Effect.succeed("ok")
+      })
+    )
+    expect(result).type.toBe<Effect.Effect<string, AiError | OtherError>>()
+  })
+
+  it("unifies additional error types", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.tapErrorTag("AiError", () => Effect.fail(new SimpleError({ code: 1 })))
+    )
+    expect(result).type.toBe<Effect.Effect<string, AiError | OtherError | SimpleError>>()
+  })
+
+  it("supports tacit pipe", () => {
+    const result = pipe(
+      simpleEffect,
+      Effect.tapErrorTag("SimpleError", Effect.log)
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+})
+
 describe("Effect.unwrapReason", () => {
   it("replaces parent error with reasons", () => {
     const result = pipe(aiEffect, Effect.unwrapReason("AiError"))

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3176,6 +3176,69 @@ export const tapError: {
 } = internal.tapError
 
 /**
+ * Inspect errors matching a specific tag without altering the original effect.
+ *
+ * **Details**
+ *
+ * This function allows you to inspect and handle specific error types based on
+ * their `_tag` property. It is useful when errors are modeled with tagged
+ * unions, letting you log or perform actions on matched errors while leaving the
+ * error channel unchanged.
+ *
+ * If the error doesn't match the specified tag, this function does nothing and
+ * the effect proceeds as usual.
+ *
+ * **Example**
+ *
+ * ```ts
+ * import { Console, Effect } from "effect"
+ *
+ * class NetworkError {
+ *   readonly _tag = "NetworkError"
+ *   constructor(readonly statusCode: number) {}
+ * }
+ *
+ * class ValidationError {
+ *   readonly _tag = "ValidationError"
+ *   constructor(readonly field: string) {}
+ * }
+ *
+ * const task: Effect.Effect<number, NetworkError | ValidationError> =
+ *   Effect.fail(new NetworkError(504))
+ *
+ * const tapping = Effect.tapErrorTag(task, "NetworkError", (error) =>
+ *   Console.log(`expected error: ${error.statusCode}`)
+ * )
+ *
+ * Effect.runFork(tapping)
+ * // Output:
+ * // expected error: 504
+ * ```
+ *
+ * @since 2.0.0
+ * @category Sequencing
+ */
+export const tapErrorTag: {
+  <const K extends Tags<E> | Arr.NonEmptyReadonlyArray<Tags<E>>, E, A1, E1, R1>(
+    k: K,
+    f: (e: ExtractTag<NoInfer<E>, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect<A1, E1, R1>
+  ): <A, R>(self: Effect<A, E, R>) => Effect<A, E | E1, R1 | R>
+  <
+    A,
+    E,
+    R,
+    const K extends Tags<E> | Arr.NonEmptyReadonlyArray<Tags<E>>,
+    R1,
+    E1,
+    A1
+  >(
+    self: Effect<A, E, R>,
+    k: K,
+    f: (e: ExtractTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect<A1, E1, R1>
+  ): Effect<A, E | E1, R | R1>
+} = internal.tapErrorTag
+
+/**
  * The `tapCause` function allows you to inspect the complete cause
  * of an error, including failures and defects.
  *

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2505,6 +2505,56 @@ export const tapError: {
 )
 
 /** @internal */
+export const tapErrorTag: {
+  <const K extends Tags<E> | Arr.NonEmptyReadonlyArray<Tags<E>>, E, A1, E1, R1>(
+    k: K,
+    f: (
+      e: ExtractTag<NoInfer<E>, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>
+    ) => Effect.Effect<A1, E1, R1>
+  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | E1, R1 | R>
+  <
+    A,
+    E,
+    R,
+    const K extends Tags<E> | Arr.NonEmptyReadonlyArray<Tags<E>>,
+    R1,
+    E1,
+    A1
+  >(
+    self: Effect.Effect<A, E, R>,
+    k: K,
+    f: (e: ExtractTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect.Effect<A1, E1, R1>
+  ): Effect.Effect<A, E | E1, R | R1>
+} = dual(
+  3,
+  <
+    A,
+    E,
+    R,
+    const K extends Tags<E> | Arr.NonEmptyReadonlyArray<Tags<E>>,
+    R1,
+    E1,
+    A1
+  >(
+    self: Effect.Effect<A, E, R>,
+    k: K,
+    f: (e: ExtractTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect.Effect<A1, E1, R1>
+  ): Effect.Effect<A, E | E1, R | R1> => {
+    const predicate = Array.isArray(k)
+      ? ((e: E): e is ExtractTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> =>
+        hasProperty(e, "_tag") && k.includes(e._tag))
+      : isTagged(k as string)
+    return tapError(
+      self,
+      (error) =>
+        predicate(error)
+          ? f(error as ExtractTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>)
+          : void_
+    )
+  }
+)
+
+/** @internal */
 export const tapDefect: {
   <E, B, E2, R2>(
     f: (defect: unknown) => Effect.Effect<B, E2, R2>


### PR DESCRIPTION
## Summary
- add internal `tapErrorTag` combinator with tag predicate handling
- export `Effect.tapErrorTag` with docs and example
- add dtslint coverage for unions and tacit pipe usage

## Testing
- `pnpm lint-fix`
- `pnpm test-types`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`