### PR TITLE
EFF-493: honor minimum trace level for sampled parent spans

### DIFF
--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5001,8 +5001,10 @@ export const makeSpanUnsafe = <XA, XE>(
       startTime: timingEnabled ? clock.currentTimeNanosUnsafe() : 0n,
       kind: options?.kind ?? "internal",
       root: options?.root ?? options?.parent === undefined,
-      sampled: options?.sampled ?? parent?.sampled ??
-        !isLogLevelGreaterThan(fiber.getRef(Tracer.MinimumTraceLevel), level)
+      sampled: options?.sampled ??
+        (parent?.sampled === false
+          ? false
+          : !isLogLevelGreaterThan(fiber.getRef(Tracer.MinimumTraceLevel), level))
     })
 
     for (const [key, value] of Object.entries(annotationsFromEnv)) {

--- a/packages/effect/test/Tracer.test.ts
+++ b/packages/effect/test/Tracer.test.ts
@@ -61,6 +61,23 @@ describe("Tracer", () => {
         strictEqual(span.parent?.spanId, "000")
       }))
 
+    it.effect("should still apply minimum trace level with sampled parent spans", () =>
+      Effect.gen(function*() {
+        const span = yield* Effect.currentSpan.pipe(
+          Effect.withSpan("A", {
+            parent: Tracer.externalSpan({
+              spanId: "000",
+              traceId: "111",
+              sampled: true
+            }),
+            level: "Info"
+          }),
+          Effect.provideService(Tracer.MinimumTraceLevel, "Error")
+        )
+
+        strictEqual(span.sampled, false)
+      }))
+
     it.effect("should not set the parent span when none exists", () =>
       Effect.gen(function*() {
         const span = yield* Effect.withSpan(Effect.currentSpan, "A")


### PR DESCRIPTION
## Summary
- update span sampling in `makeSpanUnsafe` so sampled parents no longer bypass minimum trace-level filtering
- keep explicit `sampled` options and unsampled parent propagation behavior unchanged
- add a tracer regression test covering a sampled external parent with `MinimumTraceLevel` set above the child span level

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Tracer.test.ts
- pnpm check
- pnpm build
- pnpm docgen