### PR TITLE
EFF-221: add EventLogServer core

### DIFF
--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -16,7 +16,7 @@ import * as HttpServerRequest from "../http/HttpServerRequest.ts"
 import * as HttpServerResponse from "../http/HttpServerResponse.ts"
 import type * as Socket from "../socket/Socket.ts"
 import { EntryId, makeRemoteId, type RemoteId } from "./EventJournal.ts"
-import { type EncryptedRemoteEntry } from "./EventLogEncryption.ts"
+import type { EncryptedRemoteEntry } from "./EventLogEncryption.ts"
 import {
   Ack,
   Changes,
@@ -123,7 +123,7 @@ export const makeHandler: Effect.Effect<
                   write(
                     new Changes({
                       publicKey: request.publicKey,
-                      entries
+                      entries: latestEntries
                     })
                   )
                 )


### PR DESCRIPTION
## Summary
- add unstable EventLogServer module with protocol handler and websocket upgrade
- implement in-memory storage using RcMap and PubSub change streams
- wire storage layer for server usage

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/eventlog/EventLogServer.test.ts (fails: no test files found)
- pnpm check
- pnpm build
- pnpm docgen