### PR TITLE
EFF-482 Add openai-compat and openrouter to beta changeset

### DIFF
--- a/.changeset/shy-geckos-sniff.md
+++ b/.changeset/shy-geckos-sniff.md
@@ -11,6 +11,8 @@
 "@effect/platform-node": major
 "@effect/sql-sqlite-do": major
 "@effect/ai-anthropic": major
+"@effect/ai-openai-compat": major
+"@effect/ai-openrouter": major
 "@effect/platform-bun": major
 "@effect/atom-react": major
 "@effect/atom-solid": major


### PR DESCRIPTION
## Summary
- add missing beta release entries for `@effect/ai-openai-compat` and `@effect/ai-openrouter` in `.changeset/shy-geckos-sniff.md`
- keep both packages aligned with the existing v4 beta package set by marking them as `major`

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai-compat/test/OpenAiClient.test.ts
- pnpm check
- pnpm build
- pnpm docgen