### PR TITLE
EFF-515: add Effect.validate api

### DIFF
--- a/.changeset/empty-ligers-sparkle.md
+++ b/.changeset/empty-ligers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.validate` to combine two effects while accumulating failures from both sides.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -170,6 +170,21 @@ describe("Effect do notation", () => {
   })
 })
 
+describe("Effect.validate", () => {
+  it("data-first", () => {
+    const result = Effect.validate(Effect.succeed("b"))(Effect.succeed(1))
+    expect(result).type.toBe<Effect.Effect<[number, string], never, never>>()
+  })
+
+  it("data-last", () => {
+    const result = pipe(
+      Effect.fail(new SimpleError({ code: 1 })),
+      Effect.validate(Effect.fail(new OtherError({ message: "err" })))
+    )
+    expect(result).type.toBe<Effect.Effect<[never, never], SimpleError | OtherError, never>>()
+  })
+})
+
 describe("Effect.tapErrorTag", () => {
   it("narrows tagged errors", () => {
     const result = pipe(

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2485,6 +2485,49 @@ export const zip: {
 } = internal.zip
 
 /**
+ * Combines two effects and accumulates failures from both effects.
+ *
+ * Unlike {@link zip}, this function evaluates both effects and merges failures
+ * when both sides fail.
+ *
+ * **Concurrency**
+ *
+ * By default, effects are evaluated sequentially. To evaluate both effects
+ * concurrently, use the `{ concurrent: true }` option.
+ *
+ * @see {@link zip} for a version that stops at the first failure.
+ *
+ * @example
+ * ```ts
+ * import { Cause, Effect } from "effect"
+ *
+ * const result = Effect.fail("left").pipe(
+ *   Effect.validate(Effect.fail("right")),
+ *   Effect.sandbox,
+ *   Effect.flip
+ * )
+ *
+ * Effect.runPromise(result).then((cause) => {
+ *   console.log(Cause.pretty(cause))
+ * })
+ * ```
+ *
+ * @since 2.0.0
+ * @category Error Accumulation
+ */
+export const validate: {
+  <A2, E2, R2>(
+    that: Effect<A2, E2, R2>,
+    options?: { readonly concurrent?: boolean | undefined } | undefined
+  ): <A, E, R>(self: Effect<A, E, R>) => Effect<[A, A2], E2 | E, R2 | R>
+  <A, E, R, A2, E2, R2>(
+    self: Effect<A, E, R>,
+    that: Effect<A2, E2, R2>,
+    options?: { readonly concurrent?: boolean | undefined }
+  ): Effect<[A, A2], E | E2, R | R2>
+} = internal.validate
+
+/**
  * Combines two effects sequentially and applies a function to their results to
  * produce a single value.
  *


### PR DESCRIPTION
## Summary
- add public `Effect.validate` API and internal implementation that evaluates both effects and accumulates both failure causes
- support `{ concurrent: true }` by running both effects concurrently while preserving the same accumulation semantics
- add runtime and dtslint coverage for success/failure typing and sequential vs concurrent behavior

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/dtslint/Effect.tst.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`