### PR TITLE
EFF-278 add HttpClientError reason tests

### DIFF
--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -157,7 +157,7 @@ export const HttpResponseDetails = Schema.Struct({
  *   const error = new AiError.HttpError({
  *     module: "OpenAI",
  *     method: "createCompletion",
- *     reason: "Transport",
+ *     reason: "TransportError",
  *     request: {
  *       method: "POST",
  *       url: "https://api.openai.com/v1/completions",
@@ -169,7 +169,7 @@ export const HttpResponseDetails = Schema.Struct({
  *   })
  *
  *   console.log(error.message)
- *   // "Transport: Connection timeout after 30 seconds (POST https://api.openai.com/v1/completions)"
+ *   // "TransportError: Connection timeout after 30 seconds (POST https://api.openai.com/v1/completions)"
  * })
  * ```
  *
@@ -208,7 +208,7 @@ export class HttpError extends Schema.ErrorClass<HttpError>(
    * import { AiError } from "effect/unstable/ai"
    * import type { HttpClientError } from "effect/unstable/http"
    *
-   * declare const platformError: HttpClientError.RequestError
+   * declare const platformError: HttpClientError.HttpClientError
    *
    * const aiError = AiError.HttpError.fromHttpClientError({
    *   module: "ChatGPT",

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -553,12 +553,14 @@ export const make = (
         const controller = scopedController ?? new AbortController()
         const urlResult = UrlParams.makeUrl(request.url, request.urlParams, request.hash)
         if (Result.isFailure(urlResult)) {
-          return Effect.fail(new Error.HttpClientError({
-            reason: new Error.InvalidUrlError({
-              request,
-              cause: urlResult.failure
+          return Effect.fail(
+            new Error.HttpClientError({
+              reason: new Error.InvalidUrlError({
+                request,
+                cause: urlResult.failure
+              })
             })
-          }))
+          )
         }
         const url = urlResult.success
         const tracerDisabled = fiber.getRef(Tracer.DisablePropagation) ||

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -174,7 +174,9 @@ export const matchStatus: {
  * @category filters
  */
 export const filterStatus: {
-  (f: (status: number) => boolean): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.HttpClientError>
+  (
+    f: (status: number) => boolean
+  ): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.HttpClientError>
   (self: HttpClientResponse, f: (status: number) => boolean): Effect.Effect<HttpClientResponse, Error.HttpClientError>
 } = dual(
   2,

--- a/packages/effect/test/unstable/http/HttpClientError.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientError.test.ts
@@ -1,0 +1,118 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as HttpClientError from "effect/unstable/http/HttpClientError"
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
+
+const makeRequest = () => HttpClientRequest.get("https://example.com/v1/users")
+const makeResponse = (request: HttpClientRequest.HttpClientRequest) =>
+  HttpClientResponse.fromWeb(request, new Response("nope", { status: 418 }))
+
+describe("HttpClientError", () => {
+  describe("reason messages", () => {
+    it("TransportError message", () => {
+      const request = makeRequest()
+      const reason = new HttpClientError.TransportError({
+        request,
+        description: "connection reset"
+      })
+
+      assert.strictEqual(reason.message, "Transport: connection reset (GET https://example.com/v1/users)")
+    })
+
+    it("EncodeError message", () => {
+      const request = makeRequest()
+      const reason = new HttpClientError.EncodeError({ request })
+
+      assert.strictEqual(reason.message, "Encode error (GET https://example.com/v1/users)")
+    })
+
+    it("InvalidUrlError message", () => {
+      const request = makeRequest()
+      const reason = new HttpClientError.InvalidUrlError({
+        request,
+        description: "base URL is invalid"
+      })
+
+      assert.strictEqual(reason.message, "InvalidUrl: base URL is invalid (GET https://example.com/v1/users)")
+    })
+
+    it("StatusCodeError message", () => {
+      const request = makeRequest()
+      const response = makeResponse(request)
+      const reason = new HttpClientError.StatusCodeError({
+        request,
+        response,
+        description: "unexpected status"
+      })
+
+      assert.strictEqual(reason.message, "StatusCode: unexpected status (418 GET https://example.com/v1/users)")
+    })
+
+    it("DecodeError message", () => {
+      const request = makeRequest()
+      const response = makeResponse(request)
+      const reason = new HttpClientError.DecodeError({
+        request,
+        response,
+        cause: new Error("invalid json")
+      })
+
+      assert.strictEqual(reason.message, "Decode error (418 GET https://example.com/v1/users)")
+      assert.strictEqual(reason.cause instanceof Error, true)
+    })
+
+    it("EmptyBodyError message", () => {
+      const request = makeRequest()
+      const response = makeResponse(request)
+      const reason = new HttpClientError.EmptyBodyError({
+        request,
+        response,
+        description: "missing body"
+      })
+
+      assert.strictEqual(reason.message, "EmptyBody: missing body (418 GET https://example.com/v1/users)")
+    })
+  })
+
+  describe("wrapper", () => {
+    it("delegates message and metadata", () => {
+      const request = makeRequest()
+      const response = makeResponse(request)
+      const reason = new HttpClientError.StatusCodeError({
+        request,
+        response,
+        description: "unexpected status"
+      })
+      const error = new HttpClientError.HttpClientError({ reason })
+
+      assert.strictEqual(error.message, reason.message)
+      assert.strictEqual(error.request, request)
+      assert.strictEqual(error.response, response)
+    })
+
+    it("copies cause from reason", () => {
+      const request = makeRequest()
+      const cause = new Error("boom")
+      const error = new HttpClientError.HttpClientError({
+        reason: new HttpClientError.TransportError({
+          request,
+          cause
+        })
+      })
+
+      assert.strictEqual(error.cause, cause)
+    })
+
+    it("isHttpClientError matches wrapper only", () => {
+      const request = makeRequest()
+      const wrapper = new HttpClientError.HttpClientError({
+        reason: new HttpClientError.TransportError({ request })
+      })
+
+      assert.isTrue(HttpClientError.isHttpClientError(wrapper))
+      assert.isFalse(HttpClientError.isHttpClientError(new HttpClientError.TransportError({ request })))
+      assert.isFalse(HttpClientError.isHttpClientError(new Error("regular error")))
+      assert.isFalse(HttpClientError.isHttpClientError({ _tag: "HttpClientError" }))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add HttpClientError reason + wrapper coverage in unstable http tests
- update AiError.HttpError examples for new reason tag and wrapper type
- apply lint-fix formatting in HttpClient/HttpClientResponse