### PR TITLE
EFF-444 Add single-table SQL persistence backend

### DIFF
--- a/packages/sql/mysql2/test/Persistence.test.ts
+++ b/packages/sql/mysql2/test/Persistence.test.ts
@@ -9,6 +9,11 @@ PersistedCacheTest.suite(
   Persistence.layerSql.pipe(Layer.provide(MysqlContainer.layerClient))
 )
 
+PersistedCacheTest.suite(
+  "sql-mysql2-single-table",
+  Persistence.layerSqlSingleTable.pipe(Layer.provide(MysqlContainer.layerClient))
+)
+
 PersistedQueueTest.suite(
   "sql-mysql2",
   PersistedQueue.layerStoreSql().pipe(

--- a/packages/sql/pg/test/Persistence.test.ts
+++ b/packages/sql/pg/test/Persistence.test.ts
@@ -9,6 +9,11 @@ PersistedCacheTest.suite(
   Persistence.layerSql.pipe(Layer.provide(PgContainer.layerClient))
 )
 
+PersistedCacheTest.suite(
+  "sql-pg-single-table",
+  Persistence.layerSqlSingleTable.pipe(Layer.provide(PgContainer.layerClient))
+)
+
 PersistedQueueTest.suite(
   "sql-pg",
   PersistedQueue.layerStoreSql().pipe(Layer.provide(PgContainer.layerClient))

--- a/packages/sql/sqlite-node/test/Persistence.test.ts
+++ b/packages/sql/sqlite-node/test/Persistence.test.ts
@@ -5,6 +5,7 @@ import { Duration, Effect, FileSystem, Layer } from "effect"
 import { TestClock } from "effect/testing"
 import { Persistence } from "effect/unstable/persistence"
 import { Reactivity } from "effect/unstable/reactivity"
+import type * as SqlClient from "effect/unstable/sql/SqlClient"
 
 const ClientLayer = Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem
@@ -16,69 +17,93 @@ const ClientLayer = Effect.gen(function*() {
   Layer.unwrap,
   Layer.provide([NodeFileSystem.layer, Reactivity.layer])
 )
-const PersistenceLayer = Persistence.layerBackingSql.pipe(Layer.provideMerge(ClientLayer))
 
-it.layer(PersistenceLayer)("Persistence", (it) => {
-  it.effect("set + get", () =>
-    Effect.gen(function*() {
-      const persistence = yield* Persistence.BackingPersistence
-      const store = yield* persistence.make("test_store")
-      yield* store.set("key1", { name: "Alice" }, undefined)
-      const value = yield* store.get("key1")
-      expect(value).toEqual({ name: "Alice" })
+const testLayer = (layer: Layer.Layer<Persistence.BackingPersistence, never, SqlClient.SqlClient>) =>
+  layer.pipe(Layer.provideMerge(ClientLayer))
 
-      // test upsert
-      yield* store.set("key1", { name: "Alice" }, undefined)
-    }))
+const suite = (name: string, layer: Layer.Layer<Persistence.BackingPersistence, never, SqlClient.SqlClient>) =>
+  it.layer(testLayer(layer))(`Persistence (${name})`, (it) => {
+    it.effect("set + get", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const store = yield* persistence.make("test_store")
+        yield* store.set("key1", { name: "Alice" }, undefined)
+        const value = yield* store.get("key1")
+        expect(value).toEqual({ name: "Alice" })
 
-  it.effect("setMany + getMany", () =>
-    Effect.gen(function*() {
-      const persistence = yield* Persistence.BackingPersistence
-      const store = yield* persistence.make("test_store_2")
-      yield* store.setMany([
-        ["key1", { name: "Alice" }, undefined],
-        ["key2", { name: "Bob" }, undefined],
-        ["key3", { name: "Charlie" }, undefined]
-      ])
-      const values = yield* store.getMany(["key1", "key2", "key3", "key4"])
-      expect(values).toEqual([
-        { name: "Alice" },
-        { name: "Bob" },
-        { name: "Charlie" },
-        undefined
-      ])
-    }))
+        // test upsert
+        yield* store.set("key1", { name: "Alice" }, undefined)
+      }))
 
-  it.effect("remove", () =>
-    Effect.gen(function*() {
-      const persistence = yield* Persistence.BackingPersistence
-      const store = yield* persistence.make("test_store_2")
-      yield* store.setMany([
-        ["key1", { name: "Alice" }, undefined],
-        ["key2", { name: "Bob" }, undefined],
-        ["key3", { name: "Charlie" }, undefined]
-      ])
-      yield* store.remove("key2")
-      const valuesAfter = yield* store.getMany(["key1", "key2", "key3"])
-      expect(valuesAfter).toEqual([{ name: "Alice" }, undefined, { name: "Charlie" }])
-    }))
+    it.effect("setMany + getMany", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const store = yield* persistence.make("test_store_2")
+        yield* store.setMany([
+          ["key1", { name: "Alice" }, undefined],
+          ["key2", { name: "Bob" }, undefined],
+          ["key3", { name: "Charlie" }, undefined]
+        ])
+        const values = yield* store.getMany(["key1", "key2", "key3", "key4"])
+        expect(values).toEqual([
+          { name: "Alice" },
+          { name: "Bob" },
+          { name: "Charlie" },
+          undefined
+        ])
+      }))
 
-  it.effect("expires", () =>
-    Effect.gen(function*() {
-      const persistence = yield* Persistence.BackingPersistence
-      const store = yield* persistence.make("test_store_3")
-      yield* store.setMany([
-        ["key1", { name: "Alice" }, undefined],
-        ["key2", { name: "Bob" }, undefined],
-        ["key3", { name: "Charlie" }, Duration.seconds(10)]
-      ])
-      let values = yield* store.getMany(["key1", "key2", "key3"])
-      expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, { name: "Charlie" }])
-      yield* TestClock.adjust(Duration.seconds(5))
-      values = yield* store.getMany(["key1", "key2", "key3"])
-      expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, { name: "Charlie" }])
-      yield* TestClock.adjust(Duration.seconds(5))
-      values = yield* store.getMany(["key1", "key2", "key3"])
-      expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, undefined])
-    }))
-})
+    it.effect("remove", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const store = yield* persistence.make("test_store_2")
+        yield* store.setMany([
+          ["key1", { name: "Alice" }, undefined],
+          ["key2", { name: "Bob" }, undefined],
+          ["key3", { name: "Charlie" }, undefined]
+        ])
+        yield* store.remove("key2")
+        const valuesAfter = yield* store.getMany(["key1", "key2", "key3"])
+        expect(valuesAfter).toEqual([{ name: "Alice" }, undefined, { name: "Charlie" }])
+      }))
+
+    it.effect("expires", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const store = yield* persistence.make("test_store_3")
+        yield* store.setMany([
+          ["key1", { name: "Alice" }, undefined],
+          ["key2", { name: "Bob" }, undefined],
+          ["key3", { name: "Charlie" }, Duration.seconds(10)]
+        ])
+        let values = yield* store.getMany(["key1", "key2", "key3"])
+        expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, { name: "Charlie" }])
+        yield* TestClock.adjust(Duration.seconds(5))
+        values = yield* store.getMany(["key1", "key2", "key3"])
+        expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, { name: "Charlie" }])
+        yield* TestClock.adjust(Duration.seconds(5))
+        values = yield* store.getMany(["key1", "key2", "key3"])
+        expect(values).toEqual([{ name: "Alice" }, { name: "Bob" }, undefined])
+      }))
+
+    it.effect("isolation between stores", () =>
+      Effect.gen(function*() {
+        const persistence = yield* Persistence.BackingPersistence
+        const storeA = yield* persistence.make("test_store_a")
+        const storeB = yield* persistence.make("test_store_b")
+
+        yield* storeA.set("shared-key", { name: "Alice" }, undefined)
+        yield* storeB.set("shared-key", { name: "Bob" }, undefined)
+
+        expect(yield* storeA.get("shared-key")).toEqual({ name: "Alice" })
+        expect(yield* storeB.get("shared-key")).toEqual({ name: "Bob" })
+
+        yield* storeA.clear
+
+        expect(yield* storeA.get("shared-key")).toEqual(undefined)
+        expect(yield* storeB.get("shared-key")).toEqual({ name: "Bob" })
+      }))
+  })
+
+suite("table-per-store", Persistence.layerBackingSql)
+suite("single-table", Persistence.layerBackingSqlSingleTable)


### PR DESCRIPTION
## Summary
- add `Persistence.layerBackingSqlSingleTable` and `Persistence.layerSqlSingleTable`, backed by a shared `effect_persistence` table keyed by `(store_id, id)`
- keep persistence behavior aligned with existing SQL backend (TTL cleanup, JSON serialization, get/getMany ordering, set/setMany upsert, remove and clear scoped by store)
- add regression coverage for the new backend in sqlite tests and add persisted-cache suites for pg/mysql single-table layers