### PR TITLE
EFF-286 rename EncodingError kind

### DIFF
--- a/packages/effect/src/encoding/Base64.ts
+++ b/packages/effect/src/encoding/Base64.ts
@@ -85,7 +85,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
   if (length % 4 !== 0) {
     return Result.fail(
       new EncodingError({
-        reason: "Decode",
+        kind: "Decode",
         module: "Base64",
         input: stripped,
         message: `Length must be a multiple of 4, but is ${length}`
@@ -97,7 +97,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
   if (index !== -1 && ((index < length - 2) || (index === length - 2 && stripped[length - 1] !== "="))) {
     return Result.fail(
       new EncodingError({
-        reason: "Decode",
+        kind: "Decode",
         module: "Base64",
         input: stripped,
         message: `Found a '=' character, but it is not at the end`
@@ -123,7 +123,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
   } catch (e) {
     return Result.fail(
       new EncodingError({
-        reason: "Decode",
+        kind: "Decode",
         module: "Base64",
         input: stripped,
         message: e instanceof Error ? e.message : "Invalid input"

--- a/packages/effect/src/encoding/Base64Url.ts
+++ b/packages/effect/src/encoding/Base64Url.ts
@@ -52,7 +52,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
     return Result.fail(
       new EncodingError({
         module: "Base64Url",
-        reason: "Decode",
+        kind: "Decode",
         input: stripped,
         message: `Length should be a multiple of 4, but is ${length}`
       })
@@ -63,7 +63,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
     return Result.fail(
       new EncodingError({
         module: "Base64Url",
-        reason: "Decode",
+        kind: "Decode",
         input: stripped,
         message: "Invalid input"
       })

--- a/packages/effect/src/encoding/EncodingError.ts
+++ b/packages/effect/src/encoding/EncodingError.ts
@@ -17,7 +17,7 @@ export type EncodingErrorTypeId = typeof EncodingErrorTypeId
  * @since 4.0.0
  */
 export class EncodingError extends Data.TaggedError("EncodingError")<{
-  reason: "Decode" | "Encode"
+  kind: "Decode" | "Encode"
   module: string
   input: unknown
   message: string

--- a/packages/effect/src/encoding/Hex.ts
+++ b/packages/effect/src/encoding/Hex.ts
@@ -57,7 +57,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
     return Result.fail(
       new EncodingError({
         module: "Hex",
-        reason: "Decode",
+        kind: "Decode",
         input: str,
         message: `Length must be a multiple of 2, but is ${bytes.length}`
       })
@@ -78,7 +78,7 @@ export const decode = (str: string): Result.Result<Uint8Array, EncodingError> =>
     return Result.fail(
       new EncodingError({
         module: "Hex",
-        reason: "Decode",
+        kind: "Decode",
         input: str,
         message: e instanceof Error ? e.message : "Invalid input"
       })


### PR DESCRIPTION
## Summary
- rename EncodingError field to `kind`
- update Base64, Base64Url, and Hex error creation to use `kind`

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/schema/Schema.test.ts
- pnpm check
- pnpm build
- pnpm docgen