### PR TITLE
EFF-484 Add mode support to Effect.all

### DIFF
--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4007,15 +4007,20 @@ export const all = <
   O extends {
     readonly concurrency?: Concurrency | undefined
     readonly discard?: boolean | undefined
+    readonly mode?: "default" | "result" | undefined
   }
 >(
   arg: Arg,
   options?: O
 ): Effect.All.Return<Arg, O> => {
   if (isIterable(arg)) {
-    return (forEach as any)(arg, identity, options)
+    return options?.mode === "result"
+      ? (forEach as any)(arg, result, options)
+      : (forEach as any)(arg, identity, options)
   } else if (options?.discard) {
-    return (forEach as any)(Object.values(arg), identity, options)
+    return options.mode === "result"
+      ? (forEach as any)(Object.values(arg), result, options)
+      : (forEach as any)(Object.values(arg), identity, options)
   }
   return suspend(() => {
     const out: Record<string, unknown> = {}
@@ -4023,7 +4028,7 @@ export const all = <
       forEach(
         Object.entries(arg),
         ([key, effect]) =>
-          map(effect, (value) => {
+          map(options?.mode === "result" ? result(effect) : effect, (value) => {
             out[key] = value
           }),
         {


### PR DESCRIPTION
## Summary
- add `mode: \"result\"` support to `Effect.all` for tuple / iterable / record inputs while preserving default short-circuit behavior
- update `Effect.All` type-level return inference so `mode: \"result\"` returns `Result` values and never fails
- add runtime + type assertions in `packages/effect/test/Effect.test.ts` to verify non-short-circuit execution and result-shape correctness

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check
- pnpm build
- pnpm docgen