### PR TITLE
EFF-274 refactor HttpClientError reason wrapper

### DIFF
--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -25214,11 +25214,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description)
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description)
+            })
           })
         )
     )

--- a/packages/effect/src/unstable/cluster/K8sHttpClient.ts
+++ b/packages/effect/src/unstable/cluster/K8sHttpClient.ts
@@ -122,7 +122,11 @@ export const makeCreatePod = Effect.gen(function*() {
         schedule: Schedule.spaced("1 seconds")
       }),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          err._tag === "HttpClientError" && err.reason._tag === "StatusCodeError" &&
+            err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.succeedNone
       ),
       Effect.orDie
@@ -130,7 +134,11 @@ export const makeCreatePod = Effect.gen(function*() {
     const isPodFound = readPodRaw.pipe(
       Effect.as(true),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          err._tag === "HttpClientError" && err.reason._tag === "StatusCodeError" &&
+            err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.succeed(false)
       )
     )
@@ -138,7 +146,11 @@ export const makeCreatePod = Effect.gen(function*() {
       HttpClientRequest.bodyJsonUnsafe(spec),
       client.execute,
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 409 ? err : Filter.fail(err),
+        (err) =>
+          err._tag === "HttpClientError" && err.reason._tag === "StatusCodeError" &&
+            err.reason.response.status === 409
+            ? err
+            : Filter.fail(err),
         () => readPod
       ),
       Effect.tapCause(Effect.logInfo),
@@ -148,7 +160,11 @@ export const makeCreatePod = Effect.gen(function*() {
       client.execute,
       Effect.flatMap((res) => res.json),
       Effect.catchFilter(
-        (err) => err._tag === "ResponseError" && err.response.status === 404 ? err : Filter.fail(err),
+        (err) =>
+          err._tag === "HttpClientError" && err.reason._tag === "StatusCodeError" &&
+            err.reason.response.status === 404
+            ? err
+            : Filter.fail(err),
         () => Effect.void
       ),
       Effect.tapCause(Effect.logInfo),

--- a/packages/effect/src/unstable/http/FetchHttpClient.ts
+++ b/packages/effect/src/unstable/http/FetchHttpClient.ts
@@ -7,7 +7,7 @@ import * as ServiceMap from "../../ServiceMap.ts"
 import * as Stream from "../../Stream.ts"
 import * as Headers from "./Headers.ts"
 import * as HttpClient from "./HttpClient.ts"
-import { RequestError } from "./HttpClientError.ts"
+import * as HttpClientError from "./HttpClientError.ts"
 import * as HttpClientResponse from "./HttpClientResponse.ts"
 
 /**
@@ -43,10 +43,11 @@ const fetch: HttpClient.HttpClient = HttpClient.make((request, url, signal, fibe
             signal
           } as any),
         catch: (cause) =>
-          new RequestError({
-            request,
-            reason: "Transport",
-            cause
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause
+            })
           })
       }),
       (response) => HttpClientResponse.fromWeb(request, response)

--- a/packages/effect/src/unstable/http/HttpClientError.ts
+++ b/packages/effect/src/unstable/http/HttpClientError.ts
@@ -8,6 +8,27 @@ import type * as ClientResponse from "./HttpClientResponse.ts"
 
 const TypeId = "~effect/http/HttpClientError"
 
+const reasonLabel = (tag: string) => tag.endsWith("Error") ? tag.slice(0, -5) : tag
+
+const formatRequestMessage = (
+  reason: string,
+  request: HttpClientRequest.HttpClientRequest,
+  description?: string
+) => {
+  const methodAndUrl = `${request.method} ${request.url}`
+  return description ? `${reason}: ${description} (${methodAndUrl})` : `${reason} error (${methodAndUrl})`
+}
+
+const formatResponseMessage = (
+  reason: string,
+  request: HttpClientRequest.HttpClientRequest,
+  response: ClientResponse.HttpClientResponse,
+  description?: string
+) => {
+  const info = `${response.status} ${request.method} ${request.url}`
+  return description ? `${reason}: ${description} (${info})` : `${reason} error (${info})`
+}
+
 /**
  * @since 4.0.0
  * @category guards
@@ -16,72 +37,132 @@ export const isHttpClientError = (u: unknown): u is HttpClientError => hasProper
 
 /**
  * @since 4.0.0
- * @category error
+ * @category reason
  */
-export type HttpClientError = RequestError | ResponseError
-
-/**
- * @since 4.0.0
- * @category error
- */
-export class RequestError extends Data.TaggedError("RequestError")<{
+export class TransportError extends Data.TaggedError("TransportError")<{
   readonly request: HttpClientRequest.HttpClientRequest
-  readonly reason: "Transport" | "Encode" | "InvalidUrl"
   readonly cause?: unknown
   readonly description?: string
 }> {
-  /**
-   * @since 4.0.0
-   */
-  readonly [TypeId] = TypeId
-
-  /**
-   * @since 4.0.0
-   */
-  get methodAndUrl() {
-    return `${this.request.method} ${this.request.url}`
-  }
-
-  /**
-   * @since 4.0.0
-   */
   override get message() {
-    return this.description ?
-      `${this.reason}: ${this.description} (${this.methodAndUrl})` :
-      `${this.reason} error (${this.methodAndUrl})`
+    return formatRequestMessage(reasonLabel(this._tag), this.request, this.description)
   }
 }
 
 /**
  * @since 4.0.0
- * @category error
+ * @category reason
  */
-export class ResponseError extends Data.TaggedError("ResponseError")<{
+export class EncodeError extends Data.TaggedError("EncodeError")<{
+  readonly request: HttpClientRequest.HttpClientRequest
+  readonly cause?: unknown
+  readonly description?: string
+}> {
+  override get message() {
+    return formatRequestMessage(reasonLabel(this._tag), this.request, this.description)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export class InvalidUrlError extends Data.TaggedError("InvalidUrlError")<{
+  readonly request: HttpClientRequest.HttpClientRequest
+  readonly cause?: unknown
+  readonly description?: string
+}> {
+  override get message() {
+    return formatRequestMessage(reasonLabel(this._tag), this.request, this.description)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export class StatusCodeError extends Data.TaggedError("StatusCodeError")<{
   readonly request: HttpClientRequest.HttpClientRequest
   readonly response: ClientResponse.HttpClientResponse
-  readonly reason: "StatusCode" | "Decode" | "EmptyBody"
   readonly cause?: unknown
   readonly description?: string | undefined
+}> {
+  override get message() {
+    return formatResponseMessage(reasonLabel(this._tag), this.request, this.response, this.description)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export class DecodeError extends Data.TaggedError("DecodeError")<{
+  readonly request: HttpClientRequest.HttpClientRequest
+  readonly response: ClientResponse.HttpClientResponse
+  readonly cause?: unknown
+  readonly description?: string | undefined
+}> {
+  override get message() {
+    return formatResponseMessage(reasonLabel(this._tag), this.request, this.response, this.description)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export class EmptyBodyError extends Data.TaggedError("EmptyBodyError")<{
+  readonly request: HttpClientRequest.HttpClientRequest
+  readonly response: ClientResponse.HttpClientResponse
+  readonly cause?: unknown
+  readonly description?: string | undefined
+}> {
+  override get message() {
+    return formatResponseMessage(reasonLabel(this._tag), this.request, this.response, this.description)
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export type RequestError = TransportError | EncodeError | InvalidUrlError
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export type ResponseError = StatusCodeError | DecodeError | EmptyBodyError
+
+/**
+ * @since 4.0.0
+ * @category reason
+ */
+export type HttpClientErrorReason = RequestError | ResponseError
+
+/**
+ * @since 4.0.0
+ * @category error
+ */
+export class HttpClientError extends Data.TaggedError("HttpClientError")<{
+  readonly reason: HttpClientErrorReason
+  readonly cause?: unknown
 }> {
   /**
    * @since 4.0.0
    */
   readonly [TypeId] = TypeId
 
-  /**
-   * @since 4.0.0
-   */
-  get methodAndUrl() {
-    return `${this.request.method} ${this.request.url}`
+  constructor(props: {
+    readonly reason: HttpClientErrorReason
+  }) {
+    super({
+      ...props,
+      cause: "cause" in props.reason ? props.reason.cause : undefined
+    } as any)
   }
 
-  /**
-   * @since 4.0.0
-   */
   override get message() {
-    const info = `${this.response.status} ${this.methodAndUrl}`
-    return this.description ?
-      `${this.reason}: ${this.description} (${info})` :
-      `${this.reason} error (${info})`
+    return this.reason.message
   }
 }

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -170,10 +170,11 @@ const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, E, R>
               Effect.catchCause(decode(response), (cause) =>
                 Effect.failCause(Cause.merge(
                   Cause.fail(
-                    new HttpClientError.ResponseError({
-                      reason: "StatusCode",
-                      request: response.request,
-                      response
+                    new HttpClientError.HttpClientError({
+                      reason: new HttpClientError.StatusCodeError({
+                        request: response.request,
+                        response
+                      })
                     })
                   ),
                   cause
@@ -501,19 +502,21 @@ const schemaFromArrayBuffer = (
 
 const statusOrElse = (response: HttpClientResponse.HttpClientResponse) =>
   Effect.fail(
-    new HttpClientError.ResponseError({
-      reason: "Decode",
-      request: response.request,
-      response
+    new HttpClientError.HttpClientError({
+      reason: new HttpClientError.DecodeError({
+        request: response.request,
+        response
+      })
     })
   )
 
 const statusCodeError = (response: HttpClientResponse.HttpClientResponse) =>
   Effect.fail(
-    new HttpClientError.ResponseError({
-      reason: "StatusCode",
-      request: response.request,
-      response
+    new HttpClientError.HttpClientError({
+      reason: new HttpClientError.StatusCodeError({
+        request: response.request,
+        response
+      })
     })
   )
 

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -21,10 +21,10 @@ const policy = Schedule.forever.pipe(
   Schedule.addDelay((error) => {
     if (
       HttpClientError.isHttpClientError(error)
-      && error._tag === "ResponseError"
-      && error.response.status === 429
+      && error.reason._tag === "StatusCodeError"
+      && error.reason.response.status === 429
     ) {
-      const retryAfter = UndefinedOr.map(error.response.headers["retry-after"], Num.parse) ?? 5
+      const retryAfter = UndefinedOr.map(error.reason.response.headers["retry-after"], Num.parse) ?? 5
       return Duration.seconds(retryAfter)
     }
     return Duration.seconds(1)

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -311,7 +311,7 @@ export const make = (
 ): ${name} => {
   ${commonSource}
   const decodeSuccess = <A>(response: HttpClientResponse.HttpClientResponse) =>
-    response.json as Effect.Effect<A, HttpClientError.ResponseError>
+    response.json as Effect.Effect<A, HttpClientError.HttpClientError>
   const decodeVoid = (_response: HttpClientResponse.HttpClientResponse) =>
     Effect.void
   const decodeError =
@@ -320,10 +320,10 @@ export const make = (
       response: HttpClientResponse.HttpClientResponse,
     ): Effect.Effect<
       never,
-      ${name}Error<Tag, E> | HttpClientError.ResponseError
+      ${name}Error<Tag, E> | HttpClientError.HttpClientError
     > =>
       Effect.flatMap(
-        response.json as Effect.Effect<E, HttpClientError.ResponseError>,
+        response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(${name}Error(tag, cause, response)),
       )
   const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (
@@ -426,11 +426,12 @@ const commonSource = `const unexpectedStatus = (response: HttpClientResponse.Htt
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -139,11 +139,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )
@@ -317,11 +318,12 @@ export const make = (
       Effect.orElseSucceed(response.json, () => "Unexpected status code"),
       (description) =>
         Effect.fail(
-          new HttpClientError.ResponseError({
-            request: response.request,
-            response,
-            reason: "StatusCode",
-            description: typeof description === "string" ? description : JSON.stringify(description),
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.StatusCodeError({
+              request: response.request,
+              response,
+              description: typeof description === "string" ? description : JSON.stringify(description),
+            }),
           }),
         ),
     )
@@ -342,7 +344,7 @@ export const make = (
       : (request) => Effect.flatMap(httpClient.execute(request), withOptionalResponse)
   }
   const decodeSuccess = <A>(response: HttpClientResponse.HttpClientResponse) =>
-    response.json as Effect.Effect<A, HttpClientError.ResponseError>
+    response.json as Effect.Effect<A, HttpClientError.HttpClientError>
   const decodeVoid = (_response: HttpClientResponse.HttpClientResponse) =>
     Effect.void
   const decodeError =
@@ -351,10 +353,10 @@ export const make = (
       response: HttpClientResponse.HttpClientResponse,
     ): Effect.Effect<
       never,
-      TestClientError<Tag, E> | HttpClientError.ResponseError
+      TestClientError<Tag, E> | HttpClientError.HttpClientError
     > =>
       Effect.flatMap(
-        response.json as Effect.Effect<E, HttpClientError.ResponseError>,
+        response.json as Effect.Effect<E, HttpClientError.HttpClientError>,
         (cause) => Effect.fail(TestClientError(tag, cause, response)),
       )
   const onRequest = <Config extends OperationConfig>(config: Config | undefined) => (


### PR DESCRIPTION
## Summary
- refactor HttpClientError into reason classes plus wrapper with message delegation and cause forwarding
- update HttpClient/response helpers, platform clients, and error matching to emit wrapper errors
- align AiError conversions and OpenAPI generator output with reason wrapper usage

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpEffect.test.ts
- pnpm check
- pnpm build
- pnpm docgen