### PR TITLE
TIM-254: improve Stream.flattenEffect JSDoc

### DIFF
--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1817,8 +1817,25 @@ export const mapEffect: {
   ))
 
 /**
+ * Flattens a stream of `Effect` values into a stream of their results.
+ *
+ * @example
+ * ```ts
+ * import { Console, Effect, Stream } from "effect"
+ *
+ * const stream = Stream.make(Effect.succeed(1), Effect.succeed(2), Effect.succeed(3))
+ *
+ * const program = Effect.gen(function*() {
+ *   const result = yield* Stream.runCollect(stream.pipe(Stream.flattenEffect()))
+ *   yield* Console.log(result)
+ * })
+ *
+ * Effect.runPromise(program)
+ * // Output: [1, 2, 3]
+ * ```
+ *
  * @since 2.0.0
- * @category mapping
+ * @category Mapping
  */
 export const flattenEffect: {
   (


### PR DESCRIPTION
## Summary
- add summary and example for Stream.flattenEffect
- normalize JSDoc category casing to Mapping