### PR TITLE
EFF-512 Revert PR #1380 and remove node-version workflow inputs

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -7,9 +7,6 @@ inputs:
   bun-version:
     description: The version of Bun to install
     required: false
-  node-version:
-    description: The version of Node.js to install
-    required: false
 
 runs:
   using: composite
@@ -18,10 +15,9 @@ runs:
       uses: pnpm/action-setup@v3
     - name: Install node
       uses: actions/setup-node@v4
-      if: ${{ inputs.node-version != '' }}
       with:
         cache: pnpm
-        node-version: ${{ inputs.node-version }}
+        node-version: 24.11.1
     - name: Install deno
       uses: denoland/setup-deno@v2
       if: ${{ inputs.deno-version != '' }}

--- a/.github/workflows/ai-codegen.yml
+++ b/.github/workflows/ai-codegen.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
 
       - name: Run AI Codegen
         run: node packages/tools/ai-codegen/src/bin.ts generate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - run: pnpm lint
 
   types:
@@ -37,8 +35,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - run: pnpm check
       - run: pnpm test-types --target '>=5.8'
 
@@ -53,8 +49,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Set strip internals config
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
@@ -72,7 +66,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           deno-version: v2.6.x
-          node-version: 24.10.0
       - name: Set strip internals config
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json
@@ -91,8 +84,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Clone base ref
         uses: actions/checkout@v6
         with:
@@ -132,8 +123,6 @@ jobs:
       - name: Install dependencies
         if: matrix.runtime == 'Node'
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Test
         if: matrix.runtime == 'Node'
         run: pnpm test --shard ${{ matrix.shard }}
@@ -143,7 +132,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           deno-version: v2.6.x
-          node-version: 24.10.0
       - name: Test
         if: matrix.runtime == 'Deno'
         run: deno task test --shard ${{ matrix.shard }}
@@ -185,8 +173,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Generate Documentation
         run: pnpm docgen
 
@@ -200,7 +186,5 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Check for circular dependencies
         run: pnpm circular

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-        with:
-          node-version: 24.10.0
       - name: Set strip internals config
         run: |
           sed -i 's/"stripInternal": false/"stripInternal": true/' tsconfig.base.json


### PR DESCRIPTION
## Summary
- revert `.github/actions/setup/action.yaml` changes from #1380 by removing the `node-version` input and restoring fixed Node setup in the composite action
- remove all `node-version` arguments passed to `.github/actions/setup` in GitHub workflows (`check`, `snapshot`, `ai-codegen`)
- keep Deno setup inputs intact where used, while eliminating now-unneeded node-version wiring in workflow callsites

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check
- pnpm build
- pnpm docgen