### PR TITLE
fix(ai-openrouter): sparse array crash in OpenRouter streamText toolcall handling

### DIFF
--- a/.changeset/fix-openrouter-sparse-array.md
+++ b/.changeset/fix-openrouter-sparse-array.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openrouter": patch
+---
+
+Fix sparse array crash in `streamText` tool call handling.

--- a/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
+++ b/packages/ai/openrouter/src/OpenRouterLanguageModel.ts
@@ -808,12 +808,12 @@ const makeStreamResponse = Effect.fnUntraced(
     let activeTextId: string | undefined = undefined
 
     let totalToolCalls = 0
-    const activeToolCalls: Array<{
+    const activeToolCalls: Record<number, {
       readonly id: string
       readonly type: "function"
       readonly name: string
       params: string
-    }> = []
+    }> = {}
 
     // Track reasoning details to preserve for multi-turn conversations
     const accumulatedReasoningDetails: DeepMutable<ReasoningDetails> = []
@@ -1158,7 +1158,7 @@ const makeStreamResponse = Effect.fnUntraced(
 
           // Forward any unsent tool calls if finish reason is 'tool-calls'
           if (finishReason === "tool-calls") {
-            for (const toolCall of activeToolCalls) {
+            for (const toolCall of Object.values(activeToolCalls)) {
               // Coerce invalid tool call parameters to an empty object
               let params: unknown
               // @effect-diagnostics-next-line tryCatchInEffectGen:off


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In OpenRouterLanguageModel.ts, activeToolCalls was declared as an Array. Completed tool calls were removed with delete activeToolCalls[index], which creates sparse holes (undefined entries) rather than actually removing elements. When the stream finishes with finishReason === "tool-calls", iterating with for...of yields undefined for those holes, causing a TypeError.

Changed activeToolCalls from Array to Record<number, ...> and iterate with Object.values(), matching the existing implementation in @effect/ai-openai and @effect/ai-openai-compat.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #1304
