### PR TITLE
EFF-389 Rename this option to self

### DIFF
--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1328,7 +1328,7 @@ export const gen: {
   >
   <Self, Eff extends Yieldable<any, any, any, any>, AEff>(
     options: {
-      readonly this: Self
+      readonly self: Self
     },
     f: (this: Self) => Generator<Eff, AEff, never>
   ): Effect<
@@ -10143,7 +10143,7 @@ export namespace fn {
         : never
     >
     <Self, Eff extends Yieldable<any, any, any, any>, AEff, Args extends Array<any>>(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>)
     ): (...args: Args) => Effect<
       AEff,
@@ -10186,7 +10186,7 @@ export namespace fn {
       ) => A
     ): (this: Self, ...args: Args) => A
     <Self, Eff extends Yieldable<any, any, any, any>, AEff, Args extends Array<any>, A>(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10235,7 +10235,7 @@ export namespace fn {
       b: (_: A, ...args: Args) => B
     ): (this: Self, ...args: Args) => B
     <Self, Eff extends Yieldable<any, any, any, any>, AEff, Args extends Array<any>, A, B>(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10310,7 +10310,7 @@ export namespace fn {
       B,
       C
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10392,7 +10392,7 @@ export namespace fn {
       C,
       D
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10480,7 +10480,7 @@ export namespace fn {
       D,
       E
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10574,7 +10574,7 @@ export namespace fn {
       E,
       F
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10674,7 +10674,7 @@ export namespace fn {
       F,
       G
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10780,7 +10780,7 @@ export namespace fn {
       G,
       H
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -10892,7 +10892,7 @@ export namespace fn {
       H,
       I
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11010,7 +11010,7 @@ export namespace fn {
       I,
       J
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11134,7 +11134,7 @@ export namespace fn {
       J,
       K
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11264,7 +11264,7 @@ export namespace fn {
       K,
       L
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11400,7 +11400,7 @@ export namespace fn {
       L,
       M
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11542,7 +11542,7 @@ export namespace fn {
       M,
       N
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11690,7 +11690,7 @@ export namespace fn {
       N,
       O
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -11844,7 +11844,7 @@ export namespace fn {
       O,
       P
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -12004,7 +12004,7 @@ export namespace fn {
       P,
       Q
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -12170,7 +12170,7 @@ export namespace fn {
       Q,
       R
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -12342,7 +12342,7 @@ export namespace fn {
       R,
       S
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<
@@ -12520,7 +12520,7 @@ export namespace fn {
       S,
       T
     >(
-      options: { readonly this: Self },
+      options: { readonly self: Self },
       body: (this: Self, ...args: Args) => Generator<Eff, AEff, never> | (Eff & Effect<AEff, any, any>),
       a: (
         _: Effect<

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -1066,7 +1066,7 @@ export const gen = <
   AEff
 >(
   ...args:
-    | [options: { readonly this: Self }, body: (this: Self) => Generator<Eff, AEff, never>]
+    | [options: { readonly self: Self }, body: (this: Self) => Generator<Eff, AEff, never>]
     | [body: () => Generator<Eff, AEff, never>]
 ): Effect.Effect<
   AEff,
@@ -1079,7 +1079,7 @@ export const gen = <
 > =>
   suspend(() =>
     fromIteratorUnsafe(
-      args.length === 1 ? args[0]() : (args[1].call(args[0].this) as any)
+      args.length === 1 ? args[0]() : (args[1].call(args[0].self) as any)
     )
   )
 
@@ -1115,7 +1115,7 @@ export const fn: typeof Effect.fn = function() {
   globalThis.Error.stackTraceLimit = prevLimit
 
   if (nameFirst) {
-    return (body: Function | { readonly this: any }, ...pipeables: Array<Function>) =>
+    return (body: Function | { readonly self: any }, ...pipeables: Array<Function>) =>
       makeFn(name, body, defError, pipeables, nameFirst, spanOptions)
   }
 
@@ -1131,7 +1131,7 @@ export const fn: typeof Effect.fn = function() {
 
 const makeFn = (
   name: string,
-  bodyOrOptions: Function | { readonly this: any },
+  bodyOrOptions: Function | { readonly self: any },
   defError: Error,
   pipeables: Array<Function>,
   addSpan: boolean,
@@ -1139,7 +1139,7 @@ const makeFn = (
 ) => {
   const body = typeof bodyOrOptions === "function"
     ? bodyOrOptions
-    : (pipeables.pop()!).bind(bodyOrOptions.this)
+    : (pipeables.pop()!).bind(bodyOrOptions.self)
 
   return function(this: any, ...args: Array<any>) {
     let result = suspend(() => {

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -265,7 +265,7 @@ const Proto = {
     this: Toolkit<Record<string, Tool.Any>>,
     build: Record<string, (params: any) => any> | Effect.Effect<Record<string, (params: any) => any>>
   ) {
-    return Effect.gen({ this: this }, function*() {
+    return Effect.gen({ self: this }, function*() {
       const services = yield* Effect.services<never>()
       const handlers = Effect.isEffect(build) ? yield* build : build
       const serviceMap = new Map<string, unknown>()
@@ -283,7 +283,7 @@ const Proto = {
     return Layer.effectServices(this.toHandlers(build))
   },
   asEffect(this: Toolkit<Record<string, Tool.Any>>) {
-    return Effect.gen({ this: this }, function*() {
+    return Effect.gen({ self: this }, function*() {
       const tools = this.tools
       const services = yield* Effect.services<never>()
       const schemasCache = new WeakMap<any, {

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -290,7 +290,7 @@ const Proto = {
       readonly spanAttributes?: Record<string, string> | undefined
     }
   ) {
-    const buildHandlers = Effect.gen({ this: this }, function*() {
+    const buildHandlers = Effect.gen({ self: this }, function*() {
       const behaviour = Effect.isEffect(build) ? yield* build : build
       const queue = yield* Queue.make<Envelope.Request<Rpcs>>()
 

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -828,7 +828,7 @@ class MiddlewareImpl<
     this.layerFn = layerFn
     this.dependencies = dependencies
     const contextKey = `effect/http/HttpRouter/Middleware-${++middlewareId}` as const
-    this.layer = Layer.effectServices(Effect.gen({ this: this }, function*() {
+    this.layer = Layer.effectServices(Effect.gen({ self: this }, function*() {
       const context = yield* Effect.services<Scope.Scope>()
       const stack = [context.mapUnsafe.get(fnContextKey)]
       if (this.dependencies) {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -192,7 +192,7 @@ describe("Effect", () => {
       }).pipe(Effect.runPromise).then((_) => assert.deepStrictEqual(_, 1)))
 
     it("gen with context", () =>
-      Effect.gen({ this: { a: 1, b: 2 } }, function*() {
+      Effect.gen({ self: { a: 1, b: 2 } }, function*() {
         const result = yield* Effect.succeed(this.a)
         assert.strictEqual(result, 1)
         return result + this.b


### PR DESCRIPTION
## Summary
- rename Effect.gen and Effect.fn* options from \"this\" to \"self\"
- update internal implementations to bind using the new option key
- adjust Effect.gen call sites using context options