### PR TITLE
EFF-420 Fix AsyncResult.builder onDefect

### DIFF
--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -741,7 +741,7 @@ class BuilderImpl<Out, A, E> {
   onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): BuilderImpl<Out | B, A, E> {
     return this.when(isFailure, (result) => {
       const defect = Cause.filterDefect(result.cause)
-      return Filter.isFail(defect) ? Option.some(f(defect, result)) : Option.none()
+      return Filter.isFail(defect) ? Option.none() : Option.some(f(defect, result))
     })
   }
 

--- a/packages/effect/test/reactivity/AsyncResult.test.ts
+++ b/packages/effect/test/reactivity/AsyncResult.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Cause } from "effect"
+import { AsyncResult } from "effect/unstable/reactivity"
+
+describe("AsyncResult", () => {
+  describe("builder", () => {
+    it("onDefect handles defects", () => {
+      const defect = new Error("boom")
+      const result = AsyncResult.failure<number, string>(Cause.die(defect))
+
+      const handled = AsyncResult.builder(result)
+        .onDefect((received) => received)
+        .orElse(() => null)
+
+      expect(handled).toBe(defect)
+    })
+
+    it("onDefect does not handle typed errors", () => {
+      const handled = AsyncResult.builder(AsyncResult.fail("error"))
+        .onDefect(() => "defect")
+        .orElse(() => "fallback")
+
+      expect(handled).toEqual("fallback")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- fix `AsyncResult.builder(...).onDefect(...)` to return a handled value only when a defect is present
- add regression tests in `packages/effect/test/reactivity/AsyncResult.test.ts` covering defect handling and typed-error fallback behavior
- run validation: `pnpm lint-fix`, `pnpm test packages/effect/test/reactivity/AsyncResult.test.ts`, `pnpm check`, `pnpm build`, `pnpm docgen`