### PR TITLE
Fix Queue.collect message duplication

### DIFF
--- a/.changeset/fix-queue-collect-duplication.md
+++ b/.changeset/fix-queue-collect-duplication.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Queue.collect: stop duplicating drained messages by appending each batch once

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1061,7 +1061,6 @@ export const collect = <A, E>(self: Dequeue<A, E | Done>): Effect<Array<A>, Pull
           while: constTrue,
           body: constant(takeAll(self)),
           step(items: Arr.NonEmptyArray<A>) {
-            out.push(...items)
             for (let i = 0; i < items.length; i++) {
               out.push(items[i])
             }

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -79,6 +79,16 @@ describe("Queue", () => {
       assert.deepEqual(b, [3, 4])
     }))
 
+  it.effect("collect does not duplicate messages", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<{ id: number }, Cause.Done>(10)
+      yield* Queue.offer(queue, { id: 0 })
+      yield* Queue.end(queue)
+
+      const result = yield* Queue.collect(queue)
+      assert.deepStrictEqual(result, [{ id: 0 }])
+    }))
+
   it.effect("offer dropping", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.make<number>({ capacity: 2, strategy: "dropping" })


### PR DESCRIPTION
## Summary
- remove the redundant append in `Queue.collect` so drained batches are added exactly once
- keep the implementation on an indexed `for` loop for speed and to avoid max-argument-length issues
- add a regression test proving `Queue.collect` returns `[{ id: 0 }]` instead of duplicated values

Closes #1408

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Queue.test.ts
- pnpm check
- pnpm build
- pnpm docgen