### PR TITLE
EFF-463 Ensure Ref data types extend Pipeable

### DIFF
--- a/packages/effect/src/RcRef.ts
+++ b/packages/effect/src/RcRef.ts
@@ -4,6 +4,7 @@
 import type * as Duration from "./Duration.ts"
 import type * as Effect from "./Effect.ts"
 import * as internal from "./internal/rcRef.ts"
+import type { Pipeable } from "./Pipeable.ts"
 import type { Scope } from "./Scope.ts"
 import type * as Types from "./Types.ts"
 
@@ -43,7 +44,7 @@ const TypeId = "~effect/RcRef"
  * })
  * ```
  */
-export interface RcRef<out A, out E = never> {
+export interface RcRef<out A, out E = never> extends Pipeable {
   readonly [TypeId]: RcRef.Variance<A, E>
 }
 

--- a/packages/effect/src/Ref.ts
+++ b/packages/effect/src/Ref.ts
@@ -33,6 +33,7 @@ import { dual, identity } from "./Function.ts"
 import { PipeInspectableProto } from "./internal/core.ts"
 import * as MutableRef from "./MutableRef.ts"
 import type * as Option from "./Option.ts"
+import type { Pipeable } from "./Pipeable.ts"
 import type { Invariant } from "./Types.ts"
 
 const TypeId = "~effect/Ref"
@@ -68,7 +69,7 @@ const TypeId = "~effect/Ref"
  * @since 2.0.0
  * @category models
  */
-export interface Ref<in out A> extends Ref.Variance<A> {
+export interface Ref<in out A> extends Ref.Variance<A>, Pipeable {
   readonly ref: MutableRef.MutableRef<A>
 }
 

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -5,6 +5,7 @@ import * as Effect from "./Effect.ts"
 import { dual, identity } from "./Function.ts"
 import { PipeInspectableProto } from "./internal/core.ts"
 import * as Option from "./Option.ts"
+import type { Pipeable } from "./Pipeable.ts"
 import * as PubSub from "./PubSub.ts"
 import * as Ref from "./Ref.ts"
 import * as Stream from "./Stream.ts"
@@ -16,7 +17,7 @@ const TypeId = "~effect/SubscriptionRef"
  * @since 2.0.0
  * @category models
  */
-export interface SubscriptionRef<in out A> extends SubscriptionRef.Variance<A> {
+export interface SubscriptionRef<in out A> extends SubscriptionRef.Variance<A>, Pipeable {
   readonly backing: Ref.Ref<A>
   readonly semaphore: Effect.Semaphore
   readonly pubsub: PubSub.PubSub<A>

--- a/packages/effect/src/TxRef.ts
+++ b/packages/effect/src/TxRef.ts
@@ -10,6 +10,8 @@
  */
 import * as Effect from "./Effect.ts"
 import { dual } from "./Function.ts"
+import { pipeArguments } from "./Pipeable.ts"
+import type { Pipeable } from "./Pipeable.ts"
 import type { NoInfer } from "./Types.ts"
 
 const TypeId = "~effect/transactions/TxRef"
@@ -43,7 +45,7 @@ const TypeId = "~effect/transactions/TxRef"
  * })
  * ```
  */
-export interface TxRef<in out A> {
+export interface TxRef<in out A> extends Pipeable {
   readonly [TypeId]: typeof TypeId
 
   version: number
@@ -99,6 +101,9 @@ export const make = <A>(initial: A) => Effect.sync(() => makeUnsafe(initial))
 export const makeUnsafe = <A>(initial: A): TxRef<A> => ({
   [TypeId]: TypeId,
   pending: new Map(),
+  pipe() {
+    return pipeArguments(this, arguments)
+  },
   version: 0,
   value: initial
 })

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -3,6 +3,7 @@ import * as Effect from "../Effect.ts"
 import * as Exit from "../Exit.ts"
 import * as Fiber from "../Fiber.ts"
 import { identity } from "../Function.ts"
+import { pipeArguments } from "../Pipeable.ts"
 import type * as RcRef from "../RcRef.ts"
 import * as Scope from "../Scope.ts"
 import * as ServiceMap from "../ServiceMap.ts"
@@ -40,6 +41,10 @@ const variance: RcRef.RcRef.Variance<any, any> = {
 
 class RcRefImpl<A, E> implements RcRef.RcRef<A, E> {
   readonly [TypeId]: RcRef.RcRef.Variance<A, E> = variance
+
+  pipe() {
+    return pipeArguments(this, arguments)
+  }
 
   state: State<A> = stateEmpty
   readonly semaphore = Effect.makeSemaphoreUnsafe(1)


### PR DESCRIPTION
## Summary
- make `Ref`, `SubscriptionRef`, `RcRef`, and `TxRef` interfaces extend `Pipeable` for consistent typing across Ref data types
- add runtime `pipe` support for `RcRef` and `TxRef` implementations so runtime behavior matches the new type contracts
- keep existing Ref-family runtime behavior unchanged otherwise while preserving existing constructors and combinators

Closes #1237