### PR TITLE
fix Schedule.fixed double-execution caused by clock jitter

### DIFF
--- a/.changeset/fix-schedule-fixed-double-exec.md
+++ b/.changeset/fix-schedule-fixed-double-exec.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Fix `Schedule.fixed` double-executing the effect due to clock jitter.
+
+The `elapsedSincePrevious > window` check included sleep time from the
+previous step, so any timer imprecision (e.g. 1001ms for a 1000ms sleep)
+triggered an immediate zero-delay re-execution.

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -2180,7 +2180,7 @@ export const fixed = (interval: Duration.Input): Schedule<number> => {
   return fromStepWithMetadata(effect.succeed((meta) =>
     effect.succeed([
       meta.attempt - 1,
-      window === 0 || meta.elapsedSincePrevious > window
+      window === 0
         ? Duration.zero
         : Duration.millis(window - (meta.elapsed % window))
     ])


### PR DESCRIPTION
## Summary

- `Schedule.fixed` would execute the effect twice in a row every other interval due to real-clock timer jitter
- The `elapsedSincePrevious > window` check in the delay formula included sleep time from the previous schedule step, so a 1000ms sleep taking 1001ms triggered an immediate zero-delay re-execution
- Removed the check — the `window - (elapsed % window)` formula already handles all cases including action overflow
- Added a regression test for `fixed` with a slow action, cleaned up the existing `windowed` test

Closes https://github.com/Effect-TS/effect-smol/issues/1462