### PR TITLE
Fix Atom.searchParam initial schema decode

### DIFF
--- a/.changeset/fix-searchparam-initial-decode.md
+++ b/.changeset/fix-searchparam-initial-decode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Atom.searchParam: decode initial URL values correctly when a schema is provided

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1850,7 +1850,7 @@ export const searchParam = <S extends Schema.Codec<any, string> = never>(name: s
         window.removeEventListener("pushstate", handleUpdate)
       })
       const value = new URLSearchParams(window.location.search).get(name) || ""
-      return decode ? Exit.findErrorOption(decode(value)) : value as any
+      return decode ? Exit.getSuccess(decode(value)) : value as any
     },
     (ctx, value: any) => {
       if (typeof window === "undefined") {

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -108,6 +108,45 @@ describe.sequential("Atom", () => {
     expect(second).toEqual(1)
   })
 
+  it("searchParam with schema reads initial query value", () => {
+    const previousWindow = (globalThis as any).window
+    const r = AtomRegistry.make()
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: {
+          pathname: "/",
+          search: "?page=6"
+        },
+        history: {
+          pushState: () => {
+          }
+        },
+        addEventListener: () => {
+        },
+        removeEventListener: () => {
+        }
+      },
+      configurable: true,
+      writable: true
+    })
+
+    try {
+      const page = Atom.searchParam("page", { schema: Schema.NumberFromString })
+      expect(r.get(page)).toEqual(Option.some(6))
+    } finally {
+      r.dispose()
+      if (typeof previousWindow === "undefined") {
+        delete (globalThis as any).window
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          value: previousWindow,
+          configurable: true,
+          writable: true
+        })
+      }
+    }
+  })
+
   it("runtime", async () => {
     const count = counterRuntime.atom(Counter.use((_) => _.get)).pipe(
       Atom.withLabel("count")


### PR DESCRIPTION
## Summary
- fix `Atom.searchParam` initial read to return decoded success values (`Exit.getSuccess`) when a schema is provided
- add a regression test covering initial URL query decoding with `Schema.NumberFromString`
- add a patch changeset for `effect`

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/reactivity/Atom.test.ts
- pnpm check
- pnpm build
- pnpm docgen

Closes #1435.