### PR TITLE
HttpApiEndpoint: relax `params`, `query`, and `headers` constraints to accept a full schema in addition to a record of fields

### DIFF
--- a/.changeset/httpapi-endpoint-relax-constraints.md
+++ b/.changeset/httpapi-endpoint-relax-constraints.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+HttpApiEndpoint: relax `params`, `query`, and `headers` constraints to accept a full schema in addition to a record of fields.

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -240,7 +240,7 @@ const User = Schema.Struct({
 //                     ▼            ▼
 HttpApiEndpoint.patch("updateUser", "/user/:id", {
   // Parameters from the route pattern (e.g. /user/:id).
-  // This is a record where each key is the parameter name.
+  // Can be a record of fields or a full schema.
   params: {
     //  ┌─── Schema for the "id" parameter.
     //  ▼
@@ -248,7 +248,7 @@ HttpApiEndpoint.patch("updateUser", "/user/:id", {
   },
 
   // (optional) Query string parameters (e.g. ?mode=merge).
-  // This is a record where each key is the query parameter name.
+  // Can be a record of fields or a full schema.
   query: {
     //    ┌─── Schema for the "mode" query parameter
     //    ▼
@@ -256,7 +256,7 @@ HttpApiEndpoint.patch("updateUser", "/user/:id", {
   },
 
   // (optional) Request headers.
-  // Use the exact header name as the key.
+  // Can be a record of fields or a full schema.
   headers: {
     "x-api-key": Schema.String,
     "x-request-id": Schema.String
@@ -619,7 +619,7 @@ Layer.launch(ApiLive).pipe(NodeRuntime.runMain)
 
 ## Parameters
 
-Path parameters let you capture dynamic values from the URL. For example, `/user/:id` extracts the `id` segment. Use the `params` option to declare a schema for each parameter — the framework will parse and validate the value before your handler runs.
+Path parameters let you capture dynamic values from the URL. For example, `/user/:id` extracts the `id` segment. Use the `params` option to declare a record of fields or a full schema — the framework will parse and validate the value before your handler runs.
 
 **Example** (Defining a GET Endpoint to Retrieve a User by ID)
 
@@ -847,7 +847,7 @@ curl http://localhost:3000/apiPrefix/groupPrefix/b # Returns 200 OK
 
 ## Query Parameters
 
-Query parameters are the `?key=value` pairs appended to a URL. Use the `query` option to declare a schema for each expected parameter — the framework will parse, validate, and type them for you.
+Query parameters are the `?key=value` pairs appended to a URL. Use the `query` option to declare a record of fields or a full schema — the framework will parse, validate, and type them for you.
 
 **Example** (Defining Query Parameters with Metadata)
 
@@ -977,7 +977,7 @@ curl "http://localhost:3000/users?a=1" # One value for the `a` parameter
 
 ## Request Headers
 
-Use the `headers` option to declare which request headers the endpoint expects. Each header maps to a schema that validates its value.
+Use the `headers` option to declare a record of fields or a full schema for the request headers the endpoint expects.
 
 > [!IMPORTANT]
 > All headers are normalized to lowercase. Always use lowercase keys for the headers.

--- a/packages/effect/dtslint/unstable/httpapi/HttpApiEndpoint.tst.ts
+++ b/packages/effect/dtslint/unstable/httpapi/HttpApiEndpoint.tst.ts
@@ -20,10 +20,20 @@ describe("HttpApiEndpoint", () => {
       expect<T>().type.toBe<Schema.Struct<{ id: Schema.FiniteFromString }>>()
     })
 
-    it("should not accept any other schema", () => {
+    it("should accept a Struct", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        params: Schema.Struct({ a: Schema.FiniteFromString, b: Schema.FiniteFromString })
+      })
+      type T = typeof endpoint["~Params"]
+      expect<T>().type.toBe<
+        Schema.Struct<{ readonly a: Schema.FiniteFromString; readonly b: Schema.FiniteFromString }>
+      >()
+    })
+
+    it("should not accept schema that doesn't encode to Record<string, string | ReadonlyArray<string> | undefined>", () => {
       HttpApiEndpoint.get("a", "/a", {
-        // @ts-expect-error Type 'Struct<{ readonly id: String; }>' is not assignable to type 'ParamsConstraint'.
-        params: Schema.Struct({ id: Schema.String })
+        // @ts-expect-error Type 'Struct<{ readonly id: Number; }>' is not assignable to type 'ParamsConstraint | undefined'.
+        params: Schema.Struct({ id: Schema.Number })
       })
     })
   })
@@ -54,10 +64,20 @@ describe("HttpApiEndpoint", () => {
       expect<T>().type.toBe<Schema.Struct<{ a: Schema.FiniteFromString; b: Schema.FiniteFromString }>>()
     })
 
-    it("should not accept any other schema", () => {
+    it("should accept a Struct", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        query: Schema.Struct({ a: Schema.FiniteFromString, b: Schema.FiniteFromString })
+      })
+      type T = typeof endpoint["~Query"]
+      expect<T>().type.toBe<
+        Schema.Struct<{ readonly a: Schema.FiniteFromString; readonly b: Schema.FiniteFromString }>
+      >()
+    })
+
+    it("should not accept schema that doesn't encode to Record<string, string | ReadonlyArray<string> | undefined>", () => {
       HttpApiEndpoint.get("a", "/a", {
-        // @ts-expect-error Type 'Struct<{ readonly id: String; }>' is not assignable to type 'QuerySchemaConstraint'.
-        query: Schema.Struct({ id: Schema.String })
+        // @ts-expect-error Type 'Struct<{ readonly id: Number; }>' is not assignable to type 'QueryConstraint | undefined'.
+        query: Schema.Struct({ id: Schema.Number })
       })
     })
   })
@@ -79,10 +99,20 @@ describe("HttpApiEndpoint", () => {
       expect<T>().type.toBe<Schema.Struct<{ id: Schema.FiniteFromString }>>()
     })
 
-    it("should not accept any other schema", () => {
+    it("should accept a Struct", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        headers: Schema.Struct({ a: Schema.FiniteFromString, b: Schema.FiniteFromString })
+      })
+      type T = typeof endpoint["~Headers"]
+      expect<T>().type.toBe<
+        Schema.Struct<{ readonly a: Schema.FiniteFromString; readonly b: Schema.FiniteFromString }>
+      >()
+    })
+
+    it("should not accept schema that doesn't encode to Record<string, string | ReadonlyArray<string> | undefined>", () => {
       HttpApiEndpoint.get("a", "/a", {
-        // @ts-expect-error Type 'Struct<{ readonly id: String; }>' is not assignable to type 'HeadersSchemaConstraint'.
-        headers: Schema.Struct({ id: Schema.String })
+        // @ts-expect-error Type 'Struct<{ readonly id: Number; }>' is not assignable to type 'HeadersConstraint | undefined'.
+        headers: Schema.Struct({ id: Schema.Number })
       })
     })
   })

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -505,9 +505,9 @@ function handlerToRoute(
   const endpoint = handler.endpoint
   const encodeSuccess = Schema.encodeUnknownEffect(makeSuccessSchema(endpoint))
   const encodeError = Schema.encodeUnknownEffect(makeErrorSchema(endpoint))
-  const decodeParams = UndefinedOr.map(HttpApiEndpoint.getParamsSchema(endpoint), Schema.decodeUnknownEffect)
-  const decodeHeaders = UndefinedOr.map(HttpApiEndpoint.getHeadersSchema(endpoint), Schema.decodeUnknownEffect)
-  const decodeQuery = UndefinedOr.map(HttpApiEndpoint.getQuerySchema(endpoint), Schema.decodeUnknownEffect)
+  const decodeParams = UndefinedOr.map(endpoint.params, Schema.decodeUnknownEffect)
+  const decodeHeaders = UndefinedOr.map(endpoint.headers, Schema.decodeUnknownEffect)
+  const decodeQuery = UndefinedOr.map(endpoint.query, Schema.decodeUnknownEffect)
 
   const shouldParsePayload = endpoint.payload.size > 0 && !handler.isRaw
   const payloadBy = shouldParsePayload ? buildPayloadDecoders(endpoint.payload) : undefined

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -217,7 +217,7 @@ const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, E, R>
         })
 
         // encoders
