### PR TITLE
EFF-526: use cause annotations for HTTP client interruption detection

### DIFF
--- a/.changeset/purple-carrots-jump.md
+++ b/.changeset/purple-carrots-jump.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Switch HTTP client-abort detection from special interrupt fiber ids to cause annotations.


### PR DESCRIPTION
## Summary
- Replace sentinel interrupt fiber-id checks in `HttpServerError.causeResponse` with cause annotations by introducing `HttpServerError.ClientAbort`.
- Update `HttpEffect.toHandled` to annotate interrupt causes as client aborts when the backing web `Request.signal` is aborted, and simplify `toWebHandlerWith` abort interruption to use normal interrupts.
- Add regression coverage for annotated vs unannotated interrupt status mapping (`499` vs `503`) in `HttpEffect` and `HttpServerError` tests.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpEffect.test.ts
- pnpm test packages/effect/test/unstable/http/HttpServerError.test.ts
- pnpm check
- pnpm build
- pnpm docgen