### PR TITLE
EFF-300 Add tests for Effect.ignore logging

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -20,7 +20,7 @@ import {
 } from "effect"
 import { constFalse, constTrue, pipe } from "effect/Function"
 import { TestClock } from "effect/testing"
-import { assertFailureCause } from "./utils/assert.ts"
+import { assertCauseFail } from "./utils/assert.ts"
 
 class ATag extends ServiceMap.Service<ATag, "A">()("ATag") {}
 
@@ -1316,7 +1316,7 @@ describe("Effect", () => {
         const logs = yield* runIgnore({ log: true }, "Warn")
         assert.strictEqual(logs.length, 1)
         assert.strictEqual(logs[0].logLevel, "Warn")
-        assertFailureCause(logs[0].cause, "boom")
+        assertCauseFail(logs[0].cause, "boom")
       }))
 
     it.effect("logs with the provided level when log is a LogLevel", () =>
@@ -1324,7 +1324,7 @@ describe("Effect", () => {
         const logs = yield* runIgnore({ log: "Error" }, "Warn")
         assert.strictEqual(logs.length, 1)
         assert.strictEqual(logs[0].logLevel, "Error")
-        assertFailureCause(logs[0].cause, "boom")
+        assertCauseFail(logs[0].cause, "boom")
       }))
   })
 

--- a/packages/effect/test/utils/assert.ts
+++ b/packages/effect/test/utils/assert.ts
@@ -171,15 +171,10 @@ export function assertExitSuccess<A, E>(
   deepStrictEqual(exit, Exit.succeed(expected))
 }
 
-export function assertFailureCause<E>(
+export function assertCauseFail<E>(
   cause: Cause.Cause<E>,
   expected: E,
   ..._: Array<never>
 ) {
-  strictEqual(cause.failures.length, 1)
-  const failure = cause.failures[0]
-  strictEqual(Cause.failureIsFail(failure), true)
-  if (Cause.failureIsFail(failure)) {
-    strictEqual(failure.error, expected)
-  }
+  deepStrictEqual(cause, Cause.fail(expected))
 }


### PR DESCRIPTION
Summary:\n- rename the test helper to assertCauseFail and assert via Cause.fail\n- use assertCauseFail in Effect.ignore logging tests\n\nTests:\n- pnpm lint-fix\n- pnpm test packages/effect/test/Effect.test.ts\n- pnpm check\n- pnpm build\n- pnpm docgen