### PR TITLE
EFF-257 add Param fallback prompt support

### DIFF
--- a/packages/effect/src/unstable/cli/Argument.ts
+++ b/packages/effect/src/unstable/cli/Argument.ts
@@ -2,10 +2,8 @@
  * @since 4.0.0
  */
 import type * as Effect from "../../Effect.ts"
-import type * as FileSystem from "../../FileSystem.ts"
 import { dual, type LazyArg } from "../../Function.ts"
 import type * as Option from "../../Option.ts"
-import type * as Path from "../../Path.ts"
 import type * as Redacted from "../../Redacted.ts"
 import type * as Result from "../../Result.ts"
 import type * as Schema from "../../Schema.ts"
@@ -400,7 +398,7 @@ export const mapEffect: {
   ): Argument<B>
 } = dual(2, <A, B>(
   self: Argument<A>,
-  f: (a: A) => Effect.Effect<B, CliError.CliError, FileSystem.FileSystem | Path.Path>
+  f: (a: A) => Effect.Effect<B, CliError.CliError, Environment>
 ) => Param.mapEffect(self, f))
 
 /**

--- a/packages/effect/src/unstable/cli/Flag.ts
+++ b/packages/effect/src/unstable/cli/Flag.ts
@@ -2,10 +2,8 @@
  * @since 4.0.0
  */
 import type * as Effect from "../../Effect.ts"
-import type * as FileSystem from "../../FileSystem.ts"
 import { dual, type LazyArg } from "../../Function.ts"
 import type * as Option from "../../Option.ts"
-import type * as Path from "../../Path.ts"
 import type * as Redacted from "../../Redacted.ts"
 import type * as Result from "../../Result.ts"
 import type * as Schema from "../../Schema.ts"
@@ -547,15 +545,15 @@ export const map: {
  */
 export const mapEffect: {
   <A, B>(
-    f: (a: A) => Effect.Effect<B, CliError.CliError, FileSystem.FileSystem | Path.Path>
+    f: (a: A) => Effect.Effect<B, CliError.CliError, Param.Environment>
   ): (self: Flag<A>) => Flag<B>
   <A, B>(
     self: Flag<A>,
-    f: (a: A) => Effect.Effect<B, CliError.CliError, FileSystem.FileSystem | Path.Path>
+    f: (a: A) => Effect.Effect<B, CliError.CliError, Param.Environment>
   ): Flag<B>
 } = dual(2, <A, B>(
   self: Flag<A>,
-  f: (a: A) => Effect.Effect<B, CliError.CliError, FileSystem.FileSystem | Path.Path>
+  f: (a: A) => Effect.Effect<B, CliError.CliError, Param.Environment>
 ) => Param.mapEffect(self, f))
 
 /**

--- a/packages/effect/src/unstable/cli/internal/parser.ts
+++ b/packages/effect/src/unstable/cli/internal/parser.ts
@@ -25,10 +25,8 @@
  * - Errors accumulate rather than throwing exceptions
  */
 import * as Effect from "../../../Effect.ts"
-import type { FileSystem } from "../../../FileSystem.ts"
 import type { LogLevel } from "../../../LogLevel.ts"
 import * as Option from "../../../Option.ts"
-import type { Path } from "../../../Path.ts"
 import * as CliError from "../CliError.ts"
 import type { Command, ParsedTokens } from "../Command.ts"
 import * as Param from "../Param.ts"
@@ -60,7 +58,7 @@ export const extractBuiltInOptions = (
     remainder: ReadonlyArray<Token>
   },
   CliError.CliError,
-  FileSystem | Path
+  Param.Environment
 > =>
   Effect.gen(function*() {
     const { flagMap, remainder } = consumeKnownFlags(tokens, builtInFlagRegistry)
@@ -83,7 +81,7 @@ export const parseArgs = (
   lexResult: LexResult,
   command: Command.Any,
   commandPath: ReadonlyArray<string> = []
-): Effect.Effect<ParsedTokens, CliError.CliError, FileSystem | Path> =>
+): Effect.Effect<ParsedTokens, CliError.CliError, Param.Environment> =>
   Effect.gen(function*() {
     const { tokens, trailingOperands: afterEndOfOptions } = lexResult
     const newCommandPath = [...commandPath, command.name]


### PR DESCRIPTION
## Summary
- add Param.Environment and propagate mapEffect parsing env changes to Param/Flag/Argument/parser
- implement Param.withFallbackPrompt to prompt on missing values and keep prompt wrappers through single transforms

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Arguments.test.ts
- pnpm check
- pnpm build
- pnpm docgen