### PR TITLE
EFF-415 Investigate why Atom finalizers might not run

### DIFF
--- a/.specs/README.md
+++ b/.specs/README.md
@@ -10,6 +10,7 @@ This directory contains specifications for all major features and enhancements i
 - [effect-ignore-log.md](effect-ignore-log.md) - Add optional logging to `Effect.ignore` and remove `Effect.ignoreLogged`.
 - [effect-jsdoc-improvements.md](effect-jsdoc-improvements.md) - Improve JSDoc clarity and consistency for `Effect.ts`.
 - [stream-jsdoc-improvements.md](stream-jsdoc-improvements.md) - Improve JSDoc clarity and consistency for `Stream.ts`.
+- [atom-finalizers-reliability.md](atom-finalizers-reliability.md) - Investigate finalizer reliability in Atom lifetime disposal and scheduler cleanup.
 - [scoped-atom-port.md](scoped-atom-port.md) - Port the legacy ScopedAtom module into `@effect/atom-react`.
 - [atom-solid-bindings.md](atom-solid-bindings.md) - Add `@effect/atom-solid` bindings for Effect Atom modules in SolidJS.
 - [devtools-v3-port.md](devtools-v3-port.md) - Port Effect v3 DevTools modules into `effect/unstable/devtools`.

--- a/.specs/atom-finalizers-reliability.md
+++ b/.specs/atom-finalizers-reliability.md
@@ -1,0 +1,60 @@
+# Atom Finalizer Reliability (EFF-415)
+
+## Summary
+
+Investigate why Atom finalizers can appear to "not run" in
+`effect/unstable/reactivity`.
+
+## Findings
+
+- Finalizers are stored on `Lifetime` and executed in
+  `packages/effect/src/unstable/reactivity/AtomRegistry.ts` inside
+  `LifetimeProto.dispose`.
+- `dispose` runs `finalizers[i]()` directly in reverse order, with no
+  `try/catch`.
+- Node disposal triggered by `registry.mount(... )` unmount is async:
+  `subscribe` cleanup -> `scheduleNodeRemoval` -> async scheduler task.
+- `packages/effect/src/Scheduler.ts` `MixedScheduler.runTasks` also runs tasks
+  without `try/catch`.
+
+### Consequence
+
+If any Atom finalizer throws:
+
+1. Remaining finalizers in that same `Lifetime` are skipped.
+2. The error escapes the async scheduler callback.
+3. Remaining scheduler tasks in that tick can be skipped as stack unwinds,
+   so other pending node removals / finalizers may not execute.
+
+This is the main reason finalizers can seem unreliable.
+
+## Repro Notes
+
+A temporary repro test (`packages/effect/test/reactivity/EFF-415.repro.test.ts`,
+not committed) confirmed the throw path:
+
+- stack included `LifetimeProto.dispose` at `AtomRegistry.ts:913`
+- then `NodeImpl.remove` -> `RegistryImpl.removeNode` ->
+  `MixedScheduler.runTasks`
+
+## Proposed Implementation Plan
+
+1. Make `LifetimeProto.dispose` resilient:
+   - execute all finalizers even when one throws
+   - capture thrown errors while continuing the loop
+2. Decide error policy after running all finalizers:
+   - preserve current fail-fast semantics by rethrowing first error after loop,
+     or
+   - report aggregated error in a controlled way (avoid aborting unrelated
+     scheduler tasks)
+3. Add regression tests in `packages/effect/test/reactivity/Atom.test.ts`:
+   - all finalizers run even if one throws
+   - scheduler queue continues running cleanup work when a finalizer fails
+
+## Validation (for implementation task)
+
+- `pnpm lint-fix`
+- `pnpm test packages/effect/test/reactivity/Atom.test.ts`
+- `pnpm check` (run `pnpm clean` then re-run if needed)
+- `pnpm build`
+- `pnpm docgen`


### PR DESCRIPTION
## Summary
- add a new investigation spec at `.specs/atom-finalizers-reliability.md` documenting why Atom finalizers can appear to not run
- capture the root cause: thrown finalizers in `LifetimeProto.dispose` are uncaught, and cleanup runs on async scheduler tasks that also do not catch errors
- document proposed follow-up implementation/test plan and link the spec from `.specs/README.md`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/reactivity/Atom.test.ts
- pnpm check
- pnpm build
- pnpm docgen