### PR TITLE
EFF-422: fix Stream.decodeText for split multi-byte characters

### DIFF
--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -8379,7 +8379,7 @@ export const decodeText: {
   <E, R>(self: Stream<Uint8Array, E, R>, encoding?: string | undefined): Stream<string, E, R> =>
     suspend(() => {
       const decoder = new TextDecoder(encoding)
-      return map(self, (chunk) => decoder.decode(chunk))
+      return map(self, (chunk) => decoder.decode(chunk, { stream: true }))
     })
 )
 

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -147,6 +147,29 @@ describe("Stream", () => {
       }))
   })
 
+  describe("encoding", () => {
+    it.effect("decodeText handles multi-byte characters split across chunks", () =>
+      Effect.gen(function*() {
+        const bytes = new TextEncoder().encode("🌍")
+        const result = yield* Stream.make(bytes.slice(0, 2), bytes.slice(2)).pipe(
+          Stream.decodeText(),
+          Stream.mkString
+        )
+        assert.strictEqual(result, "🌍")
+      }))
+
+    it.effect("decodeText handles mixed ASCII and multi-byte characters across chunks", () =>
+      Effect.gen(function*() {
+        const bytes = new TextEncoder().encode("Hello 🌍!")
+        const split = 8
+        const result = yield* Stream.make(bytes.slice(0, split), bytes.slice(split)).pipe(
+          Stream.decodeText(),
+          Stream.mkString
+        )
+        assert.strictEqual(result, "Hello 🌍!")
+      }))
+  })
+
   describe("taking", () => {
     it.effect("take - pulls the first `n` values from a stream", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- port the Effect 3 `Stream.decodeText` behavior by decoding chunks with `TextDecoder.decode(..., { stream: true })` so split multi-byte code points are reconstructed correctly across chunk boundaries
- add regression tests in `packages/effect/test/Stream.test.ts` for split emoji bytes and mixed ASCII + multi-byte content spanning chunks
- run validation loop: `pnpm lint-fix`, `pnpm test packages/effect/test/Stream.test.ts`, `pnpm check`, `pnpm build`, and `pnpm docgen`