### PR TITLE
EFF-525 Fix RPC JSON-RPC serialization for non-batched requests

### DIFF
--- a/.changeset/small-bugs-hunt.md
+++ b/.changeset/small-bugs-hunt.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix JSON-RPC serialization to return an object for non-batched requests while preserving array responses for true batch requests.

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -1,0 +1,61 @@
+import { assert, describe, it } from "@effect/vitest"
+import { RpcSerialization } from "effect/unstable/rpc"
+
+const responseExitSuccess = (requestId: string, value: unknown) => ({
+  _tag: "Exit",
+  requestId,
+  exit: {
+    _tag: "Success",
+    value
+  }
+})
+
+describe("RpcSerialization", () => {
+  it("jsonRpc encodes a non-batched single response array as an object", () => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    const decoded = parser.decode("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"users.get\"}")
+    assert.strictEqual(decoded.length, 1)
+
+    const encoded = parser.encode([responseExitSuccess("1", { id: 1 })])
+    assert(encoded !== undefined)
+
+    const message = JSON.parse(encoded as string)
+    assert.strictEqual(Array.isArray(message), false)
+    assert.deepStrictEqual(message, {
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        id: 1
+      }
+    })
+  })
+
+  it("jsonRpc encodes batched responses as an array", () => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    const decoded = parser.decode(
+      "[{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"users.get\"},{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"users.list\"}]"
+    )
+    assert.strictEqual(decoded.length, 2)
+
+    const encoded = parser.encode([
+      responseExitSuccess("1", "one"),
+      responseExitSuccess("2", "two")
+    ])
+    assert(encoded !== undefined)
+
+    const message = JSON.parse(encoded as string)
+    assert.strictEqual(Array.isArray(message), true)
+    assert.deepStrictEqual(message, [
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: "one"
+      },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        result: "two"
+      }
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- fix `RpcSerialization.jsonRpc` encoding so non-batched request responses are emitted as a JSON object instead of a single-element JSON array
- preserve batch behavior by keeping array responses for true batch requests and routing array inputs through batch-aware response shaping
- add `RpcSerialization` regression tests for non-batch vs batch JSON-RPC output, and include a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/rpc/RpcSerialization.test.ts
- pnpm check
- pnpm build
- pnpm docgen