### PR TITLE
EFF-248 Rename stream partition APIs

### DIFF
--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2920,7 +2920,7 @@ export const filterMapEffect: {
  * @since 2.0.0
  * @category Filtering
  */
-export const partition: {
+export const partitionFilter: {
   <A, B, X>(filter: Filter.Filter<A, B, X>, options?: {
     readonly capacity?: number | "unbounded" | undefined
   }): <E, R>(self: Stream<A, E, R>) => Effect.Effect<
@@ -2954,7 +2954,7 @@ export const partition: {
     R | Scope.Scope
   > =>
     Effect.map(
-      partitionQueue(filter, options)(self),
+      partitionFilterQueue(filter, options)(self),
       ([passes, fails]) => [fromQueue(passes), fromQueue(fails)] as const
     )
 )
@@ -2963,7 +2963,7 @@ export const partition: {
  * @since 4.0.0
  * @category Filtering
  */
-export const partitionQueue: {
+export const partitionFilterQueue: {
   <A, B, X>(filter: Filter.Filter<A, B, X>, options?: {
     readonly capacity?: number | "unbounded" | undefined
   }): <E, R>(self: Stream<A, E, R>) => Effect.Effect<
@@ -3040,7 +3040,7 @@ export const partitionQueue: {
  * @since 4.0.0
  * @category Filtering
  */
-export const partitionEffect: {
+export const partitionFilterEffect: {
   <A, B, X, EX, RX>(filter: Filter.FilterEffect<A, B, X, EX, RX>, options?: {
     readonly capacity?: number | "unbounded" | undefined
     readonly concurrency?: number | "unbounded" | undefined
@@ -3078,7 +3078,7 @@ export const partitionEffect: {
   > =>
     self.pipe(
       mapEffect(filter, options),
-      partition(identity, options)
+      partitionFilter(identity, options)
     )
 )
 

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -2829,12 +2829,12 @@ describe("Stream", () => {
       }))
   })
 
-  describe("partition", () => {
-    it.effect("partitionEffect - allows repeated runs without hanging", () =>
+  describe("partitionFilter", () => {
+    it.effect("partitionFilterEffect - allows repeated runs without hanging", () =>
       Effect.gen(function*() {
         const stream = pipe(
           Stream.fromIterable(Array.empty<number>()),
-          Stream.partitionEffect((n) => Effect.succeed(n % 2 === 0 ? n : Filter.fail(n))),
+          Stream.partitionFilterEffect((n) => Effect.succeed(n % 2 === 0 ? n : Filter.fail(n))),
           Effect.map(([evens, odds]) => pipe(evens, Stream.mergeResult(odds))),
           Effect.flatMap(Stream.runCollect),
           Effect.scoped
@@ -2846,11 +2846,11 @@ describe("Stream", () => {
         strictEqual(result, 0)
       }))
 
-    it.effect("partition - values", () =>
+    it.effect("partitionFilter - values", () =>
       Effect.gen(function*() {
         const { result1, result2 } = yield* pipe(
           Stream.range(0, 5),
-          Stream.partition((n) => n % 2 === 0 ? n : Filter.fail(n)),
+          Stream.partitionFilter((n) => n % 2 === 0 ? n : Filter.fail(n)),
           Effect.flatMap(([evens, odds]) =>
             Effect.all({
               result1: Stream.runCollect(evens),
@@ -2863,12 +2863,12 @@ describe("Stream", () => {
         deepStrictEqual(result2, [1, 3, 5])
       }))
 
-    it.effect("partition - errors", () =>
+    it.effect("partitionFilter - errors", () =>
       Effect.gen(function*() {
         const { result1, result2 } = yield* pipe(
           Stream.make(0),
           Stream.concat(Stream.fail("boom")),
-          Stream.partition((n) => n % 2 === 0 ? n : Filter.fail(n)),
+          Stream.partitionFilter((n) => n % 2 === 0 ? n : Filter.fail(n)),
           Effect.flatMap(([evens, odds]) =>
             Effect.all({
               result1: Effect.flip(Stream.runCollect(evens)),
@@ -2881,11 +2881,11 @@ describe("Stream", () => {
         assert.strictEqual(result2, "boom")
       }))
 
-    it.effect("partition - backpressure", () =>
+    it.effect("partitionFilter - backpressure", () =>
       Effect.gen(function*() {
         const { result1, result2, result3 } = yield* pipe(
           Stream.range(0, 5),
-          Stream.partition((n) => (n % 2 === 0 ? n : Filter.fail(n)), { capacity: 1 }),
+          Stream.partitionFilter((n) => (n % 2 === 0 ? n : Filter.fail(n)), { capacity: 1 }),
           Effect.flatMap(([evens, odds]) =>
             Effect.gen(function*() {
               const ref = yield* Ref.make(Array.empty<number>())


### PR DESCRIPTION
## Summary
- rename Stream partition APIs to partitionFilter naming
- update Stream partition tests for new exports

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Stream.test.ts
- pnpm check
- pnpm build
- pnpm docgen