### PR TITLE
EFF-259 add fallback prompt tests

### DIFF
--- a/packages/effect/test/unstable/cli/FallbackPrompt.test.ts
+++ b/packages/effect/test/unstable/cli/FallbackPrompt.test.ts
@@ -1,0 +1,159 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, FileSystem, Layer, Path } from "effect"
+import { TestConsole } from "effect/testing"
+import { Argument, CliError, Flag, Prompt } from "effect/unstable/cli"
+import * as MockTerminal from "./services/MockTerminal.ts"
+
+const ConsoleLayer = TestConsole.layer
+const FileSystemLayer = FileSystem.layerNoop({})
+const PathLayer = Path.layer
+const TerminalLayer = MockTerminal.layer
+
+const TestLayer = Layer.mergeAll(
+  ConsoleLayer,
+  FileSystemLayer,
+  PathLayer,
+  TerminalLayer
+)
+
+describe("Fallback prompts", () => {
+  it.effect("prompts for missing flag values and preserves remaining args", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Name" })
+      const flag = Flag.string("name").pipe(Flag.withFallbackPrompt(prompt))
+
+      yield* MockTerminal.inputText("Chandra")
+      yield* MockTerminal.inputKey("enter")
+
+      const [remaining, value] = yield* flag.parse({
+        flags: {},
+        arguments: ["tail"]
+      })
+
+      assert.strictEqual(value, "Chandra")
+      assert.deepStrictEqual(remaining, ["tail"])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not prompt when flag value is provided", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Name" })
+      const flag = Flag.string("name").pipe(Flag.withFallbackPrompt(prompt))
+
+      const [, value] = yield* flag.parse({
+        flags: { name: ["Ava"] },
+        arguments: []
+      })
+
+      assert.strictEqual(value, "Ava")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("prompts for missing arguments", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "File" })
+      const argument = Argument.string("file").pipe(Argument.withFallbackPrompt(prompt))
+
+      yield* MockTerminal.inputText("notes.txt")
+      yield* MockTerminal.inputKey("enter")
+
+      const [remaining, value] = yield* argument.parse({
+        flags: {},
+        arguments: []
+      })
+
+      assert.strictEqual(value, "notes.txt")
+      assert.deepStrictEqual(remaining, [])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("prefers defaults over fallback prompts", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Name" })
+      const flag = Flag.string("name").pipe(
+        Flag.withDefault("guest"),
+        Flag.withFallbackPrompt(prompt)
+      )
+
+      const [, value] = yield* flag.parse({
+        flags: {},
+        arguments: []
+      })
+
+      assert.strictEqual(value, "guest")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not prompt for invalid flag values", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Count" })
+      const flag = Flag.integer("count").pipe(Flag.withFallbackPrompt(prompt))
+
+      const error = yield* Effect.flip(
+        flag.parse({
+          flags: { count: ["nope"] },
+          arguments: []
+        })
+      )
+
+      assert.instanceOf(error, CliError.InvalidValue)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not prompt for invalid argument values", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Count" })
+      const argument = Argument.integer("count").pipe(Argument.withFallbackPrompt(prompt))
+
+      const error = yield* Effect.flip(
+        argument.parse({
+          flags: {},
+          arguments: ["nope"]
+        })
+      )
+
+      assert.instanceOf(error, CliError.InvalidValue)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not prompt for missing boolean flags", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Verbose" })
+      const flag = Flag.boolean("verbose").pipe(Flag.withFallbackPrompt(prompt))
+
+      const [, value] = yield* flag.parse({
+        flags: {},
+        arguments: []
+      })
+
+      assert.strictEqual(value, false)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("returns MissingOption when prompt is cancelled", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "Name" })
+      const flag = Flag.string("name").pipe(Flag.withFallbackPrompt(prompt))
+
+      yield* MockTerminal.inputKey("c", { ctrl: true })
+
+      const error = yield* Effect.flip(
+        flag.parse({
+          flags: {},
+          arguments: []
+        })
+      )
+
+      assert.instanceOf(error, CliError.MissingOption)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("returns MissingArgument when argument prompt is cancelled", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({ message: "File" })
+      const argument = Argument.string("file").pipe(Argument.withFallbackPrompt(prompt))
+
+      yield* MockTerminal.inputKey("c", { ctrl: true })
+
+      const error = yield* Effect.flip(
+        argument.parse({
+          flags: {},
+          arguments: []
+        })
+      )
+
+      assert.instanceOf(error, CliError.MissingArgument)
+    }).pipe(Effect.provide(TestLayer)))
+})

--- a/packages/effect/test/unstable/cli/services/MockTerminal.ts
+++ b/packages/effect/test/unstable/cli/services/MockTerminal.ts
@@ -30,7 +30,7 @@ export declare namespace MockTerminal {
 // =============================================================================
 
 export const MockTerminal = ServiceMap.Service<Terminal.Terminal, MockTerminal>()(
-  "@effect/platform/Terminal"
+  "effect/platform/Terminal"
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- add fallback prompt tests for flags and arguments using MockTerminal input
- cover default precedence, invalid inputs, boolean defaults, and cancellation behavior
- align MockTerminal terminal service tag with core Terminal