### PR TITLE
EFF-510 Export Effect do notation APIs

### DIFF
--- a/.changeset/fresh-emus-cheat.md
+++ b/.changeset/fresh-emus-cheat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Export `Effect` do notation APIs (`Do`, `bindTo`, `bind`, and `let`) from `effect/Effect` and add runtime and type-level coverage.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -150,6 +150,26 @@ describe("Effect.catchNoSuchElement", () => {
   })
 })
 
+describe("Effect do notation", () => {
+  it("exports Do and combinators", () => {
+    const result = pipe(
+      Effect.Do,
+      Effect.bind("a", () => Effect.succeed(1)),
+      Effect.let("b", ({ a }) => a + 1),
+      Effect.bind("c", ({ b }) => Effect.succeed(b.toString()))
+    )
+    expect(result).type.toBe<Effect.Effect<{ a: number; b: number; c: string }>>()
+  })
+
+  it("bindTo starts record inference", () => {
+    const result = pipe(
+      Effect.succeed("a"),
+      Effect.bindTo("value")
+    )
+    expect(result).type.toBe<Effect.Effect<{ value: string }>>()
+  })
+})
+
 describe("Effect.tapErrorTag", () => {
   it("narrows tagged errors", () => {
     const result = pipe(

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -119,6 +119,7 @@ import type {
   NoInfer,
   ReasonOf,
   ReasonTags,
+  Simplify,
   Tags,
   unassigned
 } from "./Types.ts"
@@ -1316,6 +1317,84 @@ export const callback: <A, E = never, R = never>(
  * @category Creating Effects
  */
 export const never: Effect<never> = internal.never
+
+/**
+ * An `Effect` containing an empty record `{}`, used as the starting point for
+ * do notation chains.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ * import { pipe } from "effect/Function"
+ *
+ * const program = pipe(
+ *   Effect.Do,
+ *   Effect.bind("x", () => Effect.succeed(2)),
+ *   Effect.bind("y", ({ x }) => Effect.succeed(x + 1)),
+ *   Effect.let("sum", ({ x, y }) => x + y)
+ * )
+ * ```
+ *
+ * @since 4.0.0
+ * @category Do notation
+ */
+export const Do: Effect<{}> = internal.Do
+
+/**
+ * Gives a name to the success value of an `Effect`, creating a single-key
+ * record used in do notation pipelines.
+ *
+ * @since 4.0.0
+ * @category Do notation
+ */
+export const bindTo: {
+  <N extends string>(name: N): <A, E, R>(self: Effect<A, E, R>) => Effect<{ [K in N]: A }, E, R>
+  <A, E, R, N extends string>(self: Effect<A, E, R>, name: N): Effect<{ [K in N]: A }, E, R>
+} = internal.bindTo
+
+const let_: {
+  <N extends string, A extends Record<string, any>, B>(
+    name: N,
+    f: (a: NoInfer<A>) => B
+  ): <E, R>(
+    self: Effect<A, E, R>
+  ) => Effect<Simplify<Omit<A, N> & Record<N, B>>, E, R>
+  <A extends Record<string, any>, E, R, B, N extends string>(
+    self: Effect<A, E, R>,
+    name: N,
+    f: (a: NoInfer<A>) => B
+  ): Effect<Simplify<Omit<A, N> & Record<N, B>>, E, R>
+} = internal.let
+
+export {
+  /**
+   * Adds a computed plain value to the do notation record.
+   *
+   * @since 4.0.0
+   * @category Do notation
+   */
+  let_ as let
+}
+
+/**
+ * Adds an `Effect` value to the do notation record under a given name.
+ *
+ * @since 4.0.0
+ * @category Do notation
+ */
+export const bind: {
+  <N extends string, A extends Record<string, any>, B, E2, R2>(
+    name: N,
+    f: (a: NoInfer<A>) => Effect<B, E2, R2>
+  ): <E, R>(
+    self: Effect<A, E, R>
+  ) => Effect<Simplify<Omit<A, N> & Record<N, B>>, E | E2, R | R2>
+  <A extends Record<string, any>, E, R, B, E2, R2, N extends string>(
+    self: Effect<A, E, R>,
+    name: N,
+    f: (a: NoInfer<A>) => Effect<B, E2, R2>
+  ): Effect<Simplify<Omit<A, N> & Record<N, B>>, E | E2, R | R2>
+} = internal.bind
 
 /**
  * Provides a way to write effectful code using generator functions, simplifying

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1218,20 +1218,22 @@ describe("Effect", () => {
       }))
   })
 
-  // describe("do notation", () => {
-  //   it.effect("works", () =>
-  //     Effect.succeed(1).pipe(
-  //       Effect.bindTo("a"),
-  //       Effect.let("b", ({ a }) => a + 1),
-  //       Effect.bind("b", ({ b }) => Effect.succeed(b.toString())),
-  //       Effect.tap((_) => {
-  //         assert.deepStrictEqual(_, {
-  //           a: 1,
-  //           b: "2"
-  //         })
-  //       })
-  //     ))
-  // })
+  describe("do notation", () => {
+    it.effect("works", () =>
+      Effect.succeed(1).pipe(
+        Effect.bindTo("a"),
+        Effect.let("b", ({ a }) => a + 1),
+        Effect.bind("b", ({ b }) => Effect.succeed(b.toString())),
+        Effect.tap((value) =>
+          Effect.sync(() => {
+            assert.deepStrictEqual(value, {
+              a: 1,
+              b: "2"
+            })
+          })
+        )
+      ))
+  })
 
   describe("stack safety", () => {
     it.live("recursion", () => {


### PR DESCRIPTION
## Summary
- export `Effect.Do`, `Effect.bindTo`, `Effect.bind`, and `Effect.let` from `packages/effect/src/Effect.ts` by wiring the existing internal implementations to the public module
- add runtime coverage in `packages/effect/test/Effect.test.ts` by enabling and updating the do-notation regression test
- add type-level coverage in `packages/effect/dtslint/Effect.tst.ts` and include a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test-types packages/effect/dtslint/Effect.tst.ts
- pnpm check
- pnpm build
- pnpm docgen