### PR TITLE
EFF-282 refactor HttpServerError reason wrapper

### DIFF
--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -170,7 +170,11 @@ export const make = Effect.gen(function*() {
           result = router.find("GET", request.url)
         }
         if (result === undefined) {
-          return Effect.fail(new HttpServerError.RequestError({ reason: "RouteNotFound", request }))
+          return Effect.fail(
+            new HttpServerError.HttpServerError({
+              reason: new HttpServerError.RouteNotFound({ request })
+            })
+          )
         }
         const route = result.handler
         if (route.prefix !== undefined) {

--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -19,7 +19,7 @@ import * as Cookies from "./Cookies.ts"
 import * as Headers from "./Headers.ts"
 import * as HttpIncomingMessage from "./HttpIncomingMessage.ts"
 import { hasBody, type HttpMethod } from "./HttpMethod.ts"
-import { type HttpServerError, RequestError } from "./HttpServerError.ts"
+import { HttpServerError, type RequestError, RequestParseError } from "./HttpServerError.ts"
 import * as Multipart from "./Multipart.ts"
 import * as UrlParams from "./UrlParams.ts"
 
@@ -261,10 +261,11 @@ export const schemaBodyFormJson = <A, I, RD, RE>(
         if (isMultipart(request)) {
           return Effect.flatMap(
             Effect.mapError(request.multipart, (cause) =>
-              new RequestError({
-                request,
-                reason: "RequestParseError",
-                cause
+              new HttpServerError({
+                reason: new RequestParseError({
+                  request,
+                  cause
+                })
               })),
             parseMultipart(field)
           )
@@ -360,17 +361,19 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
       ? Stream.fromReadableStream({
         evaluate: () => this.source.body as any,
         onError: (cause) =>
-          new RequestError({
-            request: this,
-            reason: "RequestParseError",
-            cause
+          new HttpServerError({
+            reason: new RequestParseError({
+              request: this,
+              cause
+            })
           })
       })
       : Stream.fail(
-        new RequestError({
-          request: this,
-          reason: "RequestParseError",
-          description: "can not create stream from empty body"
+        new HttpServerError({
+          reason: new RequestParseError({
+            request: this,
+            description: "can not create stream from empty body"
+          })
         })
       )
   }
@@ -384,10 +387,11 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
       Effect.tryPromise({
         try: () => this.source.text(),
         catch: (cause) =>
-          new RequestError({
-            request: this,
-            reason: "RequestParseError",
-            cause
+          new HttpServerError({
+            reason: new RequestParseError({
+              request: this,
+              cause
+            })
           })
       })
     ))
@@ -399,10 +403,11 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
       Effect.try({
         try: () => JSON.parse(text) as unknown,
         catch: (cause) =>
-          new RequestError({
-            request: this,
-            reason: "RequestParseError",
-            cause
+          new HttpServerError({
+            reason: new RequestParseError({
+              request: this,
+              cause
+            })
           })
       }))
   }
@@ -412,10 +417,11 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
       Effect.try({
         try: () => UrlParams.fromInput(new URLSearchParams(_)),
         catch: (cause) =>
-          new RequestError({
-            request: this,
-            reason: "RequestParseError",
-            cause
+          new HttpServerError({
+            reason: new RequestParseError({
+              request: this,
+              cause
+            })
           })
       }))
   }
@@ -457,10 +463,11 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
       Effect.tryPromise({
         try: () => this.source.arrayBuffer(),
         catch: (cause) =>
-          new RequestError({
-            request: this,
-            reason: "RequestParseError",
-            cause
+          new HttpServerError({
+            reason: new RequestParseError({
+              request: this,
+              cause
+            })
           })
       })
     ))
@@ -469,10 +476,11 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
 
   get upgrade(): Effect.Effect<Socket.Socket, HttpServerError> {
     return Effect.fail(
-      new RequestError({
-        request: this,
-        reason: "RequestParseError",
-        description: "Not an upgradeable ServerRequest"
+      new HttpServerError({
+        reason: new RequestParseError({
+          request: this,
+          description: "Not an upgradeable ServerRequest"
+        })
       })
     )
   }
@@ -506,9 +514,8 @@ export const toWebResult = (self: HttpServerRequest, options?: {
   const url = toURL(self)
   if (url === undefined) {
     return Result.fail(
-      new RequestError({
+      new RequestParseError({
         request: self,
-        reason: "RequestParseError",
         description: "Invalid URL"
       })
     )


### PR DESCRIPTION
## Summary
- refactor HttpServerError into reason classes and wrapper delegation
- update request/response call sites to wrap reason errors
- align fromWebHandler failures with the wrapper type

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpEffect.test.ts
- pnpm check
- pnpm build
- pnpm docgen