### PR TITLE
EFF-294 refactor SocketServerError reason pattern

### DIFF
--- a/packages/effect/src/unstable/socket/SocketServer.ts
+++ b/packages/effect/src/unstable/socket/SocketServer.ts
@@ -33,10 +33,47 @@ export type ErrorTypeId = "@effect/platform/SocketServer/SocketServerError"
  * @since 4.0.0
  * @category errors
  */
-export class SocketServerError extends Data.TaggedError("SocketServerError")<{
-  readonly reason: "Open" | "Unknown"
+export class SocketServerOpenError extends Data.TaggedError("SocketServerOpenError")<{
   readonly cause: unknown
 }> {
+  override get message(): string {
+    return "Open"
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category errors
+ */
+export class SocketServerUnknownError extends Data.TaggedError("SocketServerUnknownError")<{
+  readonly cause: unknown
+}> {
+  override get message(): string {
+    return "Unknown"
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category errors
+ */
+export type SocketServerErrorReason = SocketServerOpenError | SocketServerUnknownError
+
+/**
+ * @since 4.0.0
+ * @category errors
+ */
+export class SocketServerError extends Data.TaggedError("SocketServerError")<{
+  readonly reason: SocketServerErrorReason
+}> {
+  constructor(props: {
+    readonly reason: SocketServerErrorReason
+  }) {
+    super({
+      ...props,
+      cause: props.reason.cause
+    } as any)
+  }
   /**
    * @since 4.0.0
    */
@@ -46,7 +83,7 @@ export class SocketServerError extends Data.TaggedError("SocketServerError")<{
    * @since 4.0.0
    */
   override get message(): string {
-    return this.reason
+    return this.reason.message
   }
 }
 

--- a/packages/platform-node-shared/src/NodeSocketServer.ts
+++ b/packages/platform-node-shared/src/NodeSocketServer.ts
@@ -60,8 +60,9 @@ export const make = Effect.fnUntraced(function*(
   }).pipe(
     Effect.raceFirst(Effect.mapError(Deferred.await(errorDeferred), (err) =>
       new SocketServer.SocketServerError({
-        reason: "Open",
-        cause: err
+        reason: new SocketServer.SocketServerOpenError({
+          cause: err
+        })
       })))
   )
 
@@ -187,8 +188,9 @@ export const makeWebSocket: (
     server.once("error", (error) => {
       resume(Effect.fail(
         new SocketServer.SocketServerError({
-          reason: "Open",
-          cause: error
+          reason: new SocketServer.SocketServerOpenError({
+            cause: error
+          })
         })
       ))
     })


### PR DESCRIPTION
## Summary
- add reason classes for SocketServerError and delegate message/cause to reasons
- update NodeSocketServer to construct SocketServerError with reason instances

## Testing
- pnpm lint-fix
- pnpm test packages/platform-node/test/NodeSocket.test.ts
- pnpm check
- pnpm build
- pnpm docgen