### PR TITLE
Add catchTagOrDie and catchTagsOrDie APIs

### DIFF
--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1418,6 +1418,44 @@ describe("Effect", () => {
         assert.strictEqual(yield* effect, 3)
       }))
 
+    it.effect("catchTagOrDie", () =>
+      Effect.gen(function*() {
+        let error: ErrorA | ErrorB = new ErrorA()
+        const effect = Effect.failSync(() => error).pipe(
+          Effect.catchTagOrDie("A", (_) => Effect.succeed(1))
+        )
+        assert.strictEqual(yield* effect, 1)
+        error = new ErrorB()
+        assert.deepStrictEqual(yield* Effect.exit(effect), Exit.die(new ErrorB()))
+      }))
+
+    it.effect("catchTagOrDie - array of tags", () =>
+      Effect.gen(function*() {
+        class ErrorD extends Data.TaggedError("D") {}
+        let error: ErrorA | ErrorB | ErrorD = new ErrorA()
+        const effect = Effect.failSync(() => error).pipe(
+          Effect.catchTagOrDie(["A", "B"], (_) => Effect.succeed(1))
+        )
+        assert.strictEqual(yield* effect, 1)
+        error = new ErrorB()
+        assert.strictEqual(yield* effect, 1)
+        error = new ErrorD()
+        assert.deepStrictEqual(yield* Effect.exit(effect), Exit.die(new ErrorD()))
+      }))
+
+    it.effect("catchTagsOrDie", () =>
+      Effect.gen(function*() {
+        let error: ErrorA | ErrorB = new ErrorA()
+        const effect = Effect.failSync(() => error).pipe(
+          Effect.catchTagsOrDie({
+            A: (_) => Effect.succeed(1)
+          })
+        )
+        assert.strictEqual(yield* effect, 1)
+        error = new ErrorB()
+        assert.deepStrictEqual(yield* Effect.exit(effect), Exit.die(new ErrorB()))
+      }))
+
     it.effect("tapErrorTag", () =>
       Effect.gen(function*() {
         let error: ErrorA | ErrorB | ErrorC = new ErrorA()


### PR DESCRIPTION
Adapted from https://github.com/Effect-TS/effect/pull/6043

## Summary
- Add `catchTagOrDie` — catches specific tagged errors by `_tag`, converting unmatched errors into defects (die). Unlike `catchTag`, unhandled errors are removed from the error channel entirely.
- Add `catchTagsOrDie` — same semantics but accepts an object of handlers (like `catchTags`).
- Both support dual (data-first and data-last) calling conventions and variadic tag arguments (for `catchTagOrDie`).

## Motivation

A common pattern is catching one specific tagged error and re-mapping it, while treating all other errors as unexpected defects. The natural approach doesn't work:

```ts
declare const findUser: Effect<User, DbNotFound | DbUnknown>

findUser.pipe(
  Effect.catchTag("DbNotFound", () => new MyError({ message: "not found" })),
  Effect.orDie // also turns MyError into a defect!
)
```

`orDie` kills *all* errors — including the `MyError` that was just introduced by the handler. One workaround today is a manual `catchAll` branch:

```ts
findUser.pipe(
  Effect.catchAll((e) =>
    e._tag === "DbNotFound"
      ? new MyError({ message: "not found" })
      : Effect.die(e)
  )
)
```

`catchTagOrDie` makes this a one-liner:

```ts
findUser.pipe(
  Effect.catchTagOrDie("DbNotFound", () =>
     new MyError({ message: "not found" })
  )
)
// Effect<User, MyError>
```