### PR TITLE
EFF-523 Add Random.nextBoolean api

### DIFF
--- a/.changeset/clean-dryers-sneeze.md
+++ b/.changeset/clean-dryers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Random.nextBoolean` for generating random boolean values.

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -77,6 +77,24 @@ const randomWith = <A>(f: (random: typeof Random["Service"]) => A): Effect.Effec
 export const next: Effect.Effect<number> = randomWith((r) => r.nextDoubleUnsafe())
 
 /**
+ * Generates a random boolean value.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Random } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const value = yield* Random.nextBoolean
+ *   console.log("Random boolean:", value)
+ * })
+ * ```
+ *
+ * @since 4.0.0
+ * @category Random Number Generators
+ */
+export const nextBoolean: Effect.Effect<boolean> = randomWith((r) => r.nextDoubleUnsafe() > 0.5)
+
+/**
  * Generates a random integer between `Number.MIN_SAFE_INTEGER` (inclusive)
  * and `Number.MAX_SAFE_INTEGER` (inclusive).
  *

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -13,6 +13,40 @@ describe("Random", () => {
       }))
   })
 
+  describe("nextBoolean", () => {
+    it.effect("generates a boolean", () =>
+      Effect.gen(function*() {
+        const value = yield* Random.nextBoolean
+
+        assert.isTrue(value === true || value === false)
+      }))
+
+    it.effect("is deterministic with the same seed", () =>
+      Effect.gen(function*() {
+        const program = Effect.all([Random.nextBoolean, Random.nextBoolean, Random.nextBoolean])
+
+        const result1 = yield* program.pipe(Random.withSeed("next-boolean-seed"))
+        const result2 = yield* program.pipe(Random.withSeed("next-boolean-seed"))
+
+        assert.deepStrictEqual(result1, result2)
+      }))
+
+    it.effect("uses a strict greater-than threshold", () =>
+      Effect.gen(function*() {
+        const values = [0.5, 0.500001, 0.1]
+        let index = 0
+
+        const result = yield* Effect.all([Random.nextBoolean, Random.nextBoolean, Random.nextBoolean]).pipe(
+          Effect.provideService(Random.Random, {
+            nextIntUnsafe: () => 0,
+            nextDoubleUnsafe: () => values[index++] ?? 0
+          })
+        )
+
+        assert.deepStrictEqual(result, [false, true, false])
+      }))
+  })
+
   describe("nextInt", () => {
     it.effect("generates a safe integer", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- add `Random.nextBoolean` in `packages/effect/src/Random.ts` as an `Effect<boolean>` using the existing random service (`nextDoubleUnsafe() > 0.5`)
- add coverage in `packages/effect/test/Random.test.ts` for boolean output, deterministic seeded behavior, and the strict threshold (`0.5` is `false`)
- add a patch changeset for `effect`

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Random.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm docgen`