### PR TITLE
EFF-224 add baseline eventlog tests

### DIFF
--- a/packages/effect/test/unstable/eventlog/EventJournal.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventJournal.test.ts
@@ -1,0 +1,25 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
+
+describe("EventJournal", () => {
+  it.effect("records entries in memory", () =>
+    Effect.gen(function*() {
+      const journal = yield* EventJournal.EventJournal
+      let created = 0
+      yield* journal.write({
+        event: "test",
+        primaryKey: "pk-1",
+        payload: new Uint8Array([1, 2, 3]),
+        effect: (entry) =>
+          Effect.sync(() => {
+            created = entry.createdAtMillis
+          })
+      })
+      const entries = yield* journal.entries
+      assert.strictEqual(entries.length, 1)
+      assert.strictEqual(entries[0].event, "test")
+      assert.strictEqual(entries[0].primaryKey, "pk-1")
+      assert.strictEqual(entries[0].createdAtMillis, created)
+    }).pipe(Effect.provide(EventJournal.layerMemory)))
+})

--- a/packages/effect/test/unstable/eventlog/EventLog.test.ts
+++ b/packages/effect/test/unstable/eventlog/EventLog.test.ts
@@ -1,0 +1,76 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer, Ref, Schema } from "effect"
+import * as EventGroup from "effect/unstable/eventlog/EventGroup"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
+import * as EventLog from "effect/unstable/eventlog/EventLog"
+import * as EventLogEncryption from "effect/unstable/eventlog/EventLogEncryption"
+
+const UserPayload = Schema.Struct({
+  id: Schema.String
+})
+
+const decodeUser = Schema.decodeUnknownSync(UserPayload)
+
+const UserGroup = EventGroup.empty.add({
+  tag: "UserCreated",
+  primaryKey: (payload: unknown) => decodeUser(payload).id,
+  payload: Schema.Unknown
+})
+
+const schema = EventLog.schema(UserGroup)
+
+const handlerLayer = (handled: Ref.Ref<ReadonlyArray<string>>) =>
+  EventLog.group(
+    UserGroup,
+    (handlers) =>
+      handlers.handle("UserCreated", ({ payload }) =>
+        Ref.update(handled, (values) => [...values, decodeUser(payload).id]))
+  )
+
+const logLayer = (handled: Ref.Ref<ReadonlyArray<string>>) =>
+  EventLog.layer(schema).pipe(
+    Layer.provideMerge(EventJournal.layerMemory),
+    Layer.provideMerge(Layer.succeed(EventLog.Identity, EventLog.makeIdentity())),
+    Layer.provideMerge(handlerLayer(handled))
+  )
+
+describe("EventLog", () => {
+  it.effect("writes entries and runs handlers", () =>
+    Effect.gen(function*() {
+      const handled = yield* Ref.make<ReadonlyArray<string>>([])
+      return yield* Effect.gen(function*() {
+        const log = yield* EventLog.EventLog
+        yield* log.write({
+          schema,
+          event: "UserCreated",
+          payload: { id: "user-1" }
+        })
+        const entries = yield* log.entries
+        const seen = yield* Ref.get(handled)
+        assert.strictEqual(entries.length, 1)
+        assert.strictEqual(entries[0].event, "UserCreated")
+        assert.deepStrictEqual(seen, ["user-1"])
+      }).pipe(Effect.provide(logLayer(handled)))
+    }))
+
+  it.effect("encrypts and decrypts entries", () =>
+    Effect.gen(function*() {
+      const encryption = yield* EventLogEncryption.EventLogEncryption
+      const identity = EventLog.makeIdentity()
+      const entry = new EventJournal.Entry({
+        id: EventJournal.makeEntryId(),
+        event: "UserCreated",
+        primaryKey: "user-1",
+        payload: new Uint8Array([1, 2, 3])
+      }, { disableValidation: true })
+      const encrypted = yield* encryption.encrypt(identity, [entry])
+      const decrypted = yield* encryption.decrypt(identity, [{
+        sequence: 0,
+        iv: encrypted.iv,
+        entryId: entry.id,
+        encryptedEntry: encrypted.encryptedEntries[0]
+      }])
+      assert.strictEqual(decrypted.length, 1)
+      assert.strictEqual(decrypted[0].entry.idString, entry.idString)
+    }).pipe(Effect.provide(EventLogEncryption.layerSubtle)))
+})


### PR DESCRIPTION
## Summary
- add baseline EventJournal memory test
- add EventLog handler/entry test with inline schema decoder
- add EventLogEncryption encrypt/decrypt smoke test