### PR TITLE
add report command for chosen bundle fixtures

### DIFF
--- a/packages/tools/bundle/package.json
+++ b/packages/tools/bundle/package.json
@@ -32,6 +32,7 @@
     "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
     "check": "tsc -b tsconfig.json",
     "compare": "node src/bin.ts compare",
+    "report": "node src/bin.ts report",
     "visualize": "node src/bin.ts visualize"
   },
   "dependencies": {

--- a/packages/tools/bundle/src/Cli.ts
+++ b/packages/tools/bundle/src/Cli.ts
@@ -1,9 +1,11 @@
 /**
  * @since 1.0.0
  */
+import * as Console from "effect/Console"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
 import * as Path from "effect/Path"
+import * as Argument from "effect/unstable/cli/Argument"
 import * as Command from "effect/unstable/cli/Command"
 import * as Flag from "effect/unstable/cli/Flag"
 import * as Prompt from "effect/unstable/cli/Prompt"
@@ -62,10 +64,23 @@ const visualize = Command.make("visualize", { outputDirectory }).pipe(
   }))
 )
 
+const reportPaths = Argument.file("paths", { mustExist: true }).pipe(
+  Argument.withDescription("Fixture files to include in the report"),
+  Argument.variadic({ min: 1 })
+)
+
+const report = Command.make("report", { paths: reportPaths }).pipe(
+  Command.withHandler(Effect.fnUntraced(function*({ paths }) {
+    const reporter = yield* Reporter
+    const report = yield* reporter.reportSelected({ paths })
+    yield* Console.log(report)
+  }))
+)
+
 /**
  * @since 1.0.0
  * @category commands
  */
 export const cli = Command.make("bundle").pipe(
-  Command.withSubcommands([compare, visualize])
+  Command.withSubcommands([compare, report, visualize])
 )


### PR DESCRIPTION
## Summary
- add a new `bundle report` subcommand that accepts one or more fixture file paths as variadic positional arguments
- extend `Reporter` with `reportSelected` to bundle only the provided paths and render a markdown size table for those fixtures
- add a `report` package script so the command can be invoked directly from the bundle package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Command.test.ts
- pnpm check
- pnpm build
- pnpm docgen
- node src/bin.ts report fixtures/basic.ts fixtures/batching.ts