### PR TITLE
feat(rpc): add supportsSpanPropagation option to RpcServer.toHttpEffect

### DIFF
--- a/.changeset/rpc-toHttpEffect-span-propagation.md
+++ b/.changeset/rpc-toHttpEffect-span-propagation.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add optional `supportsSpanPropagation` option to `RpcServer.toHttpEffect` for enabling distributed tracing across HTTP RPC boundaries.

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -1078,6 +1078,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly supportsSpanPropagation?: boolean | undefined
   } | undefined
 ) => Effect.Effect<
   Effect.Effect<HttpServerResponse.HttpServerResponse, never, Scope.Scope | HttpServerRequest.HttpServerRequest>,
@@ -1093,11 +1094,15 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
     readonly disableTracing?: boolean | undefined
     readonly spanPrefix?: string | undefined
     readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly supportsSpanPropagation?: boolean | undefined
   }
 ) {
   const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect
+  const finalProtocol = options?.supportsSpanPropagation
+    ? { ...protocol, supportsSpanPropagation: true as const }
+    : protocol
   yield* make(group, options).pipe(
-    Effect.provideService(Protocol, protocol),
+    Effect.provideService(Protocol, finalProtocol),
     Effect.forkScoped
   )
   // @effect-diagnostics-next-line returnEffectInGen:off


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add optional `supportsSpanPropagation` option to `RpcServer.toHttpEffect`.

The HTTP protocol hardcodes `supportsSpanPropagation: false`, which makes sense as a default for typical HTTP RPC servers behind reverse proxies. But for same-origin setups like Cloudflare Durable Object RPC, the client and server share a trust boundary and propagating spans is expected.

This adds a single optional field to `toHttpEffect`'s options. When set to `true`, it overrides the protocol's `supportsSpanPropagation` before providing it to `make()`. No changes to `makeProtocolWithHttpEffect` — no breaking changes.

```ts
const httpApp = RpcServer.toHttpEffect(myGroup, {
  supportsSpanPropagation: true
})
```

## Related

- #6072, https://github.com/Effect-TS/effect/pull/6073