-        const encodeParams = UndefinedOr.map(HttpApiEndpoint.getParamsSchema(endpoint), Schema.encodeUnknownEffect)
+        const encodeParams = UndefinedOr.map(endpoint.params, Schema.encodeUnknownEffect)
 
         const payloadSchemas = HttpApiEndpoint.getPayloadSchemas(endpoint)
         const encodePayload = Arr.isArrayNonEmpty(payloadSchemas) ?
@@ -226,8 +226,8 @@ const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, E, R>
             : Schema.encodeUnknownEffect(Schema.Union(payloadSchemas)) :
           undefined
 
-        const encodeHeaders = UndefinedOr.map(HttpApiEndpoint.getHeadersSchema(endpoint), Schema.encodeUnknownEffect)
-        const encodeQuery = UndefinedOr.map(HttpApiEndpoint.getQuerySchema(endpoint), Schema.encodeUnknownEffect)
+        const encodeHeaders = UndefinedOr.map(endpoint.headers, Schema.encodeUnknownEffect)
+        const encodeQuery = UndefinedOr.map(endpoint.query, Schema.encodeUnknownEffect)
 
         const middlewareKeys = Array.from(onEndpointOptions.middleware, (tag) => `${tag.key}/Client`)
 

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -621,18 +621,6 @@ describe("HttpApi", () => {
     })
   })
 
-  describe("headers option", () => {
-    it("should throw on non-lowercase keys", () => {
-      assert.throws(() => {
-        HttpApiEndpoint.get("get", "/", {
-          headers: {
-            "X-foo": Schema.FiniteFromString
-          }
-        })
-      }, `Header keys must be lowercase, got "X-foo" (use "x-foo")`)
-    })
-  })
-
   describe("success option", () => {
     it.effect("no content", () => {
       const Api = HttpApi.make("api")


### PR DESCRIPTION
RE https://discord.com/channels/795981131316985866/1473717956092629185/1473764468117999669