### PR TITLE
EFF-235 tighten eventlog handler typing

### DIFF
--- a/packages/effect/src/unstable/eventlog/EventGroup.ts
+++ b/packages/effect/src/unstable/eventlog/EventGroup.ts
@@ -5,7 +5,6 @@ import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Record from "../../Record.ts"
 import type * as Schema from "../../Schema.ts"
-import * as HttpApiSchema from "../httpapi/HttpApiSchema.ts"
 import type { Event } from "./Event.ts"
 import * as EventApi from "./Event.ts"
 
@@ -143,16 +142,11 @@ const makeProto = <
       this: EventGroup<Events>,
       error: Error
     ): EventGroup<Event.AddError<Events, Error>> {
-      return makeProto({
-        events: Record.map(this.events, (event) =>
-          EventApi.make({
-            tag: event.tag,
-            primaryKey: event.primaryKey,
-            payload: event.payload,
-            success: event.success,
-            error: HttpApiSchema.UnionUnify(event.error, error)
-          }))
-      }) as EventGroup<Event.AddError<Events, Error>>
+      const events = Record.map<string, Events, Event.AddError<Events, Error>>(
+        this.events,
+        (event) => EventApi.addError(event, error)
+      )
+      return makeProto({ events })
     },
     pipe() {
       return pipeArguments(this, arguments)

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -136,7 +136,10 @@ function shouldExtractUnion(ast: AST.Union): boolean {
 export const UnionUnify = <
   A extends Schema.Top,
   B extends Schema.Top
->(self: A, that: B): Schema.Top => Schema.make(UnionUnifyAST(self.ast, that.ast))
+>(
+  self: A,
+  that: B
+): Schema.Schema<Schema.Schema.Type<A> | Schema.Schema.Type<B>> => Schema.make(UnionUnifyAST(self.ast, that.ast))
 
 /**
  * @since 4.0.0


### PR DESCRIPTION
## Summary
- tighten Event.addError typing with a typed HttpApiSchema.UnionUnify return
- reuse Event.addError in EventGroup.addError mapping to reduce payload coercions
- keep eventlog helpers aligned with schema typing expectations

## Testing
- pnpm lint-fix
- pnpm check
- pnpm build
- pnpm docgen
- pnpm test packages/effect/test/unstable/eventlog/EventLog.test.ts (fails: no test files found)