### PR TITLE
Fix approval artifact stripping across multi-round conversations

### DIFF
--- a/.changeset/fix-strip-approval-artifacts-multi-round.md
+++ b/.changeset/fix-strip-approval-artifacts-multi-round.md
@@ -1,0 +1,13 @@
+---
+"effect": patch
+---
+
+Fix LanguageModel stripping of resolved approval artifacts across multi-round conversations.
+
+Previously, `stripResolvedApprovals` only ran when there were pending approvals
+in the current round. Stale artifacts from earlier rounds would leak to the
+provider, causing errors. The stripping now runs unconditionally.
+
+In streaming mode, pre-resolved tool results are also emitted as stream parts
+so `Chat.streamText` persists them to history, preventing re-resolution on
+subsequent rounds.


### PR DESCRIPTION
## Summary
- Strip resolved approval artifacts unconditionally, not only when the current round has pending approvals. Previously, stale artifacts from earlier rounds leaked to the provider causing errors.
- In streaming mode, emit pre-resolved tool results as stream parts so `Chat.streamText` persists them to history, preventing re-resolution on subsequent rounds.

## Test plan
- [x] Existing `LanguageModel.test.ts` tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)