### PR TITLE
Remove superfluous `Cause.NoSuchElementError` from `SqlSchema.findAll` signature

### DIFF
--- a/.changeset/wacky-grapes-poke.md
+++ b/.changeset/wacky-grapes-poke.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove superfluous error from SqlSchema.findAll signature

--- a/packages/effect/src/unstable/sql/SqlSchema.ts
+++ b/packages/effect/src/unstable/sql/SqlSchema.ts
@@ -26,7 +26,7 @@ export const findAll = <Req extends Schema.Top, Res extends Schema.Top, E, R>(
     request: Req["Encoded"]
   ): Effect.Effect<
     Array<Res["Type"]>,
-    E | Schema.SchemaError | Cause.NoSuchElementError,
+    E | Schema.SchemaError,
     Req["EncodingServices"] | Res["DecodingServices"] | R
   > => Effect.flatMap(Effect.flatMap(encodeRequest(request), options.execute), decode)
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

https://github.com/Effect-TS/effect-smol/pull/1367/changes introduced differentiation between `findAll` and `findNonEmpty`, where one is supposed to return empty array on no results and the other one results with `Cause.NoSuchElementError` when results are empty.

It seems that during refactor `Cause.NoSuchElementError` was leftover in the signature of the `findAll` function  (despite not being ever actually returned). This PR removes it from the signature - type checking still passes. 

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue
- Closes #
