### PR TITLE
EFF-537: add ai docs example for Effect.acquireRelease

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -184,9 +184,9 @@ export const withFinalFallback = loadPort("invalid").pipe(
 Learn how to safely manage resources in Effect using `Scope`s and finalizers.
 
 - **[Acquiring resources with Effect.acquireRelease](./ai-docs/src/01_effect/04_resources/10_acquire-release.ts)**:
-  Define a service method that acquires a short-lived resource with
-  `Effect.acquireRelease`, then execute it with `Effect.scoped` so finalizers
-  always run.
+  Define a service that uses `Effect.acquireRelease` to manage the lifecycle of
+  an resource, ensuring that it is properly cleaned up when the service is no
+  longer needed.
 
 ## Effect HttpClient
 

--- a/ai-docs/package.json
+++ b/ai-docs/package.json
@@ -17,14 +17,18 @@
     "@effect/sql-clickhouse": "workspace:*",
     "@effect/sql-d1": "workspace:*",
     "@effect/sql-libsql": "workspace:*",
-    "@effect/sql-mysql2": "workspace:*",
     "@effect/sql-mssql": "workspace:*",
+    "@effect/sql-mysql2": "workspace:*",
     "@effect/sql-pg": "workspace:*",
     "@effect/sql-sqlite-bun": "workspace:*",
     "@effect/sql-sqlite-do": "workspace:*",
     "@effect/sql-sqlite-node": "workspace:*",
     "@effect/sql-sqlite-react-native": "workspace:*",
     "@effect/sql-sqlite-wasm": "workspace:*",
-    "effect": "workspace:*"
+    "effect": "workspace:*",
+    "nodemailer": "^8.0.1"
+  },
+  "devDependencies": {
+    "@types/nodemailer": "^7.0.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,13 @@ importers:
       effect:
         specifier: workspace:*
         version: link:../packages/effect
+      nodemailer:
+        specifier: ^8.0.1
+        version: 8.0.1
+    devDependencies:
+      '@types/nodemailer':
+        specifier: ^7.0.11
+        version: 7.0.11
 
   packages/ai/anthropic:
     devDependencies:
@@ -2628,6 +2635,9 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
+  '@types/nodemailer@7.0.11':
+    resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
+
   '@types/pg-cursor@2.7.2':
     resolution: {integrity: sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==}
 
@@ -4893,6 +4903,10 @@ packages:
     resolution: {integrity: sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==}
     engines: {node: '>=18'}
 
+  nodemailer@8.0.1:
+    resolution: {integrity: sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==}
+    engines: {node: '>=6.0.0'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -5236,6 +5250,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   precinct@12.2.0:
@@ -5979,6 +5994,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tedious@19.2.0:
     resolution: {integrity: sha512-2dDjX0KP54riDvJPiiIozv0WRS/giJb3/JG2lWpa2dgM0Gha7mLAxbTR3ltPkGzfoS6M3oDnhYnWuzeaZibHuQ==}
@@ -8458,6 +8474,10 @@ snapshots:
   '@types/node@25.2.3':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/nodemailer@7.0.11':
+    dependencies:
+      '@types/node': 25.2.3
 
   '@types/pg-cursor@2.7.2':
     dependencies:
@@ -11028,6 +11048,8 @@ snapshots:
   node-source-walk@7.0.1:
     dependencies:
       '@babel/parser': 7.29.0
+
+  nodemailer@8.0.1: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- update `ai-docs/src/01_effect/04_resources/10_acquire-release.ts` to use a `ServiceMap.Service` (`Mailer`) with `Layer.effect`
- demonstrate `Effect.acquireRelease` inside a scoped service method using an SMTP session resource and `Exit`-aware cleanup
- regenerate `LLMS.md` with `pnpm ai-docgen` so the updated example description appears in the resources section

## Validation
- pnpm ai-docgen
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check:tsgo
- pnpm docgen