### PR TITLE
EFF-373: add PgClient stream option

### DIFF
--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -22,6 +22,7 @@ import type { Connection } from "effect/unstable/sql/SqlConnection"
 import { SqlError } from "effect/unstable/sql/SqlError"
 import type { Custom, Fragment } from "effect/unstable/sql/Statement"
 import * as Statement from "effect/unstable/sql/Statement"
+import type { Duplex } from "node:stream"
 import type { ConnectionOptions } from "node:tls"
 import * as Pg from "pg"
 import * as PgConnString from "pg-connection-string"
@@ -77,6 +78,8 @@ export interface PgClientConfig {
   readonly username?: string | undefined
   readonly password?: Redacted.Redacted | undefined
 
+  readonly stream?: (() => Duplex) | undefined
+
   readonly idleTimeout?: Duration.DurationInput | undefined
   readonly connectTimeout?: Duration.DurationInput | undefined
 
@@ -120,6 +123,7 @@ export const make = (
       password: options.password ? Redacted.value(options.password) : undefined,
       ssl: options.ssl,
       port: options.port,
+      ...(options.stream ? { stream: options.stream } : {}),
       connectionTimeoutMillis: options.connectTimeout
         ? Duration.toMillis(Duration.fromDurationInputUnsafe(options.connectTimeout))
         : undefined,


### PR DESCRIPTION
## Summary
- add PgClient config `stream` option for custom pg socket creation
- pass `stream` through when constructing the pg pool

## Testing
- `pnpm lint-fix`
- `pnpm test packages/sql/pg/test/Client.test.ts` (fails: no container runtime available)
- `pnpm check`
- `pnpm build`
- `pnpm docgen`