### PR TITLE
EFF-258 add fallback prompt combinators

### DIFF
--- a/packages/effect/src/unstable/cli/Argument.ts
+++ b/packages/effect/src/unstable/cli/Argument.ts
@@ -11,6 +11,7 @@ import type * as CliError from "./CliError.ts"
 import type { Environment } from "./Command.ts"
 import * as Param from "./Param.ts"
 import type * as Primitive from "./Primitive.ts"
+import type * as Prompt from "./Prompt.ts"
 
 // -------------------------------------------------------------------------------------
 // models
@@ -311,6 +312,26 @@ export const withDefault: {
   <A>(defaultValue: A): (self: Argument<A>) => Argument<A>
   <A>(self: Argument<A>, defaultValue: A): Argument<A>
 } = dual(2, <A>(self: Argument<A>, defaultValue: A) => Param.withDefault(self, defaultValue))
+
+/**
+ * Adds a fallback prompt that is shown when a required argument is missing.
+ *
+ * @example
+ * ```ts
+ * import { Argument, Prompt } from "effect/unstable/cli"
+ *
+ * const filename = Argument.string("filename").pipe(
+ *   Argument.withFallbackPrompt(Prompt.text({ message: "Filename" }))
+ * )
+ * ```
+ *
+ * @since 4.0.0
+ * @category combinators
+ */
+export const withFallbackPrompt: {
+  <B>(prompt: Prompt.Prompt<B>): <A>(self: Argument<A>) => Argument<A | B>
+  <A, B>(self: Argument<A>, prompt: Prompt.Prompt<B>): Argument<A | B>
+} = dual(2, <A, B>(self: Argument<A>, prompt: Prompt.Prompt<B>) => Param.withFallbackPrompt(self, prompt))
 
 /**
  * Creates a variadic positional argument that accepts multiple values.

--- a/packages/effect/src/unstable/cli/Flag.ts
+++ b/packages/effect/src/unstable/cli/Flag.ts
@@ -10,6 +10,7 @@ import type * as Schema from "../../Schema.ts"
 import type * as CliError from "./CliError.ts"
 import * as Param from "./Param.ts"
 import type * as Primitive from "./Primitive.ts"
+import type * as Prompt from "./Prompt.ts"
 
 // -------------------------------------------------------------------------------------
 // models
@@ -495,6 +496,26 @@ export const withDefault: {
   <A>(defaultValue: A): (self: Flag<A>) => Flag<A>
   <A>(self: Flag<A>, defaultValue: A): Flag<A>
 } = dual(2, <A>(self: Flag<A>, defaultValue: A) => Param.withDefault(self, defaultValue))
+
+/**
+ * Adds a fallback prompt that is shown when a required flag is missing.
+ *
+ * @example
+ * ```ts
+ * import { Flag, Prompt } from "effect/unstable/cli"
+ *
+ * const name = Flag.string("name").pipe(
+ *   Flag.withFallbackPrompt(Prompt.text({ message: "Name" }))
+ * )
+ * ```
+ *
+ * @since 4.0.0
+ * @category combinators
+ */
+export const withFallbackPrompt: {
+  <B>(prompt: Prompt.Prompt<B>): <A>(self: Flag<A>) => Flag<A | B>
+  <A, B>(self: Flag<A>, prompt: Prompt.Prompt<B>): Flag<A | B>
+} = dual(2, <A, B>(self: Flag<A>, prompt: Prompt.Prompt<B>) => Param.withFallbackPrompt(self, prompt))
 
 /**
  * Transforms the parsed value of a flag using a mapping function.


### PR DESCRIPTION
## Summary
- add Flag.withFallbackPrompt and Argument.withFallbackPrompt wrappers with Prompt types and docs

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Arguments.test.ts
- pnpm check
- pnpm build
- pnpm docgen