### PR TITLE
EFF-496 Port SqlSchema.findOne from effect v3

### DIFF
--- a/.changeset/forty-otters-cry.md
+++ b/.changeset/forty-otters-cry.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Port `SqlSchema.findOne` from effect v3 to return `Option` on empty results and add `SqlSchema.single` for the fail-on-empty behavior.

--- a/packages/effect/src/unstable/sql/SqlModel.ts
+++ b/packages/effect/src/unstable/sql/SqlModel.ts
@@ -69,7 +69,7 @@ export const makeRepository = <
     const idSchema = Model.fields[options.idColumn] as Schema.Top
     const idColumn = options.idColumn as string
 
-    const insertSchema = SqlSchema.findOne({
+    const insertSchema = SqlSchema.single({
       Request: Model.insert,
       Result: Model,
       execute: (request) =>
@@ -107,7 +107,7 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
         })
       ) as any
 
-    const updateSchema = SqlSchema.findOne({
+    const updateSchema = SqlSchema.single({
       Request: Model.update,
       Result: Model,
       execute: (request: any) =>
@@ -159,7 +159,7 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
         })
       ) as any
 
-    const findByIdSchema = SqlSchema.findOne({
+    const findByIdSchema = SqlSchema.single({
       Request: idSchema,
       Result: Model,
       execute: (id: any) => sql`select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${id}`

--- a/packages/effect/src/unstable/sql/SqlSchema.ts
+++ b/packages/effect/src/unstable/sql/SqlSchema.ts
@@ -4,6 +4,7 @@
 import * as Arr from "../../Array.ts"
 import * as Cause from "../../Cause.ts"
 import * as Effect from "../../Effect.ts"
+import type * as Option from "../../Option.ts"
 import * as Schema from "../../Schema.ts"
 
 /**
@@ -64,12 +65,44 @@ export {
 }
 
 /**
- * Run a sql query with a request schema and a result schema and return the first result.
+ * Run a sql query with a request schema and a result schema and return the first result, if any.
  *
  * @since 4.0.0
  * @category constructor
  */
 export const findOne = <Req extends Schema.Top, Res extends Schema.Top, E, R>(
+  options: {
+    readonly Request: Req
+    readonly Result: Res
+    readonly execute: (request: Req["Encoded"]) => Effect.Effect<ReadonlyArray<unknown>, E, R>
+  }
+) => {
+  const encodeRequest = Schema.encodeEffect(options.Request)
+  const decode = Schema.decodeUnknownEffect(options.Result)
+  return (
+    request: Req["Type"]
+  ): Effect.Effect<
+    Option.Option<Res["Type"]>,
+    E | Schema.SchemaError,
+    R | Req["EncodingServices"] | Res["DecodingServices"]
+  > =>
+    Effect.flatMap(
+      Effect.flatMap(encodeRequest(request), options.execute),
+      (arr): Effect.Effect<
+        Option.Option<Res["Type"]>,
+        Schema.SchemaError,
+        Req["EncodingServices"] | Res["DecodingServices"]
+      > => Arr.isReadonlyArrayNonEmpty(arr) ? Effect.asSome(decode(arr[0])) : Effect.succeedNone
+    )
+}
+
+/**
+ * Run a sql query with a request schema and a result schema and return the first result.
+ *
+ * @since 4.0.0
+ * @category constructor
+ */
+export const single = <Req extends Schema.Top, Res extends Schema.Top, E, R>(
   options: {
     readonly Request: Req
     readonly Result: Res

--- a/packages/effect/test/unstable/sql/SqlSchema.test.ts
+++ b/packages/effect/test/unstable/sql/SqlSchema.test.ts
@@ -1,0 +1,75 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as Schema from "effect/Schema"
+import * as SqlSchema from "effect/unstable/sql/SqlSchema"
+
+describe("SqlSchema", () => {
+  describe("findOne", () => {
+    it.effect("returns Option.some when a row exists", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.findOne({
+          Request: Schema.NumberFromString,
+          Result: Schema.Struct({ value: Schema.String }),
+          execute: (request) => Effect.succeed([{ value: `id:${request}` }])
+        })
+
+        const result = yield* query(1)
+        assert.isTrue(Option.isSome(result))
+        if (Option.isSome(result)) {
+          assert.deepStrictEqual(result.value, { value: "id:1" })
+        }
+      }))
+
+    it.effect("returns Option.none when no rows are returned", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.findOne({
+          Request: Schema.NumberFromString,
+          Result: Schema.String,
+          execute: () => Effect.succeed([])
+        })
+
+        const result = yield* query(1)
+        assert.isTrue(Option.isNone(result))
+      }))
+
+    it.effect("fails when the first row cannot be decoded", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.findOne({
+          Request: Schema.String,
+          Result: Schema.Struct({ id: Schema.Number }),
+          execute: () => Effect.succeed([{ id: "not-a-number" }])
+        })
+
+        const error = yield* Effect.flip(query("ignored"))
+        assert.isTrue(Schema.isSchemaError(error))
+      }))
+  })
+
+  describe("single", () => {
+    it.effect("returns the first decoded row", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.single({
+          Request: Schema.String,
+          Result: Schema.NumberFromString,
+          execute: () => Effect.succeed(["1", "2"])
+        })
+
+        const result = yield* query("ignored")
+        assert.strictEqual(result, 1)
+      }))
+
+    it.effect("fails with NoSuchElementError when no rows are returned", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.single({
+          Request: Schema.String,
+          Result: Schema.String,
+          execute: () => Effect.succeed([])
+        })
+
+        const error = yield* Effect.flip(query("ignored"))
+        assert.isTrue(Cause.isNoSuchElementError(error))
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- port `SqlSchema.findOne` to v3 semantics by returning `Option` instead of failing on empty results
- add `SqlSchema.single` to preserve fail-on-empty first-row behavior and switch `SqlModel` repository helpers to use it
- add `SqlSchema` unstable tests for `findOne`/`single` behavior and include a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/sql/SqlSchema.test.ts
- pnpm check
- pnpm build
- pnpm docgen