### PR TITLE
EFF-540: Add AI docs example for creating effects

### DIFF
--- a/LLMS.md
+++ b/LLMS.md
@@ -79,9 +79,9 @@ export class SomeError extends Schema.TaggedErrorClass<SomeError>()("SomeError",
 
 ### More examples
 
-- **[Creating effects from common data sources](./ai-docs/src/01_effect/01_basics/10_creating-effects.ts)**:
+- **[Creating effects from common sources](./ai-docs/src/01_effect/01_basics/10_creating-effects.ts)**:
   Learn how to create effects from various sources, including plain values,
-  synchronous and asynchronous code, optional values, and callback-based APIs.
+  synchronous code, Promise APIs, optional values, and callback-based APIs.
 
 ## Writing Effect services
 

--- a/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
+++ b/ai-docs/src/01_effect/01_basics/10_creating-effects.ts
@@ -1,8 +1,8 @@
 /**
- * @title Creating effects from common data sources
+ * @title Creating effects from common sources
  *
  * Learn how to create effects from various sources, including plain values,
- * synchronous and asynchronous code, optional values, and callback-based APIs.
+ * synchronous code, Promise APIs, optional values, and callback-based APIs.
  */
 import { Effect, Schema } from "effect"
 


### PR DESCRIPTION
## Summary
- add a new Effect basics AI docs example at `ai-docs/src/01_effect/01_basics/10_creating-effects.ts`
- cover creating effects from common sources: values, sync/throwing code, Promise APIs, nullish values, and callback APIs
- apply review feedback by switching function wrappers to `Effect.fn`, using `Date.now()` in the sync example, and removing the `Effect.fromResult` section

## Validation
- pnpm ai-docgen
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check:tsgo
- pnpm docgen