### PR TITLE
Add fiber keep-alive and layer memoization migration guides

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -66,6 +66,7 @@ minimal Effect program bundles to ~6.3 KB (minified + gzipped). With Schema,
 - [Forking: Renamed Combinators and New Options](./migration/forking.md)
 - [Effect Subtyping → Yieldable](./migration/yieldable.md)
 - [Fiber Keep-Alive: Automatic Process Lifetime Management](./migration/fiber-keep-alive.md)
+- [Layer Memoization Across `Effect.provide` Calls](./migration/layer-memoization.md)
 
 ### Modules
 

--- a/migration/fiber-keep-alive.md
+++ b/migration/fiber-keep-alive.md
@@ -1,7 +1,7 @@
 # Fiber Keep-Alive: Automatic Process Lifetime Management
 
 In v3, the core `effect` runtime did **not** keep the Node.js process alive while
-fibers were suspended on asynchronous operations. If a fiber was waiting on
+fibers were suspended on certain asynchronous operations. If a fiber was waiting on
 something like `Deferred.await` and there was no other work scheduled on the
 event loop, the process would exit immediately — the fiber's suspension did not
 register as pending work from Node.js's perspective.
@@ -10,43 +10,36 @@ The only way to prevent this was to use `runMain` from `@effect/platform-node`
 (or `@effect/platform-bun`), which installed a long-lived `setInterval` timer
 to hold the process open until the root fiber completed.
 
-In v4, **the keep-alive mechanism is built into the core runtime**. Any
-asynchronous operation — `Deferred.await`, `Effect.callback`, `Effect.never`,
-etc. — automatically keeps the process alive while the fiber is suspended. This
-works regardless of how you run the program (`Effect.runPromise`,
-`Effect.runFork`, or `runMain`).
+In v4, **the keep-alive mechanism is built into the core runtime**.
 
 ## The Problem in v3
 
-Consider a program that forks a background fiber, then waits on a `Deferred`:
+Consider the following program:
 
 ```ts
-import { Deferred, Effect, Fiber } from "effect"
+import { Deferred, Effect } from "effect"
 
 const program = Effect.gen(function*() {
   const deferred = yield* Deferred.make<string>()
 
-  const worker = yield* Effect.fork(
-    Effect.delay(Effect.succeed("done"), "2 seconds").pipe(
-      Effect.flatMap((value) => Deferred.succeed(deferred, value))
-    )
+  const worker = yield* Effect.sleep("5 seconds").pipe(
+    Effect.andThen(Deferred.succeed(deferred, "Done")),
+    Effect.fork
   )
 
-  // Wait for the deferred to be completed by the worker
-  const result = yield* deferred // v3: Deferred is an Effect subtype
-  console.log(result)
+  yield* Deferred.await(deferred)
 })
 
 Effect.runPromise(program)
 ```
 
-In v3, when the main fiber reached `yield* deferred`, it suspended — waiting for
-the worker to complete the deferred. But from Node.js's perspective, there was
-nothing keeping the event loop alive (the `Effect.delay` was implemented via the
-Effect scheduler, not a raw `setTimeout` visible to Node.js). The process would
-exit before the worker had a chance to complete.
+In v3, when the main fiber reached `yield* Deferred.await(deferred)`, it suspended
+while waiting for the worker fiber to complete the deferred. However, from the
+JavaScript runtime's perspective, the event loop had no more work to do. Thus,
+the process would exit.
 
-The workaround was to use `runMain` from the platform package:
+The workaround was to use `runMain` from the platform package, which installs
+a timer that holds the process open until the root fiber completes:
 
 ```ts
 import { NodeRuntime } from "@effect/platform-node"
@@ -54,22 +47,12 @@ import { NodeRuntime } from "@effect/platform-node"
 NodeRuntime.runMain(program)
 ```
 
-`runMain` installed a `setInterval(constVoid, 2 ** 31 - 1)` timer that held the
-process open until the root fiber completed, then cleared it.
-
 ## What Changed in v4
 
-In v4, the async primitive (`Effect.callback`, which underlies `Deferred.await`,
-`Effect.never`, and all other async operations) automatically manages a
-reference-counted keep-alive timer:
+In v4, the Effect fiber runtime automatically manages a reference-counted
+keep-alive timer.
 
-1. When a fiber suspends on an async operation, the runtime increments a counter
-   and starts a `setInterval` timer (if one is not already running).
-2. When the fiber resumes, the counter is decremented.
-3. When the counter reaches zero (no fibers are suspended), the timer is cleared
-   and the process is free to exit.
-
-This means the following program works correctly in v4 **without** `runMain`:
+This means the following program works in v4 **without** `runMain`:
 
 ```ts
 import { Deferred, Effect, Fiber } from "effect"
@@ -77,41 +60,17 @@ import { Deferred, Effect, Fiber } from "effect"
 const program = Effect.gen(function*() {
   const deferred = yield* Deferred.make<string>()
 
-  const worker = yield* Effect.forkChild(
-    Effect.delay(Effect.succeed("done"), "2 seconds").pipe(
-      Effect.flatMap((value) => Deferred.succeed(deferred, value))
-    )
+  const worker = yield* Effect.sleep("5 seconds").pipe(
+    Effect.andThen(Deferred.succeed(deferred, "Done")),
+    Effect.forkChild
   )
 
   // The process stays alive while waiting — no runMain needed
-  const result = yield* Deferred.await(deferred)
-  console.log(result) // "done"
+  yield* Deferred.await(deferred)
 })
 
 Effect.runPromise(program)
 ```
