### PR TITLE
fix: `statement.stream` emit on connection close race condition

### DIFF
--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -348,7 +348,13 @@ function queryStream(
         })
       }
     })
-    query.on("end", () => emit.end())
+    query.on("end", () => {
+      if (buffer.length > 0) {
+        emit.array(buffer)
+        buffer = []
+      }
+      emit.end()
+    })
 
     return {
       onPause() {

--- a/packages/sql/mysql2/test/MysqlClient.test.ts
+++ b/packages/sql/mysql2/test/MysqlClient.test.ts
@@ -1,0 +1,35 @@
+import { MysqlClient } from "@effect/sql-mysql2"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Stream } from "effect"
+
+import { MysqlContainer } from "./utils.ts"
+
+describe("MysqlClient", () => {
+  it.effect("stream returns same rows as direct execution", () =>
+    Effect.gen(function*() {
+      const sql = yield* MysqlClient.MysqlClient
+
+      yield* sql`DROP TABLE IF EXISTS stream_regression_test`
+      yield* sql`CREATE TABLE stream_regression_test (id INT PRIMARY KEY AUTO_INCREMENT, value VARCHAR(255))`
+
+      const testData = Array.from({ length: 100 }, (_, i) => ({ value: `row_${i}` }))
+      yield* sql`INSERT INTO stream_regression_test ${sql.insert(testData)}`
+
+      const directResults = yield* sql`SELECT * FROM stream_regression_test`
+
+      const streamResults = yield* Stream.runCollect(
+        sql`SELECT * FROM stream_regression_test`.stream
+      )
+
+      yield* sql`DROP TABLE stream_regression_test`
+
+      assert.strictEqual(
+        streamResults.length,
+        directResults.length,
+        `Stream returned ${streamResults.length} rows, expected ${directResults.length}`
+      )
+    }).pipe(
+      Effect.provide(MysqlContainer.layerClient),
+      Effect.catchTag("ContainerError", () => Effect.void)
+    ), { timeout: 60_000 })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Flush the buffer before calling emit.end() in the "end" event handler preventing a race condition.

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #1254 
