### PR TITLE
EFF-269 Refactor HttpClientError reasons

### DIFF
--- a/.specs/http-client-error-reason-pattern.md
+++ b/.specs/http-client-error-reason-pattern.md
@@ -85,12 +85,14 @@ Behavior:
 Before:
 
 ```ts
-Effect.fail(new HttpClientError.RequestError({
-  request,
-  reason: "InvalidUrl",
-  description: "Invalid base URL",
-  cause
-}))
+Effect.fail(
+  new HttpClientError.RequestError({
+    request,
+    reason: "InvalidUrl",
+    description: "Invalid base URL",
+    cause
+  })
+)
 ```
 
 After:
@@ -119,9 +121,7 @@ Effect.catchTag("HttpClientError", (error) => {
 With `Effect.catchReason`:
 
 ```ts
-Effect.catchReason("HttpClientError", "StatusCodeError", (reason) =>
-  Effect.logError(reason.message)
-)
+Effect.catchReason("HttpClientError", "StatusCodeError", (reason) => Effect.logError(reason.message))
 ```
 
 ## Impacted Areas

--- a/.specs/worker-error-reason-pattern.md
+++ b/.specs/worker-error-reason-pattern.md
@@ -1,4 +1,3 @@
-
 **Status: DRAFT**
 
 ## Overview
@@ -92,12 +91,14 @@ The top-level `WorkerError` schema should no longer include `message` or `cause`
 All call sites should construct a reason class and wrap it in `WorkerError`:
 
 ```ts
-return Effect.fail(new WorkerError({
-  reason: new WorkerSendError({
-    message: "Failed to send message to worker",
-    cause
+return Effect.fail(
+  new WorkerError({
+    reason: new WorkerSendError({
+      message: "Failed to send message to worker",
+      cause
+    })
   })
-}))
+)
 ```
 
 No legacy literal support is required.

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -25214,11 +25214,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description)
+          HttpClientError.make({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description)
+            })
           })
         )
     )

--- a/packages/effect/src/unstable/cluster/K8sHttpClient.ts
+++ b/packages/effect/src/unstable/cluster/K8sHttpClient.ts
@@ -12,7 +12,7 @@ import * as Schedule from "../../Schedule.ts"
 import * as Schema from "../../Schema.ts"
 import * as ServiceMap from "../../ServiceMap.ts"
 import * as HttpClient from "../http/HttpClient.ts"
-import type * as HttpClientError from "../http/HttpClientError.ts"
+import * as HttpClientError from "../http/HttpClientError.ts"
 import * as HttpClientRequest from "../http/HttpClientRequest.ts"
 import * as HttpClientResponse from "../http/HttpClientResponse.ts"
 
@@ -122,7 +122,11 @@ export const makeCreatePod = Effect.gen(function*() {
         schedule: Schedule.spaced("1 seconds")
       }),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          HttpClientError.isHttpClientError(err) && err.reason._tag === "StatusCodeError"
+            && err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.succeedNone
       ),
       Effect.orDie
