### PR TITLE
ci: add node-version input

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -7,6 +7,9 @@ inputs:
   bun-version:
     description: The version of Bun to install
     required: false
+  node-version:
+    description: The version of Node.js to install
+    required: false
 
 runs:
   using: composite
@@ -15,9 +18,10 @@ runs:
       uses: pnpm/action-setup@v3
     - name: Install node
       uses: actions/setup-node@v4
+      if: ${{ inputs.node-version != '' }}
       with:
         cache: pnpm
-        node-version: 24.11.1
+        node-version: ${{ inputs.node-version }}
     - name: Install deno
       uses: denoland/setup-deno@v2
       if: ${{ inputs.deno-version != '' }}


### PR DESCRIPTION
This fixes the "Unexpected input(s) 'node-version'" warning .

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Adds a missing parameter to the internal setup composite action to suppress some warnings.
We could alternatively remove the parameter from callsites, but I like this better b/c it leaves running tests on matrixes of Node.js version on the table.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Noticed in #859 :)
