### PR TITLE
EFF-297 remove HttpApiEndpoint add* options

### DIFF
--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -70,10 +70,7 @@ export interface HttpApiEndpoint<
    * will be inferred from the schema, otherwise it will default to 200.
    */
   addSuccess<S extends Schema.Top>(
-    schema: S,
-    annotations?: {
-      readonly status?: number | undefined
-    }
+    schema: S
   ): HttpApiEndpoint<
     Name,
     Method,
@@ -93,10 +90,7 @@ export interface HttpApiEndpoint<
    * will be inferred from the schema, otherwise it will default to 500.
    */
   addError<E extends Schema.Top>(
-    schema: E,
-    annotations?: {
-      readonly status?: number | undefined
-    }
+    schema: E
   ): HttpApiEndpoint<
     Name,
     Method,


### PR DESCRIPTION
## Summary
- drop optional annotation params from HttpApiEndpoint addSuccess/addError signatures
- keep addSuccess/addError behavior unchanged while removing unused options