### PR TITLE
EFF-265 Add ChildProcess.prefix api

### DIFF
--- a/packages/effect/test/unstable/process/ChildProcess.test.ts
+++ b/packages/effect/test/unstable/process/ChildProcess.test.ts
@@ -153,12 +153,10 @@ describe("ChildProcess", () => {
       const command = ChildProcess.make("echo", ["hello"], { cwd: "/tmp", env: { TEST: "1" } })
       const prefixed = command.pipe(ChildProcess.prefix`time`)
       assert(prefixed._tag === "StandardCommand")
-      if (prefixed._tag === "StandardCommand") {
-        assert.strictEqual(prefixed.command, "time")
-        assert.deepStrictEqual(prefixed.args, ["echo", "hello"])
-        assert.strictEqual(prefixed.options.cwd, "/tmp")
-        assert.deepStrictEqual(prefixed.options.env, { TEST: "1" })
-      }
+      assert.strictEqual(prefixed.command, "time")
+      assert.deepStrictEqual(prefixed.args, ["echo", "hello"])
+      assert.strictEqual(prefixed.options.cwd, "/tmp")
+      assert.deepStrictEqual(prefixed.options.env, { TEST: "1" })
     })
 
     it("should prefix the leftmost command in a pipeline", () => {
@@ -166,33 +164,28 @@ describe("ChildProcess", () => {
         ChildProcess.pipeTo(ChildProcess.make`grep pattern`),
         ChildProcess.pipeTo(ChildProcess.make`wc -l`, { from: "stderr" })
       )
+
       const prefixed = pipeline.pipe(ChildProcess.prefix`time`)
       assert(prefixed._tag === "PipedCommand")
-      if (prefixed._tag === "PipedCommand") {
-        assert.strictEqual(prefixed.options.from, "stderr")
-        const left = prefixed.left
-        assert(left._tag === "PipedCommand")
-        if (left._tag === "PipedCommand") {
-          const leftmost = left.left
-          assert(leftmost._tag === "StandardCommand")
-          if (leftmost._tag === "StandardCommand") {
-            assert.strictEqual(leftmost.command, "time")
-            assert.deepStrictEqual(leftmost.args, ["cat", "file"])
-          }
-          const middle = left.right
-          assert(middle._tag === "StandardCommand")
-          if (middle._tag === "StandardCommand") {
-            assert.strictEqual(middle.command, "grep")
-            assert.deepStrictEqual(middle.args, ["pattern"])
-          }
-        }
-        const right = prefixed.right
-        assert(right._tag === "StandardCommand")
-        if (right._tag === "StandardCommand") {
-          assert.strictEqual(right.command, "wc")
-          assert.deepStrictEqual(right.args, ["-l"])
-        }
-      }
+      assert.strictEqual(prefixed.options.from, "stderr")
+
+      const left = prefixed.left
+      assert(left._tag === "PipedCommand")
+
+      const leftmost = left.left
+      assert(leftmost._tag === "StandardCommand")
+      assert.strictEqual(leftmost.command, "time")
+      assert.deepStrictEqual(leftmost.args, ["cat", "file"])
+
+      const middle = left.right
+      assert(middle._tag === "StandardCommand")
+      assert.strictEqual(middle.command, "grep")
+      assert.deepStrictEqual(middle.args, ["pattern"])
+
+      const right = prefixed.right
+      assert(right._tag === "StandardCommand")
+      assert.strictEqual(right.command, "wc")
+      assert.deepStrictEqual(right.args, ["-l"])
     })
   })
 


### PR DESCRIPTION
## Summary
- add ChildProcess.prefix combinator that rewrites the leftmost command while preserving options
- add tests for prefix behavior on standard commands and pipelines

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/process/ChildProcess.test.ts
- pnpm check
- pnpm build
- pnpm docgen