### PR TITLE
EFF-260 align MockTerminal service tag

### DIFF
--- a/packages/effect/test/unstable/cli/services/MockTerminal.ts
+++ b/packages/effect/test/unstable/cli/services/MockTerminal.ts
@@ -30,7 +30,7 @@ export declare namespace MockTerminal {
 // =============================================================================
 
 export const MockTerminal = ServiceMap.Service<Terminal.Terminal, MockTerminal>()(
-  "effect/platform/Terminal"
+  Terminal.Terminal.key
 )
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- align MockTerminal's service key with Terminal.Terminal.key for CLI prompt resolution
- keep CLI test helpers providing the same Terminal service tag

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/FallbackPrompt.test.ts
- pnpm check
- pnpm build
- pnpm docgen