### PR TITLE
EFF-480: Align Chunk.difference with Array.difference

### DIFF
--- a/packages/effect/src/Chunk.ts
+++ b/packages/effect/src/Chunk.ts
@@ -2871,7 +2871,7 @@ export const differenceWith = <A>(isEquivalent: (self: A, that: A) => boolean): 
 } => {
   return dual(
     2,
-    (self: Chunk<A>, that: Chunk<A>): Chunk<A> => fromArrayUnsafe(RA.differenceWith(isEquivalent)(that, self))
+    (self: Chunk<A>, that: Chunk<A>): Chunk<A> => fromArrayUnsafe(RA.differenceWith(isEquivalent)(self, that))
   )
 }
 
@@ -2908,5 +2908,5 @@ export const difference: {
   <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A>
 } = dual(
   2,
-  <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A> => fromArrayUnsafe(RA.difference(that, self))
+  <A>(self: Chunk<A>, that: Chunk<A>): Chunk<A> => fromArrayUnsafe(RA.difference(self, that))
 )

--- a/packages/effect/test/Chunk.test.ts
+++ b/packages/effect/test/Chunk.test.ts
@@ -830,18 +830,18 @@ describe("Chunk", () => {
 
     const chunk = Chunk.make({ id: 1 }, { id: 2 }, { id: 3 })
 
-    deepStrictEqual(differenceWith(Chunk.make({ id: 1 }, { id: 2 }), chunk), Chunk.make({ id: 3 }))
-    assertEquals(differenceWith(Chunk.empty(), chunk), chunk)
-    assertEquals(differenceWith(chunk, Chunk.empty()), Chunk.empty())
+    deepStrictEqual(differenceWith(chunk, Chunk.make({ id: 1 }, { id: 2 })), Chunk.make({ id: 3 }))
+    assertEquals(differenceWith(Chunk.empty(), chunk), Chunk.empty())
+    assertEquals(differenceWith(chunk, Chunk.empty()), chunk)
     assertEquals(differenceWith(chunk, chunk), Chunk.empty())
   })
 
   it("difference", () => {
     const curr = Chunk.make(1, 3, 5, 7, 9)
 
-    assertEquals(Chunk.difference(Chunk.make(1, 2, 3, 4, 5), curr), Chunk.make(7, 9))
-    assertEquals(Chunk.difference(Chunk.empty(), curr), curr)
-    assertEquals(Chunk.difference(curr, Chunk.empty()), Chunk.empty())
+    assertEquals(Chunk.difference(curr, Chunk.make(1, 2, 3, 4, 5)), Chunk.make(7, 9))
+    assertEquals(Chunk.difference(Chunk.empty(), curr), Chunk.empty())
+    assertEquals(Chunk.difference(curr, Chunk.empty()), curr)
     assertEquals(Chunk.difference(curr, curr), Chunk.empty())
   })
 })


### PR DESCRIPTION
## Summary
- fix `Chunk.difference` and `Chunk.differenceWith` to return elements from the first chunk that are not in the second chunk, matching `Array.difference`
- update `packages/effect/test/Chunk.test.ts` assertions for `difference` and `differenceWith` to enforce first-minus-second behavior
- no doc example changes were needed because existing `Chunk` docs already described the intended semantics

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Chunk.test.ts
- pnpm check
- pnpm build
- pnpm docgen