### PR TITLE
EFF-255: add Flag.withFallbackConfig

### DIFF
--- a/packages/effect/src/unstable/cli/Flag.ts
+++ b/packages/effect/src/unstable/cli/Flag.ts
@@ -1,6 +1,7 @@
 /**
  * @since 4.0.0
  */
+import type * as Config from "../../Config.ts"
 import type * as Effect from "../../Effect.ts"
 import type * as FileSystem from "../../FileSystem.ts"
 import { dual, type LazyArg } from "../../Function.ts"
@@ -497,6 +498,27 @@ export const withDefault: {
   <A>(defaultValue: A): (self: Flag<A>) => Flag<A>
   <A>(self: Flag<A>, defaultValue: A): Flag<A>
 } = dual(2, <A>(self: Flag<A>, defaultValue: A) => Param.withDefault(self, defaultValue))
+
+/**
+ * Uses a config value when a flag is not provided.
+ *
+ * @example
+ * ```ts
+ * import { Config } from "effect"
+ * import { Flag } from "effect/unstable/cli"
+ *
+ * const verbose = Flag.boolean("verbose").pipe(
+ *   Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+ * )
+ * ```
+ *
+ * @since 4.0.0
+ * @category optionality
+ */
+export const withFallbackConfig: {
+  <B>(config: Config.Config<B>): <A>(self: Flag<A>) => Flag<A | B>
+  <A, B>(self: Flag<A>, config: Config.Config<B>): Flag<A | B>
+} = dual(2, <A, B>(self: Flag<A>, config: Config.Config<B>) => Param.withFallbackConfig(self, config))
 
 /**
  * Transforms the parsed value of a flag using a mapping function.

--- a/packages/effect/test/unstable/cli/Flag.test.ts
+++ b/packages/effect/test/unstable/cli/Flag.test.ts
@@ -1,0 +1,60 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Config, ConfigProvider, Effect, FileSystem, Layer, Path } from "effect"
+import { CliError, Command, Flag } from "effect/unstable/cli"
+import { toImpl } from "effect/unstable/cli/internal/command"
+import * as Lexer from "effect/unstable/cli/internal/lexer"
+import * as Parser from "effect/unstable/cli/internal/parser"
+import * as MockTerminal from "./services/MockTerminal.ts"
+
+const BaseLayer = Layer.mergeAll(FileSystem.layerNoop({}), Path.layer, MockTerminal.layer)
+
+describe("Flag.withFallbackConfig", () => {
+  it.effect("uses config value when flag is missing", () =>
+    Effect.gen(function*() {
+      const command = Command.make("git", {
+        verbose: Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+      })
+
+      const parsedInput = yield* Parser.parseArgs(Lexer.lex([]), command)
+      const result = yield* toImpl(command).parse(parsedInput)
+
+      assert.isTrue(result.verbose)
+    }).pipe(Effect.provide(Layer.mergeAll(
+      BaseLayer,
+      ConfigProvider.layer(ConfigProvider.fromEnv({ env: { VERBOSE: "true" } }))
+    ))))
+
+  it.effect("fails when config and flag are missing", () =>
+    Effect.gen(function*() {
+      const command = Command.make("git", {
+        verbose: Flag.boolean("verbose").pipe(
+          Flag.withFallbackConfig(Config.boolean("VERBOSE"))
+        )
+      })
+
+      const parsedInput = yield* Parser.parseArgs(Lexer.lex([]), command)
+      const error = yield* Effect.flip(toImpl(command).parse(parsedInput))
+
+      assert.instanceOf(error, CliError.MissingOption)
+      assert.strictEqual(error.option, "verbose")
+    }).pipe(Effect.provide(BaseLayer)))
+
+  it.effect("maps config failures to InvalidValue", () =>
+    Effect.gen(function*() {
+      const command = Command.make("port", {
+        port: Flag.integer("port").pipe(
+          Flag.withFallbackConfig(Config.int("PORT"))
+        )
+      })
+
+      const parsedInput = yield* Parser.parseArgs(Lexer.lex([]), command)
+      const error = yield* Effect.flip(toImpl(command).parse(parsedInput))
+
+      assert.instanceOf(error, CliError.InvalidValue)
+    }).pipe(Effect.provide(Layer.mergeAll(
+      BaseLayer,
+      ConfigProvider.layer(ConfigProvider.fromEnv({ env: { PORT: "nope" } }))
+    ))))
+})


### PR DESCRIPTION
## Summary
- add Param/Flag support for config-based fallbacks, including boolean flag handling and config error mapping
- add CLI flag fallback tests covering config values, missing config, and invalid config input