### PR TITLE
EFF-499 Add requireServicesAt option to PersistedCache

### DIFF
--- a/.changeset/wet-news-invent.md
+++ b/.changeset/wet-news-invent.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add a `requireServicesAt` option to `PersistedCache.make` so lookup-service requirements can be configured like `Cache`.

--- a/packages/effect/src/unstable/persistence/PersistedCache.ts
+++ b/packages/effect/src/unstable/persistence/PersistedCache.ts
@@ -17,18 +17,18 @@ const TypeId = "~effect/persistence/PersistedCache" as const
  * @since 4.0.0
  * @category Models
  */
-export interface PersistedCache<K extends Persistable.Any> {
+export interface PersistedCache<K extends Persistable.Any, out R = never> {
   readonly [TypeId]: typeof TypeId
   readonly inMemory: Cache.Cache<
     K,
     Persistable.Success<K>,
     Persistable.Error<K> | Persistence.PersistenceError | Schema.SchemaError,
-    Persistable.Services<K>
+    Persistable.Services<K> | R
   >
   readonly get: (key: K) => Effect.Effect<
     Persistable.Success<K>,
     Persistable.Error<K> | Persistence.PersistenceError | Schema.SchemaError,
-    Persistable.Services<K>
+    Persistable.Services<K> | R
   >
   readonly invalidate: (key: K) => Effect.Effect<void, Persistence.PersistenceError>
 }
@@ -37,22 +37,32 @@ export interface PersistedCache<K extends Persistable.Any> {
  * @since 4.0.0
  * @category Constructors
  */
-export const make: <K extends Persistable.Any, R>(options: {
+export const make: <
+  K extends Persistable.Any,
+  R = never,
+  ServiceMode extends "lookup" | "construction" = never
+>(options: {
   readonly storeId: string
   readonly lookup: (key: K) => Effect.Effect<Persistable.Success<K>, Persistable.Error<K>, R>
   readonly timeToLive: Persistable.TimeToLiveFn<K>
   readonly inMemoryCapacity?: number | undefined
   readonly inMemoryTTL?: Persistable.TimeToLiveFn<K> | undefined
+  readonly requireServicesAt?: ServiceMode | undefined
 }) => Effect.Effect<
-  PersistedCache<K>,
+  PersistedCache<K, "lookup" extends ServiceMode ? R : never>,
   never,
-  R | Persistence.Persistence | Scope.Scope
-> = Effect.fnUntraced(function*<K extends Persistable.Any, R>(options: {
+  ("lookup" extends ServiceMode ? never : R) | Persistence.Persistence | Scope.Scope
+> = Effect.fnUntraced(function*<
+  K extends Persistable.Any,
+  R = never,
+  ServiceMode extends "lookup" | "construction" = never
+>(options: {
   readonly storeId: string
   readonly lookup: (key: K) => Effect.Effect<Persistable.Success<K>, Persistable.Error<K>, R>
   readonly timeToLive: Persistable.TimeToLiveFn<K>
   readonly inMemoryCapacity?: number | undefined
   readonly inMemoryTTL?: Persistable.TimeToLiveFn<K> | undefined
+  readonly requireServicesAt?: ServiceMode | undefined
 }) {
   const store = yield* (yield* Persistence.Persistence).make({
     storeId: options.storeId,
@@ -69,9 +79,10 @@ export const make: <K extends Persistable.Any, R>(options: {
       return yield* result
     }),
     timeToLive: options.inMemoryTTL ?? constant(Duration.seconds(10)),
-    capacity: options.inMemoryCapacity ?? 1024
+    capacity: options.inMemoryCapacity ?? 1024,
+    requireServicesAt: options.requireServicesAt
   })
-  return identity<PersistedCache<K>>({
+  return identity<PersistedCache<K, "lookup" extends ServiceMode ? R : never>>({
     [TypeId]: TypeId,
     inMemory,
     get: (key) => Cache.get(inMemory, key),

--- a/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedCacheTest.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import type { Layer } from "effect"
-import { Data, Effect, Exit, Result, Schema } from "effect"
+import { Data, Effect, Exit, Result, Schema, ServiceMap } from "effect"
 import { Persistable, PersistedCache, Persistence } from "effect/unstable/persistence"
 
 class User extends Schema.Class<User>("User")({
@@ -17,6 +17,8 @@ class TTLRequest extends Persistable.Class<{
 }) {}
 
 export class TransientError extends Data.TaggedError("TransientError") {}
+
+class LookupService extends ServiceMap.Service<LookupService, { readonly value: string }>()("LookupService") {}
 
 export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistence, unknown>) =>
   describe(`PersistedCache (${storeId})`, { timeout: 30_000 }, () => {
@@ -65,6 +67,34 @@ export const suite = (storeId: string, layer: Layer.Layer<Persistence.Persistenc
           Exit.fail("Not found"),
           Exit.succeed(new User({ id: 2, name: "Jane" }))
         ])
+      }).pipe(
+        Effect.provide(layer),
+        Effect.catchIf((e) => e instanceof TransientError ? Result.succeed(e) : Result.fail(e), () => Effect.void)
+      ))
+
+    it.effect("requireServicesAt: 'lookup' requires lookup services at get-time", () =>
+      Effect.gen(function*() {
+        const cache = yield* PersistedCache.make({
+          storeId: `${storeId}-require-services-at`,
+          lookup: (req: TTLRequest) =>
+            Effect.map(LookupService.asEffect(), (service) => new User({ id: req.id, name: service.value })),
+          timeToLive: () => 5000,
+          requireServicesAt: "lookup"
+        })
+
+        const result1 = yield* cache.get(new TTLRequest({ id: 1 })).pipe(
+          Effect.provideService(LookupService, LookupService.of({ value: "first" }))
+        )
+        const result2 = yield* cache.get(new TTLRequest({ id: 2 })).pipe(
+          Effect.provideService(LookupService, LookupService.of({ value: "second" }))
+        )
+        const result3 = yield* cache.get(new TTLRequest({ id: 1 })).pipe(
+          Effect.provideService(LookupService, LookupService.of({ value: "third" }))
+        )
+
+        assert.deepStrictEqual(result1, new User({ id: 1, name: "first" }))
+        assert.deepStrictEqual(result2, new User({ id: 2, name: "second" }))
+        assert.deepStrictEqual(result3, new User({ id: 1, name: "first" }))
       }).pipe(
         Effect.provide(layer),
         Effect.catchIf((e) => e instanceof TransientError ? Result.succeed(e) : Result.fail(e), () => Effect.void)


### PR DESCRIPTION
## Summary
- add `requireServicesAt` to `PersistedCache.make` with the same `"lookup" | "construction"` service-mode behavior as `Cache`
- extend `PersistedCache` typing so lookup-time service requirements are preserved when `requireServicesAt: "lookup"` is used
- add regression coverage for lookup-time service provisioning in `packages/effect/test/unstable/persistence/PersistedCacheTest.ts` and include an `effect` patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/persistence/PersistedCache.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`