### PR TITLE
Add sync Filter.Filter support to Effect.filter

### DIFF
--- a/.changeset/blue-dingos-greet.md
+++ b/.changeset/blue-dingos-greet.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.filter` support for synchronous `Filter.Filter` overloads and correctly handle non-effect `Result` return values at runtime.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4452,6 +4452,10 @@ export const filter: {
   <A>(
     predicate: Predicate.Predicate<NoInfer<A>>
   ): (elements: Iterable<A>) => Effect<Array<A>>
+  <A, B, X>(
+    filter: Filter.Filter<NoInfer<A>, B, X>,
+    options?: { readonly concurrency?: Concurrency | undefined }
+  ): (elements: Iterable<A>) => Effect<Array<B>>
   <A, B, X, E, R>(
     filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
@@ -4468,6 +4472,10 @@ export const filter: {
     elements: Iterable<A>,
     predicate: Predicate.Predicate<A>
   ): Effect<Array<A>>
+  <A, B, X>(
+    elements: Iterable<A>,
+    filter: Filter.Filter<NoInfer<A>, B, X>
+  ): Effect<Array<B>>
   <A, B, X, E, R>(
     elements: Iterable<A>,
     filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R>,

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4271,6 +4271,9 @@ export const filter: {
   <A>(
     predicate: Predicate.Predicate<NoInfer<A>>
   ): (elements: Iterable<A>) => Effect.Effect<Array<A>>
+  <A, B, X>(
+    filter: Filter.Filter<NoInfer<A>, B, X>
+  ): (elements: Iterable<A>) => Effect.Effect<Array<B>>
   <A, B, X, E, R>(
     filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
@@ -4287,6 +4290,10 @@ export const filter: {
     elements: Iterable<A>,
     predicate: Predicate.Predicate<A>
   ): Effect.Effect<Array<A>>
+  <A, B, X>(
+    elements: Iterable<A>,
+    filter: Filter.Filter<NoInfer<A>, B, X>
+  ): Effect.Effect<Array<B>>
   <A, B, X, E, R>(
     elements: Iterable<A>,
     filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R>,
@@ -4316,6 +4323,12 @@ export const filter: {
             const result = (filter as Function)(a, i)
             if (typeof result === "boolean") {
               if (result) out.push(a)
+              return void_ as any
+            }
+            if (!isEffect(result)) {
+              if (!Result.isFailure(result)) {
+                out.push(result.success)
+              }
               return void_ as any
             }
             return map(result, (r: any) => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1982,6 +1982,16 @@ describe("Effect", () => {
         )
         assert.deepStrictEqual(result, [1, 2, 3])
       }))
+    it.effect("Filter.Filter overload maps pass values", () =>
+      Effect.gen(function*() {
+        const filter: Filter.Filter<number, string, number> = (n) =>
+          n % 2 === 0 ? Result.succeed(`n=${n}`) : Result.fail(n)
+        const result = yield* Effect.filter(
+          [1, 2, 3, 4],
+          filter
+        )
+        assert.deepStrictEqual(result, ["n=2", "n=4"])
+      }))
   })
 
   describe("catch", () => {


### PR DESCRIPTION
## Summary
- add `Effect.filter` overloads for synchronous `Filter.Filter` usage in both public and internal typings
- fix runtime handling so sync filters that return `Result` values are processed without being treated as effects
- add a regression test and a changeset for the `effect` package