### PR TITLE
EFF-507 Fix AtomHttpApi.query params/query forwarding

### DIFF
--- a/.changeset/wise-ants-wave.md
+++ b/.changeset/wise-ants-wave.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+---
+
+Fix `AtomHttpApi.query` to forward v4 `params` / `query` request fields to `HttpApiClient` at runtime.
+Also align `AtomHttpApi` endpoint type inference with v4 `HttpApiEndpoint` params/query naming and add a regression test.

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -51,8 +51,8 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
       infer _Name,
       infer _Method,
       infer _Path,
-      infer _PathSchema,
-      infer _UrlParams,
+      infer _Params,
+      infer _Query,
       infer _Payload,
       infer _Headers,
       infer _Success,
@@ -62,7 +62,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
     >
   ] ? Atom.AtomResultFn<
       Simplify<
-        HttpApiEndpoint.ClientRequest<_PathSchema, _UrlParams, _Payload, _Headers, false> & {
+        HttpApiEndpoint.ClientRequest<_Params, _Query, _Payload, _Headers, false> & {
           readonly reactivityKeys?: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>> | undefined
         }
       >,
@@ -88,8 +88,8 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
         infer _Name,
         infer _Method,
         infer _Path,
-        infer _PathSchema,
-        infer _UrlParams,
+        infer _Params,
+        infer _Query,
         infer _Payload,
         infer _Headers,
         infer _Success,
@@ -98,7 +98,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
         infer _RE
       >
     ] ? Simplify<
-        HttpApiEndpoint.ClientRequest<_PathSchema, _UrlParams, _Payload, _Headers, WithResponse> & {
+        HttpApiEndpoint.ClientRequest<_Params, _Query, _Payload, _Headers, WithResponse> & {
           readonly reactivityKeys?:
             | ReadonlyArray<unknown>
             | ReadonlyRecord<string, ReadonlyArray<unknown>>
@@ -112,7 +112,8 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
       infer _Name,
       infer _Method,
       infer _Path,
-      infer _UrlParams,
+      infer _Params,
+      infer _Query,
       infer _Payload,
       infer _Headers,
       infer _Success,
@@ -170,8 +171,8 @@ export const Service = <Self>() =>
 
   const mutationFamily = Atom.family(({ endpoint, group, withResponse }: MutationKey) =>
     self.runtime.fn<{
-      path: any
-      urlParams: any
+      params: any
+      query: any
       headers: any
       payload: any
       reactivityKeys?: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>> | undefined
@@ -217,8 +218,8 @@ export const Service = <Self>() =>
     group: string,
     endpoint: string,
     request: {
-      readonly path?: any
-      readonly urlParams?: any
+      readonly params?: any
+      readonly query?: any
       readonly payload?: any
       readonly headers?: any
       readonly withResponse?: boolean
@@ -229,8 +230,8 @@ export const Service = <Self>() =>
     queryFamily({
       group,
       endpoint,
-      path: request.path,
-      urlParams: request.urlParams,
+      params: request.params,
+      query: request.query,
       payload: request.payload,
       headers: request.headers,
       withResponse: request.withResponse ?? false,
@@ -252,8 +253,8 @@ interface MutationKey {
 interface QueryKey {
   group: string
   endpoint: string
-  path: any
-  urlParams: any
+  params: any
+  query: any
   headers: any
   payload: any
   withResponse: boolean

--- a/packages/effect/test/reactivity/AtomHttpApi.test.ts
+++ b/packages/effect/test/reactivity/AtomHttpApi.test.ts
@@ -1,0 +1,66 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer, Ref, Schema } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import type * as HttpClientError from "effect/unstable/http/HttpClientError"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
+import { AtomHttpApi, AtomRegistry } from "effect/unstable/reactivity"
+
+const Api = HttpApi.make("api").add(
+  HttpApiGroup.make("group").add(
+    HttpApiEndpoint.get("get", "/users/:id", {
+      params: {
+        id: Schema.FiniteFromString
+      },
+      query: {
+        page: Schema.FiniteFromString
+      }
+    })
+  )
+)
+
+describe("AtomHttpApi", () => {
+  it.effect("query forwards params and query to HttpApiClient", () =>
+    Effect.gen(function*() {
+      const requestRef = yield* Ref.make<
+        {
+          readonly url: string
+          readonly urlParams: ReadonlyArray<readonly [string, string]>
+        } | undefined
+      >(undefined)
+
+      const httpClient = HttpClient.makeWith(
+        Effect.fnUntraced(function*(requestEffect) {
+          const request = yield* requestEffect
+          yield* Ref.set(requestRef, {
+            url: request.url,
+            urlParams: request.urlParams.params
+          })
+          return HttpClientResponse.fromWeb(request, new Response(null, { status: 204 }))
+        }),
+        Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+      )
+
+      const Client = AtomHttpApi.Service()("Client", {
+        api: Api,
+        httpClient: Layer.succeed(HttpClient.HttpClient, httpClient)
+      })
+
+      const atom = Client.query("group", "get", {
+        params: { id: 1 },
+        query: { page: 2 }
+      })
+
+      const registry = AtomRegistry.make()
+      registry.get(atom)
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+
+      const request = yield* Ref.get(requestRef)
+      if (request === undefined) {
+        assert.fail("expected query request to execute")
+      }
+      assert.strictEqual(request.url, "/users/1")
+      assert.deepStrictEqual(request.urlParams, [["page", "2"]])
+    }))
+})


### PR DESCRIPTION
## Summary
- Fix `AtomHttpApi.query` runtime request mapping to forward v4 `params` / `query` fields instead of stale `path` / `urlParams` keys.
- Align `AtomHttpApi` endpoint type inference naming with current `HttpApiEndpoint` params/query conventions.
- Add a regression test for `AtomHttpApi.query` that verifies params and query are preserved in the `HttpApiClient` request.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/reactivity/AtomHttpApi.test.ts
- pnpm check
- pnpm build
- pnpm docgen