-
-Note the two v4 changes visible in the example above (covered in their own
-migration guides):
-
-- `Effect.fork` → `Effect.forkChild`
-- `yield* deferred` → `yield* Deferred.await(deferred)` (Deferred is no longer
-  an Effect subtype)
-
-## When Does This Matter?
-
-The keep-alive change affects any program where a fiber is suspended with no
-other visible event-loop work. Common cases:
-
-- **Waiting on a `Deferred`** that will be completed by another fiber or an
-  external event.
-- **`Effect.never`** — in v3 this had its own dedicated `setInterval` to stay
-  alive. In v4, it uses `Effect.callback` like everything else and benefits from
-  the shared keep-alive.
-- **Long-running servers** — a server that calls `Effect.never` to keep running
-  after setup no longer needs special handling.
-- **`Effect.runFork` followed by `Fiber.join`** — the forked fiber's async
-  operations keep the process alive automatically.
 
 ## `runMain` Is Still Recommended
 
@@ -123,6 +82,3 @@ packages is still the recommended way to run Effect programs. It provides:
 - **Exit code management** — calls `process.exit(code)` when the program fails
   or receives a signal.
 - **Error reporting** — reports unhandled errors to the console.
-
-The difference is that `runMain` in v4 **no longer needs its own keep-alive
-timer** — it delegates to the core runtime's built-in mechanism.

--- a/migration/layer-memoization.md
+++ b/migration/layer-memoization.md
@@ -1,0 +1,98 @@
+# Layer Memoization
+
+In v3, each call to `Effect.provide` created its own memoization scope. Layers
+were memoized / deduplicated within a single `Effect.provide` call, but would
+**not** be shared across separate calls — so two `Effect.provide` calls with
+overlapping layers would silently build those layers twice.
+
+In v4, the underlying `MemoMap` data structure which facilitates memoization of
+`Layer`s is shared between `Effect.provide` calls (unless explicitly disabled
+via the `{ local: true }` option). Thus, layers are automatically memoized /
+deduplicated across `Effect.provide` calls.
+
+## Example
+
+```ts
+import { Console, Effect, Layer, ServiceMap } from "effect"
+
+const MyService = ServiceMap.Service<{ readonly value: string }>("MyService")
+
+const MyServiceLayer = Layer.effect(
+  MyService,
+  Effect.gen(function*() {
+    yield* Console.log("Building MyService")
+    return { value: "hello" }
+  })
+)
+
+const program = Effect.gen(function*() {
+  const a = yield* MyService
+  return a.value
+})
+
+// Same layer provided twice in separate provide calls
+const main = program.pipe(
+  Effect.provide(MyServiceLayer),
+  Effect.provide(MyServiceLayer)
+)
+
+// Effect v3: "Building MyService" is logged TWICE
+// Effect v4: "Building MyService" is logged ONCE
+Effect.runPromise(main)
+```
+
+## Prefer Layer Composition Over Multipl Provides
+
+Even though v4 memoizes across `provide` calls, **composing layers before
+providing is still the recommended pattern**. Layer composition makes your
+dependency graph explicit and lets you see the full structure in one place:
+
+```ts
+// Preferred — provide once
+const main = program.pipe(Effect.provide(MyServiceLayer))
+```
+
+The auto-memoization feature is a safety net to avoid the footguns associated
+with multiple `Effect.provide` calls present in v3. It is **NOT** a substitute
+for proper layer composition.
+
+## Opting Out of Shared Memoization
+
+There are cases where you **want** a layer to be built fresh — for example,
+test isolation or creating independent resource pools. v4 provides two
+mechanisms:
+
+### `Layer.fresh`
+
+Wraps a layer so it always builds with a fresh memo map, bypassing the shared
+cache. This existed in v3 as well.
+
+```ts
+import { Effect, Layer } from "effect"
+
+const main = program.pipe(
+  Effect.provide(MyServiceLayer),
+  Effect.provide(Layer.fresh(MyServiceLayer))
+)
+// "Building MyService" is logged TWICE — fresh bypasses the shared cache
+```
+
+### `Effect.provide` with `{ local: true }`
+
+New in v4. Builds the provided layer with a **local memo map** instead of the
+fiber's shared one. The layer and all its sublayers are built from scratch and
+are not shared with other `provide` calls.
+
+```ts
+import { Effect } from "effect"
+
+const main = program.pipe(
+  Effect.provide(MyServiceLayer),
+  Effect.provide(MyServiceLayer, { local: true })
+)
+// "Building MyService" is logged TWICE — local creates its own memo map
+```
+
+Use `local: true` when you need an entire layer subtree to be isolated — for
+example, when providing layers in a test harness where each test should get
+independent resources.


### PR DESCRIPTION
## Summary

- Adds two new migration guides for the v3 → v4 transition:
  - **Fiber keep-alive** — explains how the process keep-alive mechanism moved from `@effect/platform-node`'s `runMain` into the core Effect runtime, so async operations like `Deferred.await` now keep the process alive regardless of which run function is used
  - **Layer memoization** — explains how v4 shares layer memoization across multiple `Effect.provide` calls via a fiber-level `MemoMap`, and documents the `Layer.fresh` and `{ local: true }` opt-outs
- Links both guides from the migration index in `MIGRATION.md`

## Test plan

- [ ] Verify guides render correctly on GitHub
- [ ] Confirm code examples are accurate against the v4 API
- [ ] Review quick reference tables for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)