### PR TITLE
Fix double minus sign in bundle size report

### DIFF
--- a/packages/tools/bundle/src/Reporter.ts
+++ b/packages/tools/bundle/src/Reporter.ts
@@ -59,10 +59,10 @@ export class Reporter extends ServiceMap.Service<Reporter>()(
         const currSize = current.sizeInBytes
         const prevSize = previous.sizeInBytes
         const diff = currSize - prevSize
-        const diffPct = prevSize === 0 ? 0 : (diff / prevSize) * 100
+        const diffPct = prevSize === 0 ? 0 : (Math.abs(diff) / prevSize) * 100
         const currKb = (currSize / 1000).toFixed(2)
         const prevKb = (prevSize / 1000).toFixed(2)
-        const diffKb = (diff / 1000).toFixed(2)
+        const diffKb = (Math.abs(diff) / 1000).toFixed(2)
         const filename = path.basename(current.path)
         return {
           diff,


### PR DESCRIPTION
Use Math.abs for diffKb and diffPct so numeric strings are always non-negative. The sign prefix already handles the sign character.

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
