### PR TITLE
EFF-509 Rename HttpClient.retryTransient mode option

### DIFF
--- a/.changeset/thin-ducks-wonder.md
+++ b/.changeset/thin-ducks-wonder.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Rename `HttpClient.retryTransient` option `mode` to `retryOn` and rename `"both"` to `"errors-and-responses"`.

--- a/packages/effect/dtslint/unstable/http/HttpClient.tst.ts
+++ b/packages/effect/dtslint/unstable/http/HttpClient.tst.ts
@@ -2,6 +2,8 @@ import type { Effect } from "effect"
 import { HttpClient, type HttpClientError, type HttpClientResponse } from "effect/unstable/http"
 import { describe, expect, it } from "tstyche"
 
+declare const client: HttpClient.HttpClient
+
 describe("HttpClient", () => {
   describe("urlParams", () => {
     it("should accept coercible records", () => {
@@ -89,6 +91,28 @@ describe("HttpClient", () => {
         // @ts-expect-error!
         urlParams: [["q", { nested: "value" }]]
       })
+    })
+  })
+
+  describe("retryTransient", () => {
+    it("should accept retryOn values", () => {
+      client.pipe(HttpClient.retryTransient({ retryOn: "errors-only" }))
+      client.pipe(HttpClient.retryTransient({ retryOn: "response-only" }))
+      client.pipe(HttpClient.retryTransient({ retryOn: "errors-and-responses" }))
+    })
+
+    it("should reject mode option", () => {
+      client.pipe(
+        // @ts-expect-error!
+        HttpClient.retryTransient({ mode: "errors-only" })
+      )
+    })
+
+    it("should reject both retry value", () => {
+      client.pipe(
+        // @ts-expect-error!
+        HttpClient.retryTransient({ retryOn: "both" })
+      )
     })
   })
 })

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { Effect, Ref } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+
+const makeStatusClient = Effect.fnUntraced(function*(status: number) {
+  const attempts = yield* Ref.make(0)
+  const client = HttpClient.make((request) =>
+    Effect.gen(function*() {
+      yield* Ref.update(attempts, (n) => n + 1)
+      return HttpClientResponse.fromWeb(request, new Response(null, { status }))
+    })
+  )
+  return { attempts, client } as const
+})
+
+describe("HttpClient", () => {
+  describe("retryTransient", () => {
+    it.effect("retries transient responses with retryOn errors-and-responses", () =>
+      Effect.gen(function*() {
+        const { attempts, client } = yield* makeStatusClient(503)
+        const retryClient = client.pipe(HttpClient.retryTransient({ retryOn: "errors-and-responses", times: 2 }))
+        yield* retryClient.get("http://test/").pipe(Effect.ignore)
+        strictEqual(yield* Ref.get(attempts), 3)
+      }))
+
+    it.effect("does not retry transient responses with retryOn errors-only", () =>
+      Effect.gen(function*() {
+        const { attempts, client } = yield* makeStatusClient(503)
+        const retryClient = client.pipe(HttpClient.retryTransient({ retryOn: "errors-only", times: 2 }))
+        yield* retryClient.get("http://test/").pipe(Effect.ignore)
+        strictEqual(yield* Ref.get(attempts), 1)
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- rename `HttpClient.retryTransient` option `mode` to `retryOn` and replace the `"both"` value with `"errors-and-responses"`
- keep schedule-only behavior unchanged by defaulting schedule-form calls to `retryOn: "errors-and-responses"`
- add runtime and dtslint coverage for the new option name / value and rejection of removed API forms

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpClient.test.ts
- pnpm test-types packages/effect/dtslint/unstable/http/HttpClient.tst.ts
- pnpm check
- pnpm build
- pnpm docgen