### PR TITLE
EFF-293 rename MigrationError kind

### DIFF
--- a/packages/sql/mysql2/src/MysqlMigrator.ts
+++ b/packages/sql/mysql2/src/MysqlMigrator.ts
@@ -50,7 +50,7 @@ export const run: <R2 = never>(
   //         .replace(/\n{2,}/gm, "\n\n")
   //         .trim()
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   const dumpSchema = mysqlDump(["--no-data"])
@@ -70,7 +70,7 @@ export const run: <R2 = never>(
   //       yield* fs.makeDirectory(path.dirname(file), { recursive: true })
   //       yield* fs.writeFileString(file, dump)
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   return dumpFile(path)

--- a/packages/sql/pg/src/PgMigrator.ts
+++ b/packages/sql/pg/src/PgMigrator.ts
@@ -50,7 +50,7 @@ export const run: <R2 = never>(
   //         .replace(/\n{2,}/gm, "\n\n")
   //         .trim()
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   const pgDumpSchema = pgDump(["--schema-only"])
@@ -74,7 +74,7 @@ export const run: <R2 = never>(
   //       yield* fs.makeDirectory(path_.dirname(path), { recursive: true })
   //       yield* fs.writeFileString(path, dump)
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   return pgDumpFile(path)

--- a/packages/sql/sqlite-bun/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-bun/src/SqliteMigrator.ts
@@ -35,7 +35,7 @@ export const run: <R2 = never>(
   //         .replace(/\n{2,}/gm, "\n\n")
   //         .trim()
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   const dumpSchema = dump([".schema"])
@@ -59,7 +59,7 @@ export const run: <R2 = never>(
   //       yield* fs.makeDirectory(path.dirname(file), { recursive: true })
   //       yield* fs.writeFileString(file, dump)
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   return dumpFile(path)

--- a/packages/sql/sqlite-node/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-node/src/SqliteMigrator.ts
@@ -35,7 +35,7 @@ export const run: <R2 = never>(
   //         .replace(/\n{2,}/gm, "\n\n")
   //         .trim()
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   const dumpSchema = dump([".schema"])
@@ -59,7 +59,7 @@ export const run: <R2 = never>(
   //       yield* fs.makeDirectory(path.dirname(file), { recursive: true })
   //       yield* fs.writeFileString(file, dump)
   //     }).pipe(
-  //       Effect.mapError((error) => new Migrator.MigrationError({ reason: "failed", message: error.message }))
+  //       Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message }))
   //     )
   //
   //   return dumpFile(path)


### PR DESCRIPTION
## Summary
- rename MigrationError reason field to kind with PascalCase values
- update Migrator error construction and matching to use the new kind
- align commented migrator examples with kind naming