### PR TITLE
EFF-243 Add Previously Known As JSDoc for Stream exports

### DIFF
--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -308,6 +308,12 @@ export const fromEffectDrain = <A, E, R>(effect: Effect.Effect<A, E, R>): Stream
   fromPull(Effect.succeed(Effect.flatMap(effect, () => Cause.done())))
 
 /**
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.repeatEffect`
+ *
  * @since 4.0.0
  * @category constructors
  */
@@ -317,6 +323,12 @@ export const fromEffectRepeat = <A, E, R>(effect: Effect.Effect<A, E, R>): Strea
 /**
  * Creates a stream from an effect producing a value of type `A`, which is
  * repeated using the specified schedule.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.repeatEffectWithSchedule`
  *
  * @since 2.0.0
  * @category constructors
@@ -493,6 +505,15 @@ export const toChannel = <A, E, R>(
  *
  * Effect.runPromise(Stream.runCollect(stream)).then(console.log)
  * ```
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.async`
+ * - `Stream.asyncEffect`
+ * - `Stream.asyncPush`
+ * - `Stream.asyncScoped`
  *
  * @since 2.0.0
  * @category constructors
@@ -776,6 +797,12 @@ export const fromIterableEffectRepeat = <A, E, R>(
  * This function creates a Stream that emits all values from the provided array.
  * If the array is empty, it returns an empty Stream.
  *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.fromChunk`
+ *
  * @example
  * ```ts
  * import { Effect, Stream } from "effect"
@@ -807,6 +834,12 @@ export const fromArrayEffect = <A, E, R>(
 
 /**
  * Creates a stream from some ararys.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.fromChunks`
  *
  * @since 4.0.0
  * @category constructors
@@ -1297,6 +1330,12 @@ export const mapBoth: {
   ))
 
 /**
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.mapChunks`
+ *
  * @since 2.0.0
  * @category mapping
  */
@@ -1398,6 +1437,12 @@ export const flattenEffect: {
 ): Stream<A, EX | E, RX | R> => mapEffect(self, identity, options))
 
 /**
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.mapChunksEffect`
+ *
  * @since 4.0.0
  * @category mapping
  */
@@ -1721,6 +1766,12 @@ export const flatten: {
 /**
  * Flattens a stream of non-empty arrays into a single stream.
  *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.flattenChunks`
+ *
  * @since 4.0.0
  * @category sequencing
  */
@@ -1891,6 +1942,12 @@ export const forever = <A, E, R>(self: Stream<A, E, R>): Stream<A, E, R> => from
 
 /**
  * Flattens a stream of iterables into a single stream.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.flattenIterables`
  *
  * @since 4.0.0
  * @category sequencing
@@ -2186,6 +2243,12 @@ const zipArrays = <AL, AR, A>(
 /**
  * Zips this stream with another stream using a function that operates on arrays
  * (chunks) of elements rather than individual elements.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.zipWithChunks`
  *
  * @since 2.0.0
  * @category zipping
@@ -3123,6 +3186,12 @@ export const buffer: {
  * Allows a faster producer to progress independently of a slower consumer by
  * buffering up to `capacity` elements in a queue.
  *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.bufferChunks`
+ *
  * @since 2.0.0
  * @category utils
  */
@@ -3150,6 +3219,12 @@ export const bufferArray: {
 
 /**
  * Handles stream failures by examining the full Cause of failure.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.catchAllCause`
  *
  * @example
  * ```ts
@@ -3189,6 +3264,12 @@ export const catchCause: {
   ))
 
 /**
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.tapErrorCause`
+ *
  * @since 4.0.0
  * @category Error handling
  */
@@ -3224,6 +3305,12 @@ const catch_: {
 
 export {
   /**
+   * **Previously Known As**
+   *
+   * This API replaces the following from Effect 3.x:
+   *
+   * - `Stream.catchAll`
+   *
    * @since 4.0.0
    * @category Error handling
    */
@@ -3252,6 +3339,12 @@ export const tapError: {
   ))
 
 /**
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.catchSome`
+ *
  * @since 4.0.0
  * @category Error handling
  */
@@ -3399,6 +3492,12 @@ export const mapError: {
 
 /**
  * Conditionally handles stream failures based on a predicate applied to the Cause.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.catchSomeCause`
  *
  * @example
  * ```ts
@@ -4305,6 +4404,12 @@ export const combine: {
  * and conceptually "offer" it to the destination stream. `f` can maintain
  * some internal state to control the combining process, with the initial
  * state being specified by `s`.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.combineChunks`
  *
  * @since 2.0.0
  * @category utils
@@ -6567,6 +6672,12 @@ export const runLast = <A, E, R>(self: Stream<A, E, R>): Effect.Effect<Option.Op
 /**
  * Consumes all elements of the stream, passing them to the specified
  * callback.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Stream.runForEachChunk`
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary
- add Previously Known As blocks to Stream exports based on the review list
- document the Effect 3.x names for renamed constructors, mappings, and error handlers

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Stream.test.ts
- pnpm check
- pnpm build
- pnpm docgen