### PR TITLE
Fix pkg.pr.new badge not rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-[![pkg.pr.new](https://pkg.pr.new/badge/Effect-TS/effect-smol)](https://pkg.pr.new/~/Effect-TS/effect-smol)
+<!-- shields.io badge used because pkg.pr.new/badge returns HTTP 404 status despite valid SVG content, causing GitHub's image proxy to fail -->
+
+[![pkg.pr.new](https://img.shields.io/badge/pkg.pr.new-Effect--TS%2Feffect--smol-black)](https://pkg.pr.new/~/Effect-TS/effect-smol)


### PR DESCRIPTION
## Summary
- Replace pkg.pr.new badge with shields.io equivalent
- The pkg.pr.new/badge endpoint returns HTTP 404 status despite valid SVG content, causing GitHub's image proxy to fail

## Test plan
- [x] Verify badge renders correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)