### PR TITLE
EFF-265 Add ChildProcess.prefix api

### DIFF
--- a/packages/effect/test/unstable/process/ChildProcess.test.ts
+++ b/packages/effect/test/unstable/process/ChildProcess.test.ts
@@ -162,6 +162,28 @@ describe("ChildProcess", () => {
     })
   })
 
+  describe("prefix", () => {
+    it("should create a prefixed command", () => {
+      const command = ChildProcess.make("echo", ["hello"])
+      const prefixed = command.pipe(ChildProcess.prefix`time`)
+      assert.strictEqual(prefixed._tag, "PrefixedCommand")
+      if (prefixed._tag === "PrefixedCommand") {
+        assert.strictEqual(prefixed.prefix._tag, "TemplatedCommand")
+        assert.strictEqual(prefixed.command._tag, "StandardCommand")
+      }
+    })
+
+    it("should accept standard prefix commands", () => {
+      const prefix = ChildProcess.make("env", ["-i"])
+      const command = ChildProcess.make("echo", ["hello"])
+      const prefixed = ChildProcess.prefix(prefix)(command)
+      assert.strictEqual(prefixed._tag, "PrefixedCommand")
+      if (prefixed._tag === "PrefixedCommand" && prefixed.prefix._tag === "StandardCommand") {
+        assert.deepStrictEqual(prefixed.prefix.args, ["-i"])
+      }
+    })
+  })
+
   describe("guards", () => {
     it("isCommand should detect commands", () => {
       const cmd = ChildProcess.make`echo hello`
@@ -199,6 +221,13 @@ describe("ChildProcess", () => {
       )
       assert.isFalse(ChildProcess.isPipedCommand(single))
       assert.isTrue(ChildProcess.isPipedCommand(piped))
+    })
+
+    it("isPrefixedCommand should detect prefixed commands", () => {
+      const command = ChildProcess.make("echo", ["hello"])
+      const prefixed = command.pipe(ChildProcess.prefix`time`)
+      assert.isFalse(ChildProcess.isPrefixedCommand(command))
+      assert.isTrue(ChildProcess.isPrefixedCommand(prefixed))
     })
   })
 

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -872,4 +872,17 @@ describe("NodeChildProcessSpawner", () => {
         }).pipe(Effect.scoped))
     })
   })
+
+  describe("flattenCommand", () => {
+    it("should apply prefix to the leftmost command", () => {
+      const command = ChildProcess.make("echo", ["hello"])
+      const prefixed = command.pipe(ChildProcess.prefix`time`)
+      const { commands, pipeOptions } = NodeChildProcessSpawner.flattenCommand(prefixed)
+      assert.strictEqual(commands.length, 1)
+      assert.strictEqual(pipeOptions.length, 0)
+      const [first] = commands
+      assert.strictEqual(first.command, "time")
+      assert.deepStrictEqual(first.args, ["echo", "hello"])
+    })
+  })
 })


### PR DESCRIPTION
## Summary\n- add PrefixedCommand and ChildProcess.prefix combinator\n- apply prefixes in NodeChildProcessSpawner flattening/spawning\n- cover prefix behavior in ChildProcess and NodeChildProcessSpawner tests\n\n## Testing\n- pnpm lint-fix\n- pnpm test packages/effect/test/unstable/process/ChildProcess.test.ts\n- pnpm test packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts\n- pnpm check\n- pnpm build\n- pnpm docgen