### PR TITLE
EFF-216: port Event and EventGroup modules

### DIFF
--- a/packages/effect/src/unstable/eventlog/Event.ts
+++ b/packages/effect/src/unstable/eventlog/Event.ts
@@ -1,0 +1,271 @@
+/**
+ * @since 4.0.0
+ */
+import { pipeArguments } from "../../Pipeable.ts"
+import * as Predicate from "../../Predicate.ts"
+import * as Schema from "../../Schema.ts"
+import * as Msgpack from "../encoding/Msgpack.ts"
+
+/**
+ * @since 4.0.0
+ * @category type ids
+ */
+export const TypeId: unique symbol = Symbol.for("~effect/eventlog/Event")
+
+/**
+ * @since 4.0.0
+ * @category type ids
+ */
+export type TypeId = typeof TypeId
+
+/**
+ * @since 4.0.0
+ * @category guards
+ */
+export const isEvent = (u: unknown): u is Event<any, any, any, any> => Predicate.hasProperty(u, TypeId)
+
+/**
+ * Represents an event in an EventLog.
+ *
+ * @since 4.0.0
+ * @category models
+ */
+export interface Event<
+  out Tag extends string,
+  in out Payload extends Schema.Top = typeof Schema.Void,
+  in out Success extends Schema.Top = typeof Schema.Void,
+  in out Error extends Schema.Top = typeof Schema.Never
+> {
+  readonly [TypeId]: TypeId
+  readonly tag: Tag
+  readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+  readonly payload: Payload
+  readonly payloadMsgPack: Msgpack.schema<Payload>
+  readonly success: Success
+  readonly error: Error
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface EventHandler<in out Tag extends string> {
+  readonly _: unique symbol
+  readonly tag: Tag
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export declare namespace Event {
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export interface Any {
+    readonly [TypeId]: TypeId
+    readonly tag: string
+  }
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export interface AnyWithProps extends Event<string, Schema.Top, Schema.Top, Schema.Top> {}
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ToService<A> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? EventHandler<_Tag> :
+    never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Tag<A> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? _Tag :
+    never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ErrorSchema<A extends Any> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? _Error
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Error<A extends Any> = Schema.Schema.Type<ErrorSchema<A>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type AddError<A extends Any, Error extends Schema.Top> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? Event<_Tag, _Payload, _Success, _Error | Error>
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type PayloadSchema<A extends Any> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? _Payload
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Payload<A extends Any> = Schema.Schema.Type<PayloadSchema<A>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type TaggedPayload<A extends Any> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? {
+      readonly _tag: _Tag
+      readonly payload: Schema.Schema.Type<_Payload>
+    }
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type SuccessSchema<A extends Any> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ? _Success
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Success<A extends Any> = Schema.Schema.Type<SuccessSchema<A>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Context<A> = A extends Event<
+    infer _Tag,
+    infer _Payload,
+    infer _Success,
+    infer _Error
+  > ?
+      | _Payload["DecodingServices"]
+      | _Payload["EncodingServices"]
+      | _Success["DecodingServices"]
+      | _Success["EncodingServices"]
+      | _Error["DecodingServices"]
+      | _Error["EncodingServices"]
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type WithTag<Events extends Any, Tag extends string> = Extract<Events, { readonly tag: Tag }>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ExcludeTag<Events extends Any, Tag extends string> = Exclude<Events, { readonly tag: Tag }>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type PayloadWithTag<Events extends Any, Tag extends string> = Payload<WithTag<Events, Tag>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type SuccessWithTag<Events extends Any, Tag extends string> = Success<WithTag<Events, Tag>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ErrorWithTag<Events extends Any, Tag extends string> = Error<WithTag<Events, Tag>>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ContextWithTag<Events extends Any, Tag extends string> = Context<WithTag<Events, Tag>>
+}
+
+const Proto = {
+  [TypeId]: TypeId,
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const make = <
+  Tag extends string,
+  Payload extends Schema.Top = typeof Schema.Void,
+  Success extends Schema.Top = typeof Schema.Void,
+  Error extends Schema.Top = typeof Schema.Never
+>(options: {
+  readonly tag: Tag
+  readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+  readonly payload?: Payload | undefined
+  readonly success?: Success | undefined
+  readonly error?: Error | undefined
+}): Event<Tag, Payload, Success, Error> => {
+  const payload = options.payload ?? (Schema.Void as any as Payload)
+  const success = options.success ?? (Schema.Void as any as Success)
+  const error = options.error ?? (Schema.Never as any as Error)
+  return Object.assign(Object.create(Proto), {
+    tag: options.tag,
+    primaryKey: options.primaryKey,
+    payload,
+    payloadMsgPack: Msgpack.schema(payload),
+    success,
+    error
+  })
+}

--- a/packages/effect/src/unstable/eventlog/EventGroup.ts
+++ b/packages/effect/src/unstable/eventlog/EventGroup.ts
@@ -1,0 +1,158 @@
+/**
+ * @since 4.0.0
+ */
+import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
+import * as Predicate from "../../Predicate.ts"
+import * as Record from "../../Record.ts"
+import type * as Schema from "../../Schema.ts"
+import * as HttpApiSchema from "../httpapi/HttpApiSchema.ts"
+import type { Event } from "./Event.ts"
+import * as EventApi from "./Event.ts"
+
+/**
+ * @since 4.0.0
+ * @category type ids
+ */
+export const TypeId: unique symbol = Symbol.for("~effect/eventlog/EventGroup")
+
+/**
+ * @since 4.0.0
+ * @category type ids
+ */
+export type TypeId = typeof TypeId
+
+/**
+ * @since 4.0.0
+ * @category guards
+ */
+export const isEventGroup = (u: unknown): u is EventGroup.Any => Predicate.hasProperty(u, TypeId)
+
+/**
+ * An `EventGroup` is a collection of `Event`s. You can use an `EventGroup` to
+ * represent a portion of your domain.
+ *
+ * The events can be implemented later using the `EventLogBuilder.group` api.
+ *
+ * @since 4.0.0
+ * @category models
+ */
+export interface EventGroup<
+  out Events extends Event.Any = never
+> extends Pipeable {
+  new(_: never): {}
+
+  readonly [TypeId]: TypeId
+  readonly events: Record.ReadonlyRecord<string, Events>
+
+  /**
+   * Add an `Event` to the `EventGroup`.
+   */
+  add<
+    Tag extends string,
+    Payload extends Schema.Top = typeof Schema.Void,
+    Success extends Schema.Top = typeof Schema.Void,
+    Error extends Schema.Top = typeof Schema.Never
+  >(options: {
+    readonly tag: Tag
+    readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+    readonly payload?: Payload
+    readonly success?: Success
+    readonly error?: Error
+  }): EventGroup<Events | Event<Tag, Payload, Success, Error>>
+
+  /**
+   * Add an error schema to all the events in the `EventGroup`.
+   */
+  addError<Error extends Schema.Top>(error: Error): EventGroup<Event.AddError<Events, Error>>
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export declare namespace EventGroup {
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export interface Any {
+    readonly [TypeId]: TypeId
+  }
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type AnyWithProps = EventGroup<Event.AnyWithProps>
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type ToService<A> = A extends EventGroup<infer _Events> ? Event.ToService<_Events>
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Events<Group> = Group extends EventGroup<infer _Events> ? _Events
+    : never
+
+  /**
+   * @since 4.0.0
+   * @category models
+   */
+  export type Context<Group> = Event.Context<Events<Group>>
+}
+
+const Proto = {
+  [TypeId]: TypeId,
+  add(this: EventGroup.AnyWithProps, options: {
+    readonly tag: string
+    readonly primaryKey: (payload: Schema.Top["Type"]) => string
+    readonly payload?: Schema.Top
+    readonly success?: Schema.Top
+    readonly error?: Schema.Top
+  }) {
+    return makeProto({
+      events: {
+        ...this.events,
+        [options.tag]: EventApi.make(options)
+      }
+    })
+  },
+  addError(this: EventGroup.AnyWithProps, error: Schema.Top) {
+    return makeProto({
+      events: Record.map(this.events, (event) =>
+        EventApi.make({
+          ...event,
+          error: HttpApiSchema.UnionUnify(event.error, error)
+        }))
+    })
+  },
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
+}
+
+const makeProto = <
+  Events extends Event.Any
+>(options: {
+  readonly events: Record.ReadonlyRecord<string, Events>
+}): EventGroup<Events> => {
+  function EventGroup() {}
+  Object.setPrototypeOf(EventGroup, Proto)
+  return Object.assign(EventGroup, options) as any
+}
+
+/**
+ * An `EventGroup` is a collection of `Event`s. You can use an `EventGroup` to
+ * represent a portion of your domain.
+ *
+ * The events can be implemented later using the `EventLog.group` api.
+ *
+ * @since 4.0.0
+ * @category constructors
+ */
+export const empty: EventGroup<never> = makeProto({ events: Record.empty() })


### PR DESCRIPTION
## Summary
- add Event and EventGroup modules under unstable eventlog with Effect 4 schema patterns
- wire Msgpack payload schemas and group error union helpers
- align type ids, guards, and builder utilities for eventlog definitions