### PR TITLE
EFF-497 Add HttpClientRequest.bodyFormDataRecord

### DIFF
--- a/.changeset/fair-dryers-speak.md
+++ b/.changeset/fair-dryers-speak.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `HttpClientRequest.bodyFormDataRecord` and `HttpBody.makeFormDataRecord` helpers for creating multipart form bodies from plain records.

--- a/packages/effect/src/unstable/http/HttpBody.ts
+++ b/packages/effect/src/unstable/http/HttpBody.ts
@@ -285,6 +285,47 @@ export const makeFormData = (body: globalThis.FormData): FormData => new FormDat
  * @since 4.0.0
  * @category models
  */
+export type FormDataInput = Record<string, FormDataCoercible | ReadonlyArray<FormDataCoercible>>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type FormDataCoercible = string | number | boolean | globalThis.File | globalThis.Blob | null | undefined
+
+const appendFormDataValue = (formData: globalThis.FormData, key: string, value: FormDataCoercible): void => {
+  if (value == null) {
+    return
+  }
+  if (typeof value === "object") {
+    formData.append(key, value)
+    return
+  }
+  formData.append(key, String(value))
+}
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const makeFormDataRecord = (entries: FormDataInput): FormData => {
+  const formData = new globalThis.FormData()
+  for (const [key, value] of Object.entries(entries)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        appendFormDataValue(formData, key, item)
+      }
+    } else {
+      appendFormDataValue(formData, key, value as FormDataCoercible)
+    }
+  }
+  return makeFormData(formData)
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
 export class Stream extends Proto {
   readonly _tag = "Stream"
   readonly stream: Stream_.Stream<globalThis.Uint8Array, unknown>

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -528,7 +528,7 @@ export const setBody: {
   (self: HttpClientRequest, body: HttpBody.HttpBody): HttpClientRequest
 } = dual(2, (self: HttpClientRequest, body: HttpBody.HttpBody): HttpClientRequest => {
   let headers = self.headers
-  if (body._tag === "Empty") {
+  if (body._tag === "Empty" || body._tag === "FormData") {
     headers = Headers.remove(Headers.remove(headers, "Content-Type"), "Content-length")
   } else {
     if (body.contentType) {
@@ -646,6 +646,19 @@ export const bodyFormData: {
   (body: FormData): (self: HttpClientRequest) => HttpClientRequest
   (self: HttpClientRequest, body: FormData): HttpClientRequest
 } = dual(2, (self: HttpClientRequest, body: FormData): HttpClientRequest => setBody(self, HttpBody.makeFormData(body)))
+
+/**
+ * @since 4.0.0
+ * @category combinators
+ */
+export const bodyFormDataRecord: {
+  (entries: HttpBody.FormDataInput): (self: HttpClientRequest) => HttpClientRequest
+  (self: HttpClientRequest, entries: HttpBody.FormDataInput): HttpClientRequest
+} = dual(
+  2,
+  (self: HttpClientRequest, entries: HttpBody.FormDataInput): HttpClientRequest =>
+    setBody(self, HttpBody.makeFormDataRecord(entries))
+)
 
 /**
  * @since 4.0.0

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -44,4 +44,39 @@ describe("HttpClientRequest", () => {
       strictEqual(request.url, "base")
     })
   })
+
+  describe("bodyFormDataRecord", () => {
+    it("creates a form data body from a record", () => {
+      const request = HttpClientRequest.post("/").pipe(
+        HttpClientRequest.bodyFormDataRecord({
+          a: "a",
+          b: 1,
+          c: true,
+          d: null,
+          e: undefined,
+          f: ["x", 2, false, null, undefined]
+        })
+      )
+
+      strictEqual(request.body._tag, "FormData")
+      if (request.body._tag === "FormData") {
+        strictEqual(request.body.formData.get("a"), "a")
+        strictEqual(request.body.formData.get("b"), "1")
+        strictEqual(request.body.formData.get("c"), "true")
+        strictEqual(request.body.formData.has("d"), false)
+        strictEqual(request.body.formData.has("e"), false)
+        strictEqual(request.body.formData.getAll("f").join(","), "x,2,false")
+      }
+    })
+
+    it("removes content headers when switching to form data", () => {
+      const request = HttpClientRequest.post("/").pipe(
+        HttpClientRequest.bodyText("hello"),
+        HttpClientRequest.bodyFormDataRecord({ a: "a" })
+      )
+
+      strictEqual(request.headers["content-type"], undefined)
+      strictEqual(request.headers["content-length"], undefined)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add `HttpClientRequest.bodyFormDataRecord` to build multipart form-data bodies from plain records, matching effect v3 API shape
- add `HttpBody` form-data record helpers/types (`FormDataInput`, `FormDataCoercible`, `makeFormDataRecord`) used by the new request combinator
- ensure switching request bodies to form-data clears stale `content-type` / `content-length` headers and add coverage in `HttpClientRequest.test.ts`