### PR TITLE
EFF-292 refactor MultipartError reason wrapper

### DIFF
--- a/packages/effect/src/unstable/http/HttpServerRequest.ts
+++ b/packages/effect/src/unstable/http/HttpServerRequest.ts
@@ -449,7 +449,7 @@ class ServerRequestImpl extends Inspectable.Class implements HttpServerRequest {
 
   get multipartStream(): Stream.Stream<Multipart.Part, Multipart.MultipartError> {
     return Stream.pipeThroughChannel(
-      Stream.mapError(this.stream, (cause) => new Multipart.MultipartError({ reason: "InternalError", cause })),
+      Stream.mapError(this.stream, (cause) => Multipart.MultipartError.fromReason("InternalError", cause)),
       Multipart.makeChannel(this.headers)
     )
   }

--- a/packages/platform-bun/src/BunMultipart.ts
+++ b/packages/platform-bun/src/BunMultipart.ts
@@ -16,7 +16,7 @@ import * as BunStream from "./BunStream.ts"
 export const stream = (source: Request): Stream.Stream<Multipart.Part, Multipart.MultipartError> =>
   BunStream.fromReadableStream({
     evaluate: () => source.body!,
-    onError: (cause) => new Multipart.MultipartError({ reason: "InternalError", cause })
+    onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
   }).pipe(
     Stream.pipeThroughChannel(Multipart.makeChannel(Object.fromEntries(source.headers)))
   )

--- a/packages/platform-node/src/NodeMultipart.ts
+++ b/packages/platform-node/src/NodeMultipart.ts
@@ -53,7 +53,7 @@ export const persisted = (
   Multipart.toPersisted(stream(source, headers), (path, file) =>
     Effect.tryPromise({
       try: (signal) => NodeStreamP.pipeline((file as FileImpl).file, NFS.createWriteStream(path), { signal }),
-      catch: (cause) => new Multipart.MultipartError({ reason: "InternalError", cause })
+      catch: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
     }))
 
 /**
@@ -120,10 +120,10 @@ class FileImpl extends PartBase implements Multipart.File {
     this.contentType = file.info.contentType
     this.content = NodeStream.fromReadable({
       evaluate: () => file,
-      onError: (cause) => new Multipart.MultipartError({ reason: "InternalError", cause })
+      onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
     })
     this.contentEffect = NodeStream.toUint8Array(() => file, {
-      onError: (cause) => new Multipart.MultipartError({ reason: "InternalError", cause })
+      onError: (cause) => Multipart.MultipartError.fromReason("InternalError", cause)
     })
   }
 
@@ -143,21 +143,21 @@ function convertError(cause: MP.MultipartError): Multipart.MultipartError {
     case "ReachedLimit": {
       switch (cause.limit) {
         case "MaxParts": {
-          return new Multipart.MultipartError({ reason: "TooManyParts", cause })
+          return Multipart.MultipartError.fromReason("TooManyParts", cause)
         }
         case "MaxFieldSize": {
-          return new Multipart.MultipartError({ reason: "FieldTooLarge", cause })
+          return Multipart.MultipartError.fromReason("FieldTooLarge", cause)
         }
         case "MaxPartSize": {
-          return new Multipart.MultipartError({ reason: "FileTooLarge", cause })
+          return Multipart.MultipartError.fromReason("FileTooLarge", cause)
         }
         case "MaxTotalSize": {
-          return new Multipart.MultipartError({ reason: "BodyTooLarge", cause })
+          return Multipart.MultipartError.fromReason("BodyTooLarge", cause)
         }
       }
     }
     default: {
-      return new Multipart.MultipartError({ reason: "Parse", cause })
+      return Multipart.MultipartError.fromReason("Parse", cause)
     }
   }
 }

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -119,7 +119,7 @@ describe("HttpServer", () => {
           return HttpServerResponse.empty()
         }).pipe(
           Effect.catchTag("MultipartError", (error) =>
-            error.reason === "FileTooLarge" ?
+            error.reason._tag === "FileTooLarge" ?
               Effect.succeed(HttpServerResponse.empty({ status: 413 })) :
               Effect.fail(error))
         )
@@ -147,7 +147,7 @@ describe("HttpServer", () => {
           return HttpServerResponse.empty()
         }).pipe(
           Effect.catchTag("MultipartError", (error) =>
-            error.reason === "FieldTooLarge" ?
+            error.reason._tag === "FieldTooLarge" ?
               Effect.succeed(HttpServerResponse.empty({ status: 413 })) :
               Effect.fail(error))
         )


### PR DESCRIPTION
## Summary
- switch MultipartError to a reason class wrapper like CookiesError
- update multipart error creation and NodeHttpServer tests to use reason tags
- keep InternalError mapping via MultipartError.fromReason helper