### PR TITLE
EFF-209: expose tapErrorTag docs

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -3178,6 +3178,11 @@ export const tapError: {
 /**
  * Inspect errors matching a specific tag without altering the original effect.
  *
+ * **When to Use**
+ *
+ * Use this function when your errors are modeled as tagged unions and you want
+ * to run a side effect for a matching tag without changing the error channel.
+ *
  * **Details**
  *
  * This function allows you to inspect and handle specific error types based on


### PR DESCRIPTION
## Summary
- add usage guidance to the `Effect.tapErrorTag` doc comment
- keep tapErrorTag example aligned with error-tagged patterns

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check
- pnpm build
- pnpm docgen