### PR TITLE
EFF-253 add sqlite eventlog tests

### DIFF
--- a/packages/sql/sqlite-node/test/SqlEventLogJournal.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogJournal.test.ts
@@ -1,0 +1,84 @@
+import { SqliteClient } from "@effect/sql-sqlite-node"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
+import * as SqlEventLogJournal from "effect/unstable/eventlog/SqlEventLogJournal"
+import { Reactivity } from "effect/unstable/reactivity"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+
+const makeJournal = Effect.gen(function*() {
+  const sql = yield* SqliteClient.make({ filename: ":memory:" })
+  return yield* SqlEventLogJournal.make().pipe(
+    Effect.provideService(SqlClient.SqlClient, sql)
+  )
+}).pipe(Effect.provide(Reactivity.layer))
+
+describe("SqlEventLogJournal", () => {
+  it.effect("writes and reads entries", () =>
+    Effect.gen(function*() {
+      const journal = yield* makeJournal
+      let createdAt = 0
+      yield* journal.write({
+        event: "UserCreated",
+        primaryKey: "user-1",
+        payload: new Uint8Array([1]),
+        effect: (entry) =>
+          Effect.sync(() => {
+            createdAt = entry.createdAtMillis
+          })
+      })
+      const entries = yield* journal.entries
+      assert.strictEqual(entries.length, 1)
+      assert.strictEqual(entries[0].event, "UserCreated")
+      assert.strictEqual(entries[0].createdAtMillis, createdAt)
+    }))
+
+  it.effect("writes remote entries and sequences", () =>
+    Effect.gen(function*() {
+      const journal = yield* makeJournal
+      const remoteId = EventJournal.makeRemoteIdUnsafe()
+      const initial = yield* journal.nextRemoteSequence(remoteId)
+      assert.strictEqual(initial, 0)
+
+      const entryA = new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe(),
+        event: "UserCreated",
+        primaryKey: "user-2",
+        payload: new Uint8Array([2])
+      }, { disableValidation: true })
+      const entryB = new EventJournal.Entry({
+        id: EventJournal.makeEntryIdUnsafe(),
+        event: "UserCreated",
+        primaryKey: "user-3",
+        payload: new Uint8Array([3])
+      }, { disableValidation: true })
+      const remoteEntries = [
+        new EventJournal.RemoteEntry({ remoteSequence: 0, entry: entryA }),
+        new EventJournal.RemoteEntry({ remoteSequence: 1, entry: entryB })
+      ]
+      const seenConflicts: Array<ReadonlyArray<EventJournal.Entry>> = []
+      yield* journal.writeFromRemote({
+        remoteId,
+        entries: remoteEntries,
+        effect: ({ conflicts }) =>
+          Effect.sync(() => {
+            seenConflicts.push(conflicts)
+          })
+      })
+      const next = yield* journal.nextRemoteSequence(remoteId)
+      assert.strictEqual(next, 2)
+
+      yield* journal.write({
+        event: "LocalCreated",
+        primaryKey: "local-1",
+        payload: new Uint8Array([4]),
+        effect: () => Effect.void
+      })
+      const uncommitted = yield* journal.withRemoteUncommited(remoteId, (entries) => Effect.succeed(entries))
+      assert.strictEqual(uncommitted.length, 1)
+      assert.strictEqual(uncommitted[0].event, "LocalCreated")
+      assert.strictEqual(seenConflicts.length, 2)
+      assert.strictEqual(seenConflicts[0][0]?.idString, entryA.idString)
+      assert.strictEqual(seenConflicts[1][0]?.idString, entryB.idString)
+    }))
+})

--- a/packages/sql/sqlite-node/test/SqlEventLogServer.test.ts
+++ b/packages/sql/sqlite-node/test/SqlEventLogServer.test.ts
@@ -1,0 +1,83 @@
+import { SqliteClient } from "@effect/sql-sqlite-node"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Queue } from "effect"
+import * as EventJournal from "effect/unstable/eventlog/EventJournal"
+import * as EventLog from "effect/unstable/eventlog/EventLog"
+import * as EventLogEncryption from "effect/unstable/eventlog/EventLogEncryption"
+import * as EventLogServer from "effect/unstable/eventlog/EventLogServer"
+import * as SqlEventLogServer from "effect/unstable/eventlog/SqlEventLogServer"
+import { Reactivity } from "effect/unstable/reactivity"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+
+const makeEntry = (value: number) =>
+  new EventJournal.Entry({
+    id: EventJournal.makeEntryIdUnsafe(),
+    event: "UserCreated",
+    primaryKey: `user-${value}`,
+    payload: new Uint8Array([value])
+  }, { disableValidation: true })
+
+const persistEntries = (
+  encryption: EventLogEncryption.EventLogEncryption["Service"],
+  identity: EventLog.Identity["Service"],
+  entries: ReadonlyArray<EventJournal.Entry>
+) =>
+  Effect.gen(function*() {
+    const encrypted = yield* encryption.encrypt(identity, entries)
+    return encrypted.encryptedEntries.map((encryptedEntry, index) =>
+      new EventLogServer.PersistedEntry({
+        entryId: entries[index].id,
+        iv: encrypted.iv,
+        encryptedEntry
+      })
+    )
+  })
+
+describe("SqlEventLogServer", () => {
+  it.effect("persists remote id across storage instances", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const sql = yield* SqliteClient.make({ filename: ":memory:" })
+        const storageA = yield* SqlEventLogServer.makeStorage().pipe(
+          Effect.provideService(SqlClient.SqlClient, sql)
+        )
+        const storageB = yield* SqlEventLogServer.makeStorage().pipe(
+          Effect.provideService(SqlClient.SqlClient, sql)
+        )
+        const idA = yield* storageA.getId
+        const idB = yield* storageB.getId
+        assert.deepStrictEqual(idA, idB)
+      })
+    ).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+
+  it.effect("writes entries and streams changes", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const sql = yield* SqliteClient.make({ filename: ":memory:" })
+        const storage = yield* SqlEventLogServer.makeStorage().pipe(
+          Effect.provideService(SqlClient.SqlClient, sql)
+        )
+        const encryption = yield* EventLogEncryption.EventLogEncryption
+        const identity = EventLog.makeIdentityUnsafe()
+        const entries = [makeEntry(1), makeEntry(2)]
+        const persisted = yield* persistEntries(encryption, identity, entries)
+        const written = yield* storage.write(identity.publicKey, persisted)
+        assert.deepStrictEqual(written.map((entry) => entry.sequence), [1, 2])
+
+        const stored = yield* storage.entries(identity.publicKey, 0)
+        assert.deepStrictEqual(stored.map((entry) => entry.sequence), [1, 2])
+
+        const changes = yield* storage.changes(identity.publicKey, 0)
+        const initial = yield* Queue.takeAll(changes)
+        assert.deepStrictEqual(initial.map((entry) => entry.sequence), [1, 2])
+
+        const nextEntry = makeEntry(3)
+        const nextPersisted = yield* persistEntries(encryption, identity, [nextEntry])
+        const updated = yield* storage.write(identity.publicKey, nextPersisted)
+        assert.deepStrictEqual(updated.map((entry) => entry.sequence), [3])
+
+        const next = yield* Queue.take(changes)
+        assert.strictEqual(next.sequence, 3)
+      })
+    ).pipe(Effect.provide([Reactivity.layer, EventLogEncryption.layerSubtle])))
+})


### PR DESCRIPTION
## Summary
- add sqlite-backed SqlEventLogJournal tests for local/remote sequencing
- add sqlite-backed SqlEventLogServer tests for storage ids, entries, and changes