### PR TITLE
EFF-280 align AiError HttpError docs

### DIFF
--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -157,7 +157,7 @@ export const HttpResponseDetails = Schema.Struct({
  *   const error = new AiError.HttpError({
  *     module: "OpenAI",
  *     method: "createCompletion",
- *     reason: "Transport",
+ *     reason: "TransportError",
  *     request: {
  *       method: "POST",
  *       url: "https://api.openai.com/v1/completions",
@@ -169,7 +169,7 @@ export const HttpResponseDetails = Schema.Struct({
  *   })
  *
  *   console.log(error.message)
- *   // "Transport: Connection timeout after 30 seconds (POST https://api.openai.com/v1/completions)"
+ *   // "TransportError: Connection timeout after 30 seconds (POST https://api.openai.com/v1/completions)"
  * })
  * ```
  *
@@ -208,7 +208,7 @@ export class HttpError extends Schema.ErrorClass<HttpError>(
    * import { AiError } from "effect/unstable/ai"
    * import type { HttpClientError } from "effect/unstable/http"
    *
-   * declare const platformError: HttpClientError.RequestError
+   * declare const platformError: HttpClientError.HttpClientError
    *
    * const aiError = AiError.HttpError.fromHttpClientError({
    *   module: "ChatGPT",

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -553,12 +553,14 @@ export const make = (
         const controller = scopedController ?? new AbortController()
         const urlResult = UrlParams.makeUrl(request.url, request.urlParams, request.hash)
         if (Result.isFailure(urlResult)) {
-          return Effect.fail(new Error.HttpClientError({
-            reason: new Error.InvalidUrlError({
-              request,
-              cause: urlResult.failure
+          return Effect.fail(
+            new Error.HttpClientError({
+              reason: new Error.InvalidUrlError({
+                request,
+                cause: urlResult.failure
+              })
             })
-          }))
+          )
         }
         const url = urlResult.success
         const tracerDisabled = fiber.getRef(Tracer.DisablePropagation) ||

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -174,7 +174,9 @@ export const matchStatus: {
  * @category filters
  */
 export const filterStatus: {
-  (f: (status: number) => boolean): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.HttpClientError>
+  (
+    f: (status: number) => boolean
+  ): (self: HttpClientResponse) => Effect.Effect<HttpClientResponse, Error.HttpClientError>
   (self: HttpClientResponse, f: (status: number) => boolean): Effect.Effect<HttpClientResponse, Error.HttpClientError>
 } = dual(
   2,


### PR DESCRIPTION
## Summary
- align AiError HttpError doc examples with TransportError and HttpClientError wrapper
- apply lint formatting adjustments in HttpClient modules

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/AiError.test.ts
- pnpm check
- pnpm build
- pnpm docgen