### PR TITLE
SCHEMA.md fix missing and unexpected key messages

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -792,7 +792,7 @@ const schema = Schema.Struct({
   username: Schema.String.annotateKey({
     description: "The username used to log in",
     // Custom message shown if the key is missing
-    missingKeyMessage: "Username is required"
+    messageMissingKey: "Username is required"
   })
 })
 
@@ -815,7 +815,7 @@ import { Schema } from "effect"
 
 const schema = Schema.Struct({
   a: Schema.String
-}).annotate({ unexpectedKeyMessage: "Custom message" })
+}).annotate({ messageUnexpectedKey: "Custom message" })
 
 console.log(String(Schema.decodeUnknownExit(schema)({ a: "a", b: "b" }, { onExcessProperty: "error" })))
 /*
@@ -1278,7 +1278,7 @@ const schema = Schema.Tuple([
   Schema.String.annotateKey({
     description: "my element description",
     // a message to display when the element is missing
-    missingKeyMessage: "this element is required"
+    messageMissingKey: "this element is required"
   })
 ])
 
@@ -5537,7 +5537,7 @@ export interface Issue {
 You can customize the messages of the `Issue` object in two main ways:
 
 - By passing formatter hooks
-- By annotating schemas with `message` or `missingKeyMessage` or `unexpectedKeyMessage`
+- By annotating schemas with `message` or `messageMissingKey` or `messageUnexpectedKey`
 
 ##### Hooks
 
@@ -5725,7 +5725,7 @@ const Person = Schema.Struct({
     // Message for invalid type (e.g., number instead of string)
     .annotate({ message: t("string.mismatch") })
     // Message to show when the key is missing
-    .annotateKey({ missingKeyMessage: t("struct.missingKey") })
+    .annotateKey({ messageMissingKey: t("struct.missingKey") })
     // Message to show when the string is empty
     .check(Schema.isNonEmpty({ message: t("string.minLength", { minLength: 1 }) }))
 })


### PR DESCRIPTION

## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

The examples of `.annotate` and `.annotateKey` reference annotations that are named differently