### PR TITLE
add missing `showOperationId` in scalar config

### DIFF
--- a/.changeset/add-scalar-show-operation-id.md
+++ b/.changeset/add-scalar-show-operation-id.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `showOperationId` to `HttpApiScalar.ScalarConfig`.

--- a/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiScalar.ts
@@ -98,6 +98,12 @@ export type ScalarConfig = {
    * Default: `false`
    */
   defaultOpenAllTags?: boolean
+  /**
+   * Whether to display the operation ID in the operation reference.
+   *
+   * Default: `false`
+   */
+  showOperationId?: boolean
 }
 
 type ScalarSource =


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add missing `showOperationId` property to `HttpApiScalar.ScalarConfig` type. The property is valid in the Scalar API reference but was not included in the type definition, causing type errors when used.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

N/A
