### PR TITLE
EFF-517: Add Effect.validate API

### DIFF
--- a/.changeset/curvy-apples-float.md
+++ b/.changeset/curvy-apples-float.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.validate` for validating collections while accumulating all failures, equivalent to the v3 `Effect.validateAll` behavior.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -170,6 +170,23 @@ describe("Effect do notation", () => {
   })
 })
 
+describe("Effect.validate", () => {
+  it("returns collected successes on success", () => {
+    const result = Effect.validate([1, 2, 3], (n) => Effect.succeed(n.toString()))
+    expect(result).type.toBe<Effect.Effect<Array<string>, [never, ...Array<never>]>>()
+  })
+
+  it("returns non-empty array errors", () => {
+    const result = Effect.validate([1, 2, 3], () => Effect.fail("error" as const))
+    expect(result).type.toBe<Effect.Effect<Array<never>, ["error", ...Array<"error">]>>()
+  })
+
+  it("supports discard option", () => {
+    const result = Effect.validate([1, 2, 3], (n) => Effect.succeed(n), { discard: true })
+    expect(result).type.toBe<Effect.Effect<void, [never, ...Array<never>]>>()
+  })
+})
+
 describe("Effect.tapErrorTag", () => {
   it("narrows tagged errors", () => {
     const result = pipe(

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -800,6 +800,74 @@ export const partition: {
 } = internal.partition
 
 /**
+ * Applies an effectful function to each element and accumulates all failures.
+ *
+ * This function always evaluates every element. If at least one effect fails,
+ * all failures are returned as a non-empty array and successes are discarded.
+ * If all effects succeed, it returns all collected successes.
+ *
+ * Use `discard: true` to ignore successful values while still validating all
+ * elements.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.validate([0, 1, 2, 3], (n) =>
+ *   n % 2 === 0 ? Effect.fail(`${n} is even`) : Effect.succeed(n)
+ * )
+ *
+ * Effect.runPromiseExit(program).then(console.log)
+ * // {
+ * //   _id: 'Exit',
+ * //   _tag: 'Failure',
+ * //   cause: {
+ * //     _id: 'Cause',
+ * //     reasons: [
+ * //       { _id: 'Reason', _tag: 'Fail', error: '0 is even' },
+ * //       { _id: 'Reason', _tag: 'Fail', error: '2 is even' }
+ * //     ]
+ * //   }
+ * // }
+ * ```
+ *
+ * @since 4.0.0
+ * @category Error Accumulation
+ */
+export const validate: {
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options?: {
+      readonly concurrency?: Concurrency | undefined
+      readonly discard?: false | undefined
+    } | undefined
+  ): (elements: Iterable<A>) => Effect<Array<B>, Arr.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options: {
+      readonly concurrency?: Concurrency | undefined
+      readonly discard: true
+    }
+  ): (elements: Iterable<A>) => Effect<void, Arr.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    elements: Iterable<A>,
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options?: {
+      readonly concurrency?: Concurrency | undefined
+      readonly discard?: false | undefined
+    } | undefined
+  ): Effect<Array<B>, Arr.NonEmptyArray<E>, R>
+  <A, B, E, R>(
+    elements: Iterable<A>,
+    f: (a: A, i: number) => Effect<B, E, R>,
+    options: {
+      readonly concurrency?: Concurrency | undefined
+      readonly discard: true
+    }
+  ): Effect<void, Arr.NonEmptyArray<E>, R>
+} = internal.validate
+
+/**
  * Executes an effectful operation for each element in an `Iterable`.
  *
  * **Details**

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -448,6 +448,30 @@ describe("Effect", () => {
       }))
   })
 
+  describe("validate", () => {
+    it.effect("collects successes when all effects succeed", () =>
+      Effect.gen(function*() {
+        const values = [0, 1, 2, 3, 4]
+        const satisfying = yield* Effect.validate(values, Effect.succeed)
+        assert.deepStrictEqual(satisfying, values)
+      }))
+
+    it.effect("accumulates all failures", () =>
+      Effect.gen(function*() {
+        const values = [0, 1, 2, 3, 4, 5]
+        const errors = yield* Effect.validate(values, (n) => n % 2 === 0 ? Effect.fail(n) : Effect.succeed(n)).pipe(
+          Effect.flip
+        )
+        assert.deepStrictEqual(errors, [0, 2, 4])
+      }))
+
+    it.effect("supports discard option", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.validate([1, 2, 3], Effect.succeed, { discard: true })
+        assert.strictEqual(result, undefined)
+      }))
+  })
+
   describe("filter", () => {
     it.live("odd numbers", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- add `Effect.validate` to `packages/effect/src/Effect.ts` and `packages/effect/src/internal/effect.ts` with v3 `Effect.validateAll` semantics (evaluate all elements, accumulate failures, return successes only when no failures)
- support `concurrency` and `discard` options, with a non-empty array error type for accumulated failures
- add runtime coverage in `packages/effect/test/Effect.test.ts`, type-level coverage in `packages/effect/dtslint/Effect.tst.ts`, and include a patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/dtslint/Effect.tst.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`