@@ -130,7 +134,11 @@ export const makeCreatePod = Effect.gen(function*() {
     const isPodFound = readPodRaw.pipe(
       Effect.as(true),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          HttpClientError.isHttpClientError(err) && err.reason._tag === "StatusCodeError"
+            && err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.succeed(false)
       )
     )
@@ -138,7 +146,11 @@ export const makeCreatePod = Effect.gen(function*() {
       HttpClientRequest.bodyJsonUnsafe(spec),
       client.execute,
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 409 ? err : Filter.fail(err),
+        (err) =>
+          HttpClientError.isHttpClientError(err) && err.reason._tag === "StatusCodeError"
+            && err.reason.response.status === 409
+            ? err
+            : Filter.fail(err),
         () => readPod
       ),
       Effect.tapCause(Effect.logInfo),
@@ -148,7 +160,11 @@ export const makeCreatePod = Effect.gen(function*() {
       client.execute,
       Effect.flatMap((res) => res.json),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          HttpClientError.isHttpClientError(err) && err.reason._tag === "StatusCodeError"
+            && err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.void
       ),
       Effect.tapCause(Effect.logInfo),

--- a/packages/effect/src/unstable/http/FetchHttpClient.ts
+++ b/packages/effect/src/unstable/http/FetchHttpClient.ts
@@ -7,7 +7,7 @@ import * as ServiceMap from "../../ServiceMap.ts"
 import * as Stream from "../../Stream.ts"
 import * as Headers from "./Headers.ts"
 import * as HttpClient from "./HttpClient.ts"
-import { RequestError } from "./HttpClientError.ts"
+import * as HttpClientError from "./HttpClientError.ts"
 import * as HttpClientResponse from "./HttpClientResponse.ts"
 
 /**
@@ -43,10 +43,11 @@ const fetch: HttpClient.HttpClient = HttpClient.make((request, url, signal, fibe
             signal
           } as any),
         catch: (cause) =>
-          new RequestError({
-            request,
-            reason: "Transport",
-            cause
+          HttpClientError.make({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause
+            })
           })
       }),
       (response) => HttpClientResponse.fromWeb(request, response)

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -478,11 +478,11 @@ export const filterOrFail: {
  * @category filters
  */
 export const filterStatus: {
-  (f: (status: number) => boolean): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | Error.ResponseError, R>
-  <E, R>(self: HttpClient.With<E, R>, f: (status: number) => boolean): HttpClient.With<E | Error.ResponseError, R>
+  (f: (status: number) => boolean): <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | Error.HttpClientError, R>
+  <E, R>(self: HttpClient.With<E, R>, f: (status: number) => boolean): HttpClient.With<E | Error.HttpClientError, R>
 } = dual(
   2,
-  <E, R>(self: HttpClient.With<E, R>, f: (status: number) => boolean): HttpClient.With<E | Error.ResponseError, R> =>
+  <E, R>(self: HttpClient.With<E, R>, f: (status: number) => boolean): HttpClient.With<E | Error.HttpClientError, R> =>
     transformResponse(self, Effect.flatMap(HttpClientResponse.filterStatus(f)))
 )
 
@@ -492,7 +492,7 @@ export const filterStatus: {
  * @since 4.0.0
  * @category filters
  */
-export const filterStatusOk: <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | Error.ResponseError, R> =
+export const filterStatusOk: <E, R>(self: HttpClient.With<E, R>) => HttpClient.With<E | Error.HttpClientError, R> =
   transformResponse(Effect.flatMap(HttpClientResponse.filterStatusOk))
 
 /**
@@ -553,7 +553,12 @@ export const make = (
         const controller = scopedController ?? new AbortController()
         const urlResult = UrlParams.makeUrl(request.url, request.urlParams, request.hash)
         if (Result.isFailure(urlResult)) {
-          return Effect.fail(new Error.RequestError({ request, reason: "InvalidUrl", cause: urlResult.failure }))
+          return Effect.fail(Error.make({
+            reason: new Error.InvalidUrlError({
+              request,
+              cause: urlResult.failure
+            })
+          }))
         }
         const url = urlResult.success
         const tracerDisabled = fiber.getRef(Tracer.DisablePropagation) ||
@@ -1189,8 +1194,8 @@ const isTransientError = (error: unknown) => Cause.isTimeoutError(error) || isTr
 
 const isTransientHttpError = (error: unknown) =>
   Error.isHttpClientError(error) &&
-  ((error._tag === "RequestError" && error.reason === "Transport") ||
-    (error._tag === "ResponseError" && isTransientResponse(error.response)))
+  (error.reason._tag === "TransportError" ||
+    (error.reason._tag === "StatusCodeError" && isTransientResponse(error.reason.response)))
 
 const transientStatuses = new Set([
   408,

--- a/packages/effect/src/unstable/http/HttpClientError.ts
+++ b/packages/effect/src/unstable/http/HttpClientError.ts
@@ -1,12 +1,30 @@
 /**
  * @since 4.0.0
  */
-import * as Data from "../../Data.ts"
 import { hasProperty } from "../../Predicate.ts"
+import * as Schema from "../../Schema.ts"
 import type * as HttpClientRequest from "./HttpClientRequest.ts"
 import type * as ClientResponse from "./HttpClientResponse.ts"
 
-const TypeId = "~effect/http/HttpClientError"
+const TypeId = "~effect/http/HttpClientError" as const
+
+const RequestSchema: Schema.declare<HttpClientRequest.HttpClientRequest> = Schema.Any as any
+const ResponseSchema: Schema.declare<ClientResponse.HttpClientResponse> = Schema.Any as any
+
+const reasonLabel = (tag: string) => tag.endsWith("Error") ? tag.slice(0, -5) : tag
+
+const formatRequestMessage = (tag: string, description: string | undefined, methodAndUrl: string) =>
+  description ? `${tag}: ${description} (${methodAndUrl})` : `${tag} error (${methodAndUrl})`
+
+const formatResponseMessage = (
+  tag: string,
+  description: string | undefined,
+  methodAndUrl: string,
+  status: number
+) => {
+  const info = `${status} ${methodAndUrl}`
+  return description ? `${tag}: ${description} (${info})` : `${tag} error (${info})`
+}
 
 /**
  * @since 4.0.0
@@ -16,25 +34,14 @@ export const isHttpClientError = (u: unknown): u is HttpClientError => hasProper
 
 /**
  * @since 4.0.0
- * @category error
+ * @category reasons
  */
-export type HttpClientError = RequestError | ResponseError
-
-/**
- * @since 4.0.0
- * @category error
- */
-export class RequestError extends Data.TaggedError("RequestError")<{
-  readonly request: HttpClientRequest.HttpClientRequest
-  readonly reason: "Transport" | "Encode" | "InvalidUrl"
-  readonly cause?: unknown
-  readonly description?: string
-}> {
-  /**
-   * @since 4.0.0
-   */
-  readonly [TypeId] = TypeId
-
+export class TransportError extends Schema.ErrorClass<TransportError>("effect/http/HttpClientError/TransportError")({
+  _tag: Schema.tag("TransportError"),
+  request: RequestSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
   /**
    * @since 4.0.0
    */
@@ -46,28 +53,20 @@ export class RequestError extends Data.TaggedError("RequestError")<{
    * @since 4.0.0
    */
   override get message() {
-    return this.description ?
-      `${this.reason}: ${this.description} (${this.methodAndUrl})` :
-      `${this.reason} error (${this.methodAndUrl})`
+    return formatRequestMessage(reasonLabel(this._tag), this.description, this.methodAndUrl)
   }
 }
 
 /**
  * @since 4.0.0
- * @category error
+ * @category reasons
  */
-export class ResponseError extends Data.TaggedError("ResponseError")<{
-  readonly request: HttpClientRequest.HttpClientRequest
-  readonly response: ClientResponse.HttpClientResponse
-  readonly reason: "StatusCode" | "Decode" | "EmptyBody"
-  readonly cause?: unknown
-  readonly description?: string | undefined
-}> {
-  /**
-   * @since 4.0.0
-   */
-  readonly [TypeId] = TypeId
-
+export class EncodeError extends Schema.ErrorClass<EncodeError>("effect/http/HttpClientError/EncodeError")({
+  _tag: Schema.tag("EncodeError"),
+  request: RequestSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
   /**
    * @since 4.0.0
    */
@@ -79,9 +78,205 @@ export class ResponseError extends Data.TaggedError("ResponseError")<{
    * @since 4.0.0
    */
   override get message() {
-    const info = `${this.response.status} ${this.methodAndUrl}`
-    return this.description ?
-      `${this.reason}: ${this.description} (${info})` :
-      `${this.reason} error (${info})`
+    return formatRequestMessage(reasonLabel(this._tag), this.description, this.methodAndUrl)
   }
 }
+
+/**
+ * @since 4.0.0
+ * @category reasons
+ */
+export class InvalidUrlError extends Schema.ErrorClass<InvalidUrlError>(
+  "effect/http/HttpClientError/InvalidUrlError"
+)({
+  _tag: Schema.tag("InvalidUrlError"),
+  request: RequestSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
+  /**
+   * @since 4.0.0
+   */
+  get methodAndUrl() {
+    return `${this.request.method} ${this.request.url}`
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return formatRequestMessage(reasonLabel(this._tag), this.description, this.methodAndUrl)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reasons
+ */
+export class StatusCodeError extends Schema.ErrorClass<StatusCodeError>(
+  "effect/http/HttpClientError/StatusCodeError"
+)({
+  _tag: Schema.tag("StatusCodeError"),
+  request: RequestSchema,
+  response: ResponseSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
+  /**
+   * @since 4.0.0
+   */
+  get methodAndUrl() {
+    return `${this.request.method} ${this.request.url}`
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return formatResponseMessage(
+      reasonLabel(this._tag),
+      this.description,
+      this.methodAndUrl,
+      this.response.status
+    )
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reasons
+ */
+export class DecodeError extends Schema.ErrorClass<DecodeError>(
+  "effect/http/HttpClientError/DecodeError"
+)({
+  _tag: Schema.tag("DecodeError"),
+  request: RequestSchema,
+  response: ResponseSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
+  /**
+   * @since 4.0.0
+   */
+  get methodAndUrl() {
+    return `${this.request.method} ${this.request.url}`
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return formatResponseMessage(
+      reasonLabel(this._tag),
+      this.description,
+      this.methodAndUrl,
+      this.response.status
+    )
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reasons
+ */
+export class EmptyBodyError extends Schema.ErrorClass<EmptyBodyError>(
+  "effect/http/HttpClientError/EmptyBodyError"
+)({
+  _tag: Schema.tag("EmptyBodyError"),
+  request: RequestSchema,
+  response: ResponseSchema,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect)
+}) {
+  /**
+   * @since 4.0.0
+   */
+  get methodAndUrl() {
+    return `${this.request.method} ${this.request.url}`
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return formatResponseMessage(
+      reasonLabel(this._tag),
+      this.description,
+      this.methodAndUrl,
+      this.response.status
+    )
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type HttpClientErrorReason =
+  | TransportError
+  | EncodeError
+  | InvalidUrlError
+  | StatusCodeError
+  | DecodeError
+  | EmptyBodyError
+
+/**
+ * @since 4.0.0
+ * @category schemas
+ */
+export const HttpClientErrorReason: Schema.Union<[
+  typeof TransportError,
+  typeof EncodeError,
+  typeof InvalidUrlError,
+  typeof StatusCodeError,
+  typeof DecodeError,
+  typeof EmptyBodyError
+]> = Schema.Union([
+  TransportError,
+  EncodeError,
+  InvalidUrlError,
+  StatusCodeError,
+  DecodeError,
+  EmptyBodyError
+])
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type RequestError = TransportError | EncodeError | InvalidUrlError
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ResponseError = StatusCodeError | DecodeError | EmptyBodyError
+
+/**
+ * @since 4.0.0
+ * @category error
+ */
+export class HttpClientError extends Schema.ErrorClass<HttpClientError>("effect/http/HttpClientError")({
+  _tag: Schema.tag("HttpClientError"),
+  reason: HttpClientErrorReason
+}) {
+  /**
+   * @since 4.0.0
+   */
+  readonly [TypeId] = TypeId
+
+  /**
+   * @since 4.0.0
+   */
+  override get message() {
+    return this.reason.message
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const make = (params: {
+  readonly reason: HttpClientErrorReason
+}): HttpClientError => new HttpClientError(params)

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -43,12 +43,12 @@ export const TypeId = "~effect/http/HttpClientResponse"
  * @since 4.0.0
  * @category models
  */
-export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMessage<Error.ResponseError> {
+export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMessage<Error.HttpClientError> {
   readonly [TypeId]: typeof TypeId
   readonly request: HttpClientRequest.HttpClientRequest
   readonly status: number
   readonly cookies: Cookies.Cookies
-  readonly formData: Effect.Effect<FormData, Error.ResponseError>
+  readonly formData: Effect.Effect<FormData, Error.HttpClientError>
 }
 
 /**
@@ -78,7 +78,7 @@ export const schemaJson = <
   const decode = Schema.decodeEffect(Schema.toCodecJson(schema).annotate({ options }))
   return (
     self: HttpClientResponse
-  ): Effect.Effect<A, Schema.SchemaError | Error.ResponseError, RD> =>
+  ): Effect.Effect<A, Schema.SchemaError | Error.HttpClientError, RD> =>
     Effect.flatMap(self.json, (body) =>
       decode({
         status: self.status,
@@ -117,7 +117,7 @@ export const schemaNoBody = <
  */
 export const stream = <E, R>(
   effect: Effect.Effect<HttpClientResponse, E, R>
-): Stream.Stream<Uint8Array, Error.ResponseError | E, R> => Stream.unwrap(Effect.map(effect, (self) => self.stream))
+): Stream.Stream<Uint8Array, Error.HttpClientError | E, R> => Stream.unwrap(Effect.map(effect, (self) => self.stream))
 
 /**
  * @since 4.0.0
@@ -174,18 +174,21 @@ export const matchStatus: {
  * @category filters
  */
 export const filterStatus: {
-  (f: (status: number) => boolean): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.ResponseError>
-  (self: HttpClientResponse, f: (status: number) => boolean): Effect.Effect<HttpClientResponse, Error.ResponseError>
+  (
+    f: (status: number) => boolean
+  ): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.HttpClientError>
+  (self: HttpClientResponse, f: (status: number) => boolean): Effect.Effect<HttpClientResponse, Error.HttpClientError>
 } = dual(
   2,
   (self: HttpClientResponse, f: (status: number) => boolean) =>
     Effect.suspend(() =>
       f(self.status) ? Effect.succeed(self) : Effect.fail(
-        new Error.ResponseError({
-          response: self,
-          request: self.request,
-          reason: "StatusCode",
-          description: "invalid status code"
+        Error.make({
+          reason: new Error.StatusCodeError({
+            response: self,
+            request: self.request,
+            description: "invalid status code"
+          })
         })
       )
     )
@@ -195,13 +198,14 @@ export const filterStatus: {
  * @since 4.0.0
  * @category filters
  */
-export const filterStatusOk = (self: HttpClientResponse): Effect.Effect<HttpClientResponse, Error.ResponseError> =>
+export const filterStatusOk = (self: HttpClientResponse): Effect.Effect<HttpClientResponse, Error.HttpClientError> =>
   self.status >= 200 && self.status < 300 ? Effect.succeed(self) : Effect.fail(
-    new Error.ResponseError({
-      response: self,
-      request: self.request,
-      reason: "StatusCode",
-      description: "non 2xx status code"
+    Error.make({
+      reason: new Error.StatusCodeError({
+        response: self,
+        request: self.request,
+        description: "non 2xx status code"
+      })
     })
   )
 
@@ -255,94 +259,101 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
     return undefined
   }
 
-  get stream(): Stream.Stream<Uint8Array, Error.ResponseError> {
+  get stream(): Stream.Stream<Uint8Array, Error.HttpClientError> {
     return this.source.body
       ? Stream.fromReadableStream({
         evaluate: () => this.source.body!,
         onError: (cause) =>
-          new Error.ResponseError({
-            request: this.request,
-            response: this,
-            reason: "Decode",
-            cause
+          Error.make({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
       })
       : Stream.fail(
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "EmptyBody",
-          description: "can not create stream from empty body"
+        Error.make({
+          reason: new Error.EmptyBodyError({
+            request: this.request,
+            response: this,
+            description: "can not create stream from empty body"
+          })
         })
       )
   }
 
-  get json(): Effect.Effect<unknown, Error.ResponseError> {
+  get json(): Effect.Effect<unknown, Error.HttpClientError> {
     return Effect.flatMap(this.text, (text) =>
       Effect.try({
         try: () => text === "" ? null : JSON.parse(text) as unknown,
         catch: (cause) =>
-          new Error.ResponseError({
-            request: this.request,
-            response: this,
-            reason: "Decode",
-            cause
+          Error.make({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
       }))
   }
 
-  private textBody?: Effect.Effect<string, Error.ResponseError>
-  get text(): Effect.Effect<string, Error.ResponseError> {
+  private textBody?: Effect.Effect<string, Error.HttpClientError>
+  get text(): Effect.Effect<string, Error.HttpClientError> {
     return this.textBody ??= Effect.tryPromise({
       try: () => this.source.text(),
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }
 
-  get urlParamsBody(): Effect.Effect<UrlParams.UrlParams, Error.ResponseError> {
+  get urlParamsBody(): Effect.Effect<UrlParams.UrlParams, Error.HttpClientError> {
     return Effect.flatMap(this.text, (_) =>
       Effect.try({
         try: () => UrlParams.fromInput(new URLSearchParams(_)),
         catch: (cause) =>
-          new Error.ResponseError({
-            request: this.request,
-            response: this,
-            reason: "Decode",
-            cause
+          Error.make({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
       }))
   }
 
-  private formDataBody?: Effect.Effect<FormData, Error.ResponseError>
-  get formData(): Effect.Effect<FormData, Error.ResponseError> {
+  private formDataBody?: Effect.Effect<FormData, Error.HttpClientError>
+  get formData(): Effect.Effect<FormData, Error.HttpClientError> {
     return this.formDataBody ??= Effect.tryPromise({
       try: () => this.source.formData(),
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }
 
-  private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.ResponseError>
-  get arrayBuffer(): Effect.Effect<ArrayBuffer, Error.ResponseError> {
+  private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.HttpClientError>
+  get arrayBuffer(): Effect.Effect<ArrayBuffer, Error.HttpClientError> {
     return this.arrayBufferBody ??= Effect.tryPromise({
       try: () => this.source.arrayBuffer(),
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -170,10 +170,11 @@ const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, E, R>
               Effect.catchCause(decode(response), (cause) =>
                 Effect.failCause(Cause.merge(
                   Cause.fail(
-                    new HttpClientError.ResponseError({
-                      reason: "StatusCode",
-                      request: response.request,
-                      response
+                    HttpClientError.make({
+                      reason: new HttpClientError.StatusCodeError({
+                        request: response.request,
+                        response
+                      })
                     })
                   ),
                   cause
@@ -501,19 +502,21 @@ const schemaFromArrayBuffer = (
 
 const statusOrElse = (response: HttpClientResponse.HttpClientResponse) =>
   Effect.fail(
-    new HttpClientError.ResponseError({
-      reason: "Decode",
-      request: response.request,
-      response
+    HttpClientError.make({
+      reason: new HttpClientError.DecodeError({
+        request: response.request,
+        response
+      })
     })
   )
 
 const statusCodeError = (response: HttpClientResponse.HttpClientResponse) =>
   Effect.fail(
-    new HttpClientError.ResponseError({
-      reason: "StatusCode",
-      request: response.request,
-      response
+    HttpClientError.make({
+      reason: new HttpClientError.StatusCodeError({
+        request: response.request,
+        response
+      })
     })
   )
 

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -21,10 +21,10 @@ const policy = Schedule.forever.pipe(
   Schedule.addDelay((error) => {
     if (
       HttpClientError.isHttpClientError(error)
-      && error._tag === "ResponseError"
-      && error.response.status === 429
+      && error.reason._tag === "StatusCodeError"
+      && error.reason.response.status === 429
     ) {
-      const retryAfter = UndefinedOr.map(error.response.headers["retry-after"], Num.parse) ?? 5
+      const retryAfter = UndefinedOr.map(error.reason.response.headers["retry-after"], Num.parse) ?? 5
       return Duration.seconds(retryAfter)
     }
     return Duration.seconds(1)

--- a/packages/platform-browser/src/BrowserHttpClient.ts
+++ b/packages/platform-browser/src/BrowserHttpClient.ts
@@ -103,7 +103,7 @@ const makeXmlHttpRequest = HttpClient.make(
       })
       return Effect.andThen(
         sendBody(xhr, request),
-        Effect.callback<ClientResponseImpl, HttpClientError.RequestError>((resume) => {
+        Effect.callback<ClientResponseImpl, HttpClientError.HttpClientError>((resume) => {
           let sent = false
           const onChange = () => {
             if (!sent && xhr.readyState >= 2) {
@@ -114,10 +114,11 @@ const makeXmlHttpRequest = HttpClient.make(
           xhr.onreadystatechange = onChange
           xhr.onerror = (_event) => {
             resume(Effect.fail(
-              new HttpClientError.RequestError({
-                request,
-                reason: "Transport",
-                cause: xhr.statusText
+              HttpClientError.make({
+                reason: new HttpClientError.TransportError({
+                  request,
+                  cause: xhr.statusText
+                })
               })
             ))
           }
@@ -131,7 +132,7 @@ const makeXmlHttpRequest = HttpClient.make(
 const sendBody = (
   xhr: globalThis.XMLHttpRequest,
   request: HttpClientRequest.HttpClientRequest
-): Effect.Effect<void, HttpClientError.RequestError> => {
+): Effect.Effect<void, HttpClientError.HttpClientError> => {
   const body = request.body
   switch (body._tag) {
     case "Empty":
@@ -153,10 +154,11 @@ const sendBody = (
         {
           onFailure: (cause) =>
             Effect.fail(
-              new HttpClientError.RequestError({
-                request,
-                reason: "Encode",
-                cause
+              HttpClientError.make({
+                reason: new HttpClientError.EncodeError({
+                  request,
+                  cause
+                })
               })
             ),
           onSuccess: (body) => Effect.sync(() => xhr.send(body))
@@ -331,7 +333,7 @@ abstract class IncomingMessageImpl<E> extends Inspectable.Class implements HttpI
   }
 }
 
-class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.ResponseError>
+class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.HttpClientError>
   implements HttpClientResponse.HttpClientResponse
 {
   readonly [HttpClientResponse.TypeId]: typeof HttpClientResponse.TypeId
@@ -342,11 +344,12 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.ResponseErr
     source: globalThis.XMLHttpRequest
   ) {
     super(source, (cause) =>
-      new HttpClientError.ResponseError({
-        request,
-        response: this,
-        reason: "Decode",
-        cause
+      HttpClientError.make({
+        reason: new HttpClientError.DecodeError({
+          request,
+          response: this,
+          cause
+        })
       }))
     this.request = request
     this[HttpClientResponse.TypeId] = HttpClientResponse.TypeId
@@ -356,7 +359,7 @@ class ClientResponseImpl extends IncomingMessageImpl<HttpClientError.ResponseErr
     return this.source.status
   }
 
-  get formData(): Effect.Effect<FormData, HttpClientError.ResponseError> {
+  get formData(): Effect.Effect<FormData, HttpClientError.HttpClientError> {
     return Effect.die("Not implemented")
   }
 

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -114,10 +114,11 @@ export const makeUndici = Effect.gen(function*() {
               bodyTimeout: 0
             }),
           catch: (cause) =>
-            new Error.RequestError({
-              request,
-              reason: "Transport",
-              cause
+            Error.make({
+              reason: new Error.TransportError({
+                request,
+                cause
+              })
             })
         })
       ),
@@ -191,85 +192,91 @@ class UndiciResponse extends Inspectable.Class implements HttpClientResponse {
     return undefined
   }
 
-  get stream(): Stream.Stream<Uint8Array, Error.ResponseError> {
+  get stream(): Stream.Stream<Uint8Array, Error.HttpClientError> {
     return NodeStream.fromReadable({
       evaluate: () => this.source.body,
       onError: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     })
   }
 
-  get json(): Effect.Effect<unknown, Error.ResponseError> {
+  get json(): Effect.Effect<unknown, Error.HttpClientError> {
     return Effect.flatMap(this.text, (text) =>
       Effect.try({
         try: () => text === "" ? null : JSON.parse(text) as unknown,
         catch: (cause) =>
-          new Error.ResponseError({
-            request: this.request,
-            response: this,
-            reason: "Decode",
-            cause
+          Error.make({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
       }))
   }
 
-  private textBody?: Effect.Effect<string, Error.ResponseError>
-  get text(): Effect.Effect<string, Error.ResponseError> {
+  private textBody?: Effect.Effect<string, Error.HttpClientError>
+  get text(): Effect.Effect<string, Error.HttpClientError> {
     return this.textBody ??= Effect.tryPromise({
       try: () => this.source.body.text(),
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }
 
-  get urlParamsBody(): Effect.Effect<UrlParams.UrlParams, Error.ResponseError> {
+  get urlParamsBody(): Effect.Effect<UrlParams.UrlParams, Error.HttpClientError> {
     return Effect.flatMap(this.text, (_) =>
       Effect.try({
         try: () => UrlParams.fromInput(new URLSearchParams(_)),
         catch: (cause) =>
-          new Error.ResponseError({
-            request: this.request,
-            response: this,
-            reason: "Decode",
-            cause
+          Error.make({
+            reason: new Error.DecodeError({
+              request: this.request,
+              response: this,
+              cause
+            })
           })
       }))
   }
 
-  private formDataBody?: Effect.Effect<FormData, Error.ResponseError>
-  get formData(): Effect.Effect<FormData, Error.ResponseError> {
+  private formDataBody?: Effect.Effect<FormData, Error.HttpClientError>
+  get formData(): Effect.Effect<FormData, Error.HttpClientError> {
     return this.formDataBody ??= Effect.tryPromise({
       try: () => this.source.body.formData() as Promise<FormData>,
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }
 
-  private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.ResponseError>
-  get arrayBuffer(): Effect.Effect<ArrayBuffer, Error.ResponseError> {
+  private arrayBufferBody?: Effect.Effect<ArrayBuffer, Error.HttpClientError>
+  get arrayBuffer(): Effect.Effect<ArrayBuffer, Error.HttpClientError> {
     return this.arrayBufferBody ??= Effect.tryPromise({
       try: () => this.source.body.arrayBuffer(),
       catch: (cause) =>
-        new Error.ResponseError({
-          request: this.request,
-          response: this,
-          reason: "Decode",
-          cause
+        Error.make({
+          reason: new Error.DecodeError({
+            request: this.request,
+            response: this,
+            cause
+          })
         })
     }).pipe(Effect.cached, Effect.runSync)
   }
@@ -374,8 +381,8 @@ const sendBody = (
   nodeRequest: Http.ClientRequest,
   request: HttpClientRequest,
   body: Body.HttpBody
-): Effect.Effect<void, Error.RequestError> =>
-  Effect.suspend((): Effect.Effect<void, Error.RequestError> => {
+): Effect.Effect<void, Error.HttpClientError> =>
+  Effect.suspend((): Effect.Effect<void, Error.HttpClientError> => {
     switch (body._tag) {
       case "Empty": {
         nodeRequest.end()
@@ -396,28 +403,31 @@ const sendBody = (
         return Effect.tryPromise({
           try: () => pipeline(Readable.fromWeb(response.body! as any), nodeRequest),
           catch: (cause) =>
-            new Error.RequestError({
-              request,
-              reason: "Transport",
-              cause
+            Error.make({
+              reason: new Error.TransportError({
+                request,
+                cause
+              })
             })
         })
       }
       case "Stream": {
         return Stream.run(
           Stream.mapError(body.stream, (cause) =>
-            new Error.RequestError({
-              request,
-              reason: "Encode",
-              cause
+            Error.make({
+              reason: new Error.EncodeError({
+                request,
+                cause
+              })
             })),
           NodeSink.fromWritable({
             evaluate: () => nodeRequest,
             onError: (cause) =>
-              new Error.RequestError({
-                request,
-                reason: "Transport",
-                cause
+              Error.make({
+                reason: new Error.TransportError({
+                  request,
+                  cause
+                })
               })
           })
         )
@@ -426,13 +436,14 @@ const sendBody = (
   })
 
 const waitForResponse = (nodeRequest: Http.ClientRequest, request: HttpClientRequest) =>
-  Effect.callback<Http.IncomingMessage, Error.RequestError>((resume) => {
+  Effect.callback<Http.IncomingMessage, Error.HttpClientError>((resume) => {
     function onError(cause: Error) {
       resume(Effect.fail(
-        new Error.RequestError({
-          request,
-          reason: "Transport",
-          cause
+        Error.make({
+          reason: new Error.TransportError({
+            request,
+            cause
+          })
         })
       ))
     }
@@ -453,13 +464,14 @@ const waitForResponse = (nodeRequest: Http.ClientRequest, request: HttpClientReq
   })
 
 const waitForFinish = (nodeRequest: Http.ClientRequest, request: HttpClientRequest) =>
-  Effect.callback<void, Error.RequestError>((resume) => {
+  Effect.callback<void, Error.HttpClientError>((resume) => {
     function onError(cause: Error) {
       resume(Effect.fail(
-        new Error.RequestError({
-          request,
-          reason: "Transport",
-          cause
+        Error.make({
+          reason: new Error.TransportError({
+            request,
+            cause
+          })
         })
       ))
     }
@@ -477,7 +489,7 @@ const waitForFinish = (nodeRequest: Http.ClientRequest, request: HttpClientReque
     })
   })
 
-class NodeHttpResponse extends NodeHttpIncomingMessage<Error.ResponseError> implements HttpClientResponse {
+class NodeHttpResponse extends NodeHttpIncomingMessage<Error.HttpClientError> implements HttpClientResponse {
   readonly [Response.TypeId]: typeof Response.TypeId
   readonly request: HttpClientRequest
 
@@ -486,11 +498,12 @@ class NodeHttpResponse extends NodeHttpIncomingMessage<Error.ResponseError> impl
     source: Http.IncomingMessage
   ) {
     super(source, (cause) =>
-      new Error.ResponseError({
-        request,
-        response: this,
-        reason: "Decode",
-        cause
+      Error.make({
+        reason: new Error.DecodeError({
+          request,
+          response: this,
+          cause
+        })
       }))
     this[Response.TypeId] = Response.TypeId
     this.request = request
@@ -509,7 +522,7 @@ class NodeHttpResponse extends NodeHttpIncomingMessage<Error.ResponseError> impl
     return this.cachedCookies = header ? Cookies.fromSetCookie(header) : Cookies.empty
   }
 
-  get formData(): Effect.Effect<FormData, Error.ResponseError> {
+  get formData(): Effect.Effect<FormData, Error.HttpClientError> {
     return Effect.tryPromise({
       try: () => {
         const init: {

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -311,7 +311,7 @@ export const make = (
 ): ${name} => {
   ${commonSource}
   const decodeSuccess = <A>(response: HttpClientResponse.HttpClientResponse) =>
-    response.json as Effect.Effect<A, HttpClientError.ResponseError>
+    response.json as Effect.Effect<A, HttpClientError.HttpClientError>
   const decodeVoid = (_response: HttpClientResponse.HttpClientResponse) =>
     Effect.void
   const decodeError =
@@ -320,10 +320,10 @@ export const make = (
       response: HttpClientResponse.HttpClientResponse,
     ): Effect.Effect<
       never,
-      ${name}Error<Tag, E> | HttpClientError.ResponseError
+      ${name}Error<Tag, E> | HttpClientError.HttpClientError
     > =>
       Effect.flatMap(
-        response.json as Effect.Effect<E, HttpClientError.ResponseError>,
+        response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(${name}Error(tag, cause, response)),
       )
   const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
@@ -426,11 +426,12 @@ const commonSource = `const unexpectedStatus = (response: HttpClientResponse.Htt
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          HttpClientError.make({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -139,11 +139,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          HttpClientError.make({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )
@@ -317,11 +318,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          HttpClientError.make({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )
@@ -342,7 +344,7 @@ export const make = (
       : (request) => Effect.flatMap(httpClient.execute(request), withOptionalResponse)
   }
   const decodeSuccess = <A>(response: HttpClientResponse.HttpClientResponse) =>
-    response.json as Effect.Effect<A, HttpClientError.ResponseError>
+    response.json as Effect.Effect<A, HttpClientError.HttpClientError>
   const decodeVoid = (_response: HttpClientResponse.HttpClientResponse) =>
     Effect.void
   const decodeError =
@@ -351,10 +353,10 @@ export const make = (
       response: HttpClientResponse.HttpClientResponse,
     ): Effect.Effect<
       never,
-      TestClientError<Tag, E> | HttpClientError.ResponseError
+      TestClientError<Tag, E> | HttpClientError.HttpClientError
     > =>
       Effect.flatMap(
-        response.json as Effect.Effect<E, HttpClientError.ResponseError>,
+        response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(TestClientError(tag, cause, response)),
       )
   const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (


### PR DESCRIPTION
## Summary
- replace HttpClientError with reason classes and wrapper, keeping message formatting
- update core/http client implementations and OpenAPI handling to wrap reason errors
- align AiError and transient status handling with reason tags