### PR TITLE
Fix Graph.toMermaid special character escaping

### DIFF
--- a/.changeset/fix-mermaid-escape-special-chars.md
+++ b/.changeset/fix-mermaid-escape-special-chars.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Graph.toMermaid` to escape special characters using HTML entity codes per the Mermaid specification.

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1957,13 +1957,23 @@ export interface MermaidOptions<N, E> {
  * Escapes special characters in labels for Mermaid syntax compatibility.
  */
 const escapeMermaidLabel = (label: string): string => {
+  // Escape special characters for Mermaid using HTML entity codes
+  // According to: https://mermaid.js.org/syntax/flowchart.html#special-characters-that-break-syntax
   return label
-    .replace(/\\/g, "\\\\") // Escape backslashes first
-    .replace(/"/g, "\\\"") // Escape quotes
-    .replace(/\[/g, "\\[") // Escape square brackets
-    .replace(/\]/g, "\\]") // Escape square brackets
-    .replace(/\|/g, "\\|") // Escape pipes
-    .replace(/\n/g, "<br/>") // Convert newlines to HTML breaks
+    .replace(/#/g, "#35;")
+    .replace(/"/g, "#quot;")
+    .replace(/</g, "#lt;")
+    .replace(/>/g, "#gt;")
+    .replace(/&/g, "#amp;")
+    .replace(/\[/g, "#91;")
+    .replace(/\]/g, "#93;")
+    .replace(/\{/g, "#123;")
+    .replace(/\}/g, "#125;")
+    .replace(/\(/g, "#40;")
+    .replace(/\)/g, "#41;")
+    .replace(/\|/g, "#124;")
+    .replace(/\\/g, "#92;")
+    .replace(/\n/g, "<br/>")
 }
 
 /**

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1790,10 +1790,10 @@ describe("Graph", () => {
 
       const mermaid = Graph.toMermaid(graph)
 
-      expect(mermaid).toContain("0[\"Node with \\\"quotes\\\"\"]")
-      expect(mermaid).toContain("1[\"Node with \\[brackets\\]\"]")
-      expect(mermaid).toContain("2[\"Node with \\| pipe\"]")
-      expect(mermaid).toContain("3[\"Node with \\\\ backslash\"]")
+      expect(mermaid).toContain("0[\"Node with #quot;quotes#quot;\"]")
+      expect(mermaid).toContain("1[\"Node with #91;brackets#93;\"]")
+      expect(mermaid).toContain("2[\"Node with #124; pipe\"]")
+      expect(mermaid).toContain("3[\"Node with #92; backslash\"]")
       expect(mermaid).toContain("4[\"Node with <br/> newline\"]")
     })
 
@@ -1966,8 +1966,8 @@ describe("Graph", () => {
       expect(mermaid).toContain("2[\"C\"]")
       expect(mermaid).toContain("3[\"D\"]")
       expect(mermaid).toContain("4[\"E\"]")
-      expect(mermaid).toContain("0 -->|\"A->B\"| 1")
-      expect(mermaid).toContain("2 -->|\"C->D\"| 3")
+      expect(mermaid).toContain("0 -->|\"A-#gt;B\"| 1")
+      expect(mermaid).toContain("2 -->|\"C-#gt;D\"| 3")
     })
 
     it("should handle custom labels with complex data", () => {
@@ -2005,7 +2005,7 @@ describe("Graph", () => {
       expect(mermaid).toContain("flowchart LR")
       expect(mermaid).toContain("0[\"node1:42\"]")
       expect(mermaid).toContain("1[\"node2:84\"]")
-      expect(mermaid).toContain("0 -->|\"data(1.5)\"| 1")
+      expect(mermaid).toContain("0 -->|\"data#40;1.5#41;\"| 1")
     })
   })
 


### PR DESCRIPTION
## Summary
- Fix `escapeMermaidLabel` to use HTML entity codes instead of backslash escaping, per the [Mermaid spec](https://mermaid.js.org/syntax/flowchart.html#special-characters-that-break-syntax)
- Covers all syntax-breaking characters: `# " < > & [ ] { } ( ) | \`
- Update tests to match new escaping format

## Test plan
- [x] `pnpm test packages/effect/test/Graph.test.ts` — all 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)