### PR TITLE
EFF-532 Add cli Command.withAlias

### DIFF
--- a/.changeset/yellow-clocks-dance.md
+++ b/.changeset/yellow-clocks-dance.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Command.withAlias` for unstable CLI commands, including subcommand parsing by alias and help output that renders aliases as `name, alias` in subcommand listings.

--- a/packages/effect/src/unstable/cli/CliOutput.ts
+++ b/packages/effect/src/unstable/cli/CliOutput.ts
@@ -409,6 +409,8 @@ const renderTable = (rows: ReadonlyArray<Row>, widthCap: number) => {
   return rows.map(({ left, right }) => `  ${pad(left, col)}${right}`).join("\n")
 }
 
+const formatSubcommandName = (name: string, alias: string | undefined): string => alias ? `${name}, ${alias}` : name
+
 /**
  * Color functions interface for help formatting.
  * @internal
@@ -533,7 +535,7 @@ const formatHelpDocImpl = (doc: HelpDoc, colors: ColorFunctions): string => {
       sections.push(colors.bold("SUBCOMMANDS"))
       sections.push(renderTable(
         ungrouped.commands.map((sub) => ({
-          left: colors.cyan(sub.name),
+          left: colors.cyan(formatSubcommandName(sub.name, sub.alias)),
           right: sub.shortDescription ?? sub.description
         })),
         20
@@ -548,7 +550,7 @@ const formatHelpDocImpl = (doc: HelpDoc, colors: ColorFunctions): string => {
       sections.push(colors.bold(`${group.group}:`))
       sections.push(renderTable(
         group.commands.map((sub) => ({
-          left: colors.cyan(sub.name),
+          left: colors.cyan(formatSubcommandName(sub.name, sub.alias)),
           right: sub.shortDescription ?? sub.description
         })),
         20

--- a/packages/effect/src/unstable/cli/Command.ts
+++ b/packages/effect/src/unstable/cli/Command.ts
@@ -100,6 +100,11 @@ export interface Command<Name extends string, Input, E = never, R = never> exten
   readonly shortDescription: string | undefined
 
   /**
+   * An optional alias that can be used as a shorter command name.
+   */
+  readonly alias: string | undefined
+
+  /**
    * Optional usage examples for the command.
    */
   readonly examples: ReadonlyArray<Command.Example>
@@ -644,6 +649,7 @@ export const withSubcommands: {
     config: impl.config,
     description: impl.description,
     shortDescription: impl.shortDescription,
+    alias: impl.alias,
     annotations: impl.annotations,
     examples: impl.examples,
     service: impl.service,
@@ -720,6 +726,28 @@ export const withShortDescription: {
   self: Command<Name, Input, E, R>,
   shortDescription: string
 ) => makeCommand({ ...toImpl(self), shortDescription }))
+
+/**
+ * Sets an alias for a command.
+ *
+ * Aliases are accepted as alternate subcommand names during parsing and are
+ * shown in help output as `name, alias`.
+ *
+ * @since 4.0.0
+ * @category combinators
+ */
+export const withAlias: {
+  (alias: string): <const Name extends string, Input, E, R>(
+    self: Command<Name, Input, E, R>
+  ) => Command<Name, Input, E, R>
+  <const Name extends string, Input, E, R>(
+    self: Command<Name, Input, E, R>,
+    alias: string
+  ): Command<Name, Input, E, R>
+} = dual(2, <const Name extends string, Input, E, R>(
+  self: Command<Name, Input, E, R>,
+  alias: string
+) => makeCommand({ ...toImpl(self), alias }))
 
 /**
  * Adds a custom annotation to a command.

--- a/packages/effect/src/unstable/cli/HelpDoc.ts
+++ b/packages/effect/src/unstable/cli/HelpDoc.ts
@@ -175,12 +175,14 @@ export interface FlagDoc {
  *
  * const deploySubcommand: HelpDoc.SubcommandDoc = {
  *   name: "deploy",
+ *   alias: "d",
  *   shortDescription: "Deploy app",
  *   description: "Deploy the application to the cloud"
  * }
  *
  * const buildSubcommand: HelpDoc.SubcommandDoc = {
  *   name: "build",
+ *   alias: undefined,
  *   shortDescription: undefined,
  *   description: "Build the application for production"
  * }
@@ -206,6 +208,11 @@ export interface SubcommandDoc {
    * Name of the subcommand
    */
   readonly name: string
+
+  /**
+   * Optional short alias for invoking the subcommand.
+   */
+  readonly alias: string | undefined
 
   /**
    * Optional short description of what the subcommand does.

--- a/packages/effect/src/unstable/cli/internal/command.ts
+++ b/packages/effect/src/unstable/cli/internal/command.ts
@@ -90,6 +90,7 @@ export const makeCommand = <const Name extends string, Input, E, R>(options: {
   readonly annotations?: ServiceMap.ServiceMap<never> | undefined
   readonly description?: string | undefined
   readonly shortDescription?: string | undefined
+  readonly alias?: string | undefined
   readonly examples?: ReadonlyArray<Command.Example> | undefined
   readonly subcommands?: ReadonlyArray<SubcommandGroup> | undefined
   readonly parse?: ((input: ParsedTokens) => Effect.Effect<Input, CliError.CliError, Environment>) | undefined
@@ -165,6 +166,7 @@ export const makeCommand = <const Name extends string, Input, E, R>(options: {
         group: group.group,
         commands: Arr.map(group.commands, (subcommand) => ({
           name: subcommand.name,
+          alias: subcommand.alias,
           shortDescription: subcommand.shortDescription,
           description: subcommand.description ?? ""
         }))
@@ -200,6 +202,9 @@ export const makeCommand = <const Name extends string, Input, E, R>(options: {
       : {}),
     ...(Predicate.isNotUndefined(options.shortDescription)
       ? { shortDescription: options.shortDescription }
+      : {}),
+    ...(Predicate.isNotUndefined(options.alias)
+      ? { alias: options.alias }
       : {})
   })
 }

--- a/packages/effect/src/unstable/cli/internal/parser.ts
+++ b/packages/effect/src/unstable/cli/internal/parser.ts
@@ -244,9 +244,22 @@ const buildSubcommandIndex = (
   subcommands: Command.Any["subcommands"]
 ): Map<string, Command<string, unknown, unknown, unknown>> => {
   const index = new Map<string, Command<string, unknown, unknown, unknown>>()
+  const setKey = (key: string, command: Command<string, unknown, unknown, unknown>) => {
+    const existing = index.get(key)
+    if (existing && existing !== command) {
+      throw new Error(
+        `Duplicate subcommand name/alias "${key}" in command definition (conflicts with "${existing.name}")`
+      )
+    }
+    index.set(key, command)
+  }
+
   for (const group of subcommands) {
     for (const subcommand of group.commands) {
-      index.set(subcommand.name, subcommand)
+      setKey(subcommand.name, subcommand)
+      if (subcommand.alias && subcommand.alias !== subcommand.name) {
+        setKey(subcommand.alias, subcommand)
+      }
     }
   }
   return index

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -338,4 +338,33 @@ describe("Command help output", () => {
           functions    Manage edge functions"
       `)
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("subcommand aliases in listings", () =>
+    Effect.gen(function*() {
+      const plan = Command.make("plan").pipe(
+        Command.withAlias("p"),
+        Command.withDescription("Draft a plan in your editor")
+      )
+
+      const root = Command.make("tool").pipe(Command.withSubcommands([plan]))
+      const runRoot = Command.runWith(root, { version: "1.0.0" })
+
+      yield* runRoot(["--help"])
+
+      const helpText = (yield* TestConsole.logLines).join("\n")
+
+      expect(helpText).toMatchInlineSnapshot(`
+        "USAGE
+          tool <subcommand> [flags]
+
+        GLOBAL FLAGS
+          --help, -h              Show help information
+          --version               Show version information
+          --completions choice    Print shell completion script
+          --log-level choice      Sets the minimum log level
+
+        SUBCOMMANDS
+          plan, p    Draft a plan in your editor"
+      `)
+    }).pipe(Effect.provide(TestLayer)))
 })


### PR DESCRIPTION
## Summary
- add `Command.withAlias` and command-level `alias` metadata so subcommands can expose short aliases
- update subcommand parsing to accept aliases in addition to canonical command names, including duplicate name/alias conflict checks
- include aliases in structured `HelpDoc` subcommand metadata and render `name, alias` in default help output
- add regression tests for alias invocation, help-doc metadata, and formatted help output, plus a patch changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Command.test.ts
- pnpm test packages/effect/test/unstable/cli/Help.test.ts
- pnpm check:tsgo
- pnpm docgen