### PR TITLE
Fix unstable Headers prototype enumerability for fetch polyfills

### DIFF
--- a/.changeset/fix-headers-proto-enumerability.md
+++ b/.changeset/fix-headers-proto-enumerability.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/http Headers: hide inspectable prototype methods from for..in iteration to avoid invalid header names in runtime fetch polyfills

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -44,22 +44,37 @@ export interface Headers extends Redactable.Redactable {
   readonly [key: string]: string
 }
 
-const Proto = Object.assign(Object.create(null), Inspectable.BaseProto, {
-  [TypeId]: TypeId,
-  [Redactable.symbolRedactable](
-    this: Headers,
-    context: ServiceMap.ServiceMap<never>
-  ): Record<string, string | Redacted.Redacted<string>> {
-    return redact(this, ServiceMap.get(context, CurrentRedactedNames))
+const Proto = Object.create(null)
+
+Object.defineProperties(Proto, {
+  [TypeId]: {
+    value: TypeId
   },
-  toJSON() {
-    return Redactable.redact(this)
+  [Redactable.symbolRedactable]: {
+    value(this: Headers, context: ServiceMap.ServiceMap<never>): Record<string, string | Redacted.Redacted<string>> {
+      return redact(this, ServiceMap.get(context, CurrentRedactedNames))
+    }
   },
-  [Equal.symbol](this: Headers, that: Headers): boolean {
-    return Equivalence(this, that)
+  toJSON: {
+    value(this: Headers) {
+      return Redactable.redact(this)
+    }
   },
-  [Hash.symbol](this: Headers): number {
-    return Hash.structure(this)
+  [Equal.symbol]: {
+    value(this: Headers, that: Headers): boolean {
+      return Equivalence(this, that)
+    }
+  },
+  [Hash.symbol]: {
+    value(this: Headers): number {
+      return Hash.structure(this)
+    }
+  },
+  toString: {
+    value: Inspectable.BaseProto.toString
+  },
+  [Inspectable.NodeInspectSymbol]: {
+    value: Inspectable.BaseProto[Inspectable.NodeInspectSymbol]
   }
 })
 

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@effect/vitest"
+import { deepStrictEqual, doesNotThrow, strictEqual } from "@effect/vitest/utils"
 import { Schema } from "effect"
 import { Headers } from "effect/unstable/http"
 import { assertSuccess } from "../../utils/assert.ts"
@@ -20,5 +21,29 @@ describe("Headers", () => {
         })
       )
     })
+  })
+
+  it("does not expose inspectable prototype methods during for..in iteration", () => {
+    const headers = Headers.fromInput({ foo: "bar" })
+    const keys: Array<string> = []
+
+    for (const key in headers) {
+      keys.push(key)
+    }
+
+    deepStrictEqual(keys, ["foo"])
+  })
+
+  it("works with for..in based headers polyfills", () => {
+    const effectHeaders = Headers.fromInput({ foo: "bar" })
+    const nativeHeaders = new globalThis.Headers()
+
+    doesNotThrow(() => {
+      for (const key in effectHeaders) {
+        nativeHeaders.append(key, effectHeaders[key])
+      }
+    })
+
+    strictEqual(nativeHeaders.get("foo"), "bar")
   })
 })


### PR DESCRIPTION
## Summary
- build unstable HTTP `Headers` prototype with non-enumerable method/symbol properties so `for..in` only yields actual header entries
- preserve existing inspect/equality/hash behavior while preventing internal keys from leaking into header iteration
- add regressions verifying `for..in` iteration and compatibility with `Headers.append` loops used by some runtime/polyfill implementations

Partially addresses #1404 (point 2: headers)

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/Headers.test.ts
- pnpm check
- pnpm build
- pnpm docgen