### PR TITLE
EFF-225: align eventlog TypeIds with string constants

### DIFF
--- a/packages/effect/src/unstable/eventlog/Event.ts
+++ b/packages/effect/src/unstable/eventlog/Event.ts
@@ -10,13 +10,13 @@ import * as Msgpack from "../encoding/Msgpack.ts"
  * @since 4.0.0
  * @category type ids
  */
-export const TypeId = "~effect/eventlog/Event"
+export type TypeId = "~effect/eventlog/Event"
 
 /**
  * @since 4.0.0
  * @category type ids
  */
-export type TypeId = typeof TypeId
+export const TypeId: TypeId = "~effect/eventlog/Event"
 
 /**
  * @since 4.0.0

--- a/packages/effect/src/unstable/eventlog/EventGroup.ts
+++ b/packages/effect/src/unstable/eventlog/EventGroup.ts
@@ -13,13 +13,13 @@ import * as EventApi from "./Event.ts"
  * @since 4.0.0
  * @category type ids
  */
-export const TypeId = "~effect/eventlog/EventGroup"
+export type TypeId = "~effect/eventlog/EventGroup"
 
 /**
  * @since 4.0.0
  * @category type ids
  */
-export type TypeId = typeof TypeId
+export const TypeId: TypeId = "~effect/eventlog/EventGroup"
 
 /**
  * @since 4.0.0


### PR DESCRIPTION
## Summary
- align Event and EventGroup TypeId exports with string literal ids used across eventlog
- keep TypeId constants and types in sync with explicit string literal types

## Testing
- pnpm lint-fix
- pnpm check
- pnpm test packages/effect/test/unstable/eventlog/Event.test.ts (fails: no test files found)
- pnpm build
- pnpm docgen