### PR TITLE
Add Decoder and Encoder views

### DIFF
--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -1491,7 +1491,7 @@ function mergeChecks(checks: Checks | undefined, b: AST): Checks | undefined {
 }
 
 /** @internal */
-export function Struct<Fields extends Schema.Struct.Fields>(
+export function struct<Fields extends Schema.Struct.Fields>(
   fields: Fields,
   checks: Checks | undefined,
   annotations?: Schema.Annotations.Annotations
@@ -1529,7 +1529,7 @@ export function union<Members extends ReadonlyArray<Schema.Top>>(
 }
 
 /** @internal */
-export function StructWithRest(ast: Objects, records: ReadonlyArray<Objects>): Objects {
+export function structWithRest(ast: Objects, records: ReadonlyArray<Objects>): Objects {
   if (ast.encoding || records.some((r) => r.encoding)) {
     throw new Error("StructWithRest does not support encodings")
   }


### PR DESCRIPTION
```ts
/**
 * A `Codec` view intended for APIs that only *decode* (parse/validate) values.
 *
 * When to use:
 * - You want to accept "anything that can decode to `T`", without requiring encoding support.
 * - You are writing helpers that should not depend on the schema’s `Encoded` representation.
 *
 * @since 4.0.0
 */
export interface Decoder<out T, out RD = never> extends Codec<T, unknown, RD, unknown> {}

/**
 * A `Codec` view intended for APIs that only *encode* values.
 *
 * When to use:
 * - You want to accept "anything that can encode to `E`", without requiring decoding support.
 * - You are writing helpers that should not depend on the schema’s decoded `Type`.
 *
 * @since 4.0.0
 */
export interface Encoder<out E, out RE = never> extends Codec<unknown, E, unknown, RE> {}
```