### PR TITLE
EFF-531 Update VariantSchema APIs to array-style arguments

### DIFF
--- a/.changeset/blue-ligers-cheat.md
+++ b/.changeset/blue-ligers-cheat.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update unstable schema variant helpers to use array-based arguments for `FieldOnly`, `FieldExcept`, and `Union`, aligning `VariantSchema` and `Model` with other v4 API shapes.

--- a/packages/effect/dtslint/VariantSchema.tst.ts
+++ b/packages/effect/dtslint/VariantSchema.tst.ts
@@ -1,0 +1,49 @@
+import { Schema } from "effect"
+import { Model, VariantSchema } from "effect/unstable/schema"
+import { describe, expect, it } from "tstyche"
+
+describe("VariantSchema", () => {
+  it("FieldOnly and FieldExcept take key arrays", () => {
+    const Test = VariantSchema.make({
+      variants: ["a", "b"],
+      defaultVariant: "a"
+    })
+
+    expect(Test.FieldOnly).type.toBeCallableWith(["a"] as const)
+    expect(Test.FieldExcept).type.toBeCallableWith(["b"] as const)
+    expect(Test.FieldOnly).type.not.toBeCallableWith("a")
+    expect(Test.FieldExcept).type.not.toBeCallableWith("b")
+  })
+
+  it("Union takes members as an array", () => {
+    const Test = VariantSchema.make({
+      variants: ["a", "b"],
+      defaultVariant: "a"
+    })
+    const first = Test.Struct({
+      value: Test.FieldOnly(["a", "b"])(Schema.String)
+    })
+    const second = Test.Struct({
+      value: Test.FieldOnly(["a", "b"])(Schema.Number)
+    })
+
+    expect(Test.Union).type.toBeCallableWith([first, second])
+    expect(Test.Union).type.not.toBeCallableWith(first, second)
+  })
+})
+
+describe("Model", () => {
+  it("re-exports array based variant APIs", () => {
+    const first = Model.Struct({
+      value: Schema.String
+    })
+    const second = Model.Struct({
+      value: Schema.Number
+    })
+
+    expect(Model.FieldOnly).type.toBeCallableWith(["insert"] as const)
+    expect(Model.FieldExcept).type.toBeCallableWith(["insert"] as const)
+    expect(Model.Union).type.toBeCallableWith([first, second])
+    expect(Model.Union).type.not.toBeCallableWith(first, second)
+  })
+})

--- a/packages/effect/src/unstable/schema/VariantSchema.ts
+++ b/packages/effect/src/unstable/schema/VariantSchema.ts
@@ -301,12 +301,12 @@ export const make = <
     config: A & { readonly [K in Exclude<keyof A, Variants[number]>]: never }
   ) => Field<A>
   readonly FieldOnly: <const Keys extends ReadonlyArray<Variants[number]>>(
-    ...keys: Keys
+    keys: Keys
   ) => <S extends Schema.Top>(
     schema: S
   ) => Field<{ readonly [K in Keys[number]]: S }>
   readonly FieldExcept: <const Keys extends ReadonlyArray<Variants[number]>>(
-    ...keys: Keys
+    keys: Keys
   ) => <S extends Schema.Top>(
     schema: S
   ) => Field<{ readonly [K in Exclude<Variants[number], Keys[number]>]: S }>
@@ -364,7 +364,7 @@ export const make = <
         readonly [V in Variants[number]]: Extract<V, Struct<Fields>>
       }
   readonly Union: <const Members extends ReadonlyArray<Struct<any>>>(
-    ...members: Members
+    members: Members
   ) => Union<Members> & Union.Variants<Members, Variants[number]>
   readonly extract: {
     <V extends Variants[number]>(
@@ -403,7 +403,7 @@ export const make = <
       return Base
     }
   }
-  function FieldOnly<Keys extends Variants>(...keys: Keys) {
+  function FieldOnly<const Keys extends ReadonlyArray<Variants[number]>>(keys: Keys) {
     return function<S extends Schema.Top>(schema: S) {
       const obj: Record<string, S> = {}
       for (const key of keys) {
@@ -412,7 +412,7 @@ export const make = <
       return Field(obj)
     }
   }
-  function FieldExcept<Keys extends Variants>(...keys: Keys) {
+  function FieldExcept<const Keys extends ReadonlyArray<Variants[number]>>(keys: Keys) {
     return function<S extends Schema.Top>(schema: S) {
       const obj: Record<string, S> = {}
       for (const variant of options.variants) {
@@ -423,7 +423,7 @@ export const make = <
       return Field(obj)
     }
   }
-  function UnionVariants(...members: ReadonlyArray<Struct<any>>) {
+  function UnionVariants(members: ReadonlyArray<Struct<any>>) {
     return Union(members, options.variants)
   }
   const fieldEvolve = dual(

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -1,0 +1,32 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Schema from "effect/Schema"
+import { Model, VariantSchema } from "effect/unstable/schema"
+
+describe("VariantSchema", () => {
+  it("FieldOnly and FieldExcept accept key arrays", () => {
+    const Test = VariantSchema.make({
+      variants: ["a", "b", "c"],
+      defaultVariant: "a"
+    })
+    const struct = Test.Struct({
+      common: Schema.String,
+      onlyB: Test.FieldOnly(["b"])(Schema.Number),
+      exceptC: Test.FieldExcept(["c"])(Schema.Boolean)
+    })
+
+    assert.deepStrictEqual(Object.keys(Test.extract(struct, "a").fields), ["common", "exceptC"])
+    assert.deepStrictEqual(Object.keys(Test.extract(struct, "b").fields), ["common", "onlyB", "exceptC"])
+    assert.deepStrictEqual(Object.keys(Test.extract(struct, "c").fields), ["common"])
+  })
+})
+
+describe("Model", () => {
+  it("FieldOnly accepts array arguments", () => {
+    const InsertOnly = Model.Struct({
+      value: Model.FieldOnly(["insert"])(Schema.String)
+    })
+
+    assert.deepStrictEqual(Object.keys(Model.extract(InsertOnly, "insert").fields), ["value"])
+    assert.deepStrictEqual(Object.keys(Model.extract(InsertOnly, "select").fields), [])
+  })
+})


### PR DESCRIPTION
## Summary
- update `VariantSchema.make` helper signatures so `FieldOnly`, `FieldExcept`, and `Union` accept arrays instead of rest arguments, aligning with v4 API conventions
- add runtime regression tests for array-based `FieldOnly` / `FieldExcept` in `VariantSchema` and `Model`
- add dtslint coverage to assert `VariantSchema` / `Model` reject legacy spread call shapes for these APIs
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/schema/VariantSchema.test.ts
- pnpm test-types packages/effect/dtslint/VariantSchema.tst.ts
- pnpm check:tsgo
- pnpm docgen