### PR TITLE
EFF-513 Add Random.shuffle API

### DIFF
--- a/.changeset/young-doors-change.md
+++ b/.changeset/young-doors-change.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Random.shuffle` to shuffle iterables with seeded randomness support.

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -148,6 +148,34 @@ export const nextIntBetween = (min: number, max: number, options?: {
 }
 
 /**
+ * Uses the pseudo-random number generator to shuffle the specified iterable.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Random } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const values = yield* Random.shuffle([1, 2, 3, 4, 5])
+ *   console.log(values)
+ * })
+ * ```
+ *
+ * @since 4.0.0
+ * @category Random Number Generators
+ */
+export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
+  randomWith((r) => {
+    const buffer = Array.from(elements)
+    for (let i = buffer.length - 1; i >= 1; i = i - 1) {
+      const index = Math.min(i, Math.floor(r.nextDoubleUnsafe() * (i + 1)))
+      const value = buffer[i]!
+      buffer[i] = buffer[index]!
+      buffer[index] = value
+    }
+    return buffer
+  })
+
+/**
  * Generates a random UUID (v4) string.
  *
  * @example

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -67,6 +67,28 @@ describe("Random", () => {
       }))
   })
 
+  describe("shuffle", () => {
+    it.effect("returns a shuffled copy of all values", () =>
+      Effect.gen(function*() {
+        const input = [1, 2, 3, 4, 5]
+        const output = yield* Random.shuffle(input)
+
+        assert.notStrictEqual(output, input)
+        assert.deepStrictEqual(input, [1, 2, 3, 4, 5])
+        assert.deepStrictEqual(Array.from(output).sort((a, b) => a - b), [1, 2, 3, 4, 5])
+      }))
+
+    it.effect("is deterministic with the same seed", () =>
+      Effect.gen(function*() {
+        const program = Random.shuffle([1, 2, 3, 4, 5])
+
+        const result1 = yield* program.pipe(Random.withSeed("shuffle-seed"))
+        const result2 = yield* program.pipe(Random.withSeed("shuffle-seed"))
+
+        assert.deepStrictEqual(result1, result2)
+      }))
+  })
+
   describe("nextUUIDv4", () => {
     it.effect("generates valid UUID v4 format", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- add `Random.shuffle(elements)` to `packages/effect/src/Random.ts` using a Fisher-Yates shuffle over an `Array.from(iterable)` buffer
- preserve deterministic behavior under `Random.withSeed` and return a shuffled copy without mutating the input iterable
- add runtime tests in `packages/effect/test/Random.test.ts` and include a patch changeset for the new API