### PR TITLE
Add IndexedDB support to BrowserKeyValueStore

### DIFF
--- a/.changeset/add-indexed-db-key-value-store.md
+++ b/.changeset/add-indexed-db-key-value-store.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": minor
+---
+
+Add IndexedDB-backend KeyValueStore implementation in BrowserKeyValueStore.

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "effect": "workspace:^",
+    "fake-indexeddb": "^6.2.5",
     "mock-xmlhttprequest": "^8.4.1"
   },
   "dependencies": {

--- a/packages/platform-browser/src/BrowserKeyValueStore.ts
+++ b/packages/platform-browser/src/BrowserKeyValueStore.ts
@@ -1,7 +1,9 @@
 /**
  * @since 1.0.0
  */
-import type * as Layer from "effect/Layer"
+import { Effect } from "effect"
+import * as Layer from "effect/Layer"
+import * as ServiceMap from "effect/ServiceMap"
 import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
 
 /**
@@ -27,3 +29,237 @@ export const layerLocalStorage: Layer.Layer<KeyValueStore.KeyValueStore> = KeyVa
 export const layerSessionStorage: Layer.Layer<KeyValueStore.KeyValueStore> = KeyValueStore.layerStorage(() =>
   globalThis.sessionStorage
 )
+
+class IDBDatabaseService
+  extends ServiceMap.Service<IDBDatabaseService, IDBDatabase>()("effect/persistence/KeyValueStore/IDBDatabase")
+{
+  static readonly acquire = (name: string, storeName: string, version: number) =>
+    Effect.callback<IDBDatabase, KeyValueStore.KeyValueStoreError, never>((resume) => {
+      if (!globalThis.indexedDB) {
+        resume(Effect.fail(
+          new KeyValueStore.KeyValueStoreError({
+            message: "IndexedDB is not supported",
+            method: "acquire",
+            cause: new Error("IndexedDB is not supported")
+          })
+        ))
+        return
+      }
+      const request = globalThis.indexedDB.open(name, version)
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains(storeName)) {
+          request.result.createObjectStore(storeName)
+        }
+      }
+      request.onsuccess = () => resume(Effect.succeed(request.result))
+      request.onerror = (cause) => {
+        resume(
+          Effect.fail(
+            new KeyValueStore.KeyValueStoreError({
+              message: request.error?.message || "Error acquiring indexedDB database",
+              method: "acquire",
+              cause
+            })
+          )
+        )
+      }
+    })
+
+  static readonly release = (database: IDBDatabase) => Effect.sync(() => database.close())
+
+  static readonly layer = (dbName: string, storeName: string, version: number) =>
+    Layer.effect(this, Effect.acquireRelease(this.acquire(dbName, storeName, version), this.release))
+}
+
+type ReadMethod = "get" | "size"
+type WriteMethod = "set" | "remove" | "clear"
+type Method = ReadMethod | WriteMethod
+type Mode = "readonly" | "readwrite"
+
+const acquireTransaction = (database: IDBDatabase, storeName: string, method: Method, mode: Mode) =>
+  Effect.try({
+    try() {
+      const transaction = database.transaction(storeName, mode)
+      const store = transaction.objectStore(storeName)
+
+      return { transaction, store }
+    },
+    catch: (cause) =>
+      new KeyValueStore.KeyValueStoreError({
+        message: `Unable to create transaction on store ${storeName}`,
+        method,
+        cause
+      })
+  })
+
+const makeRequest = <A>(
+  database: IDBDatabase,
+  storeName: string,
+  method: Method,
+  fn: (store: IDBObjectStore) => IDBRequest<A>,
+  catchError: (event: Event) => KeyValueStore.KeyValueStoreError,
+  mode: Mode
+) =>
+  acquireTransaction(database, storeName, method, mode).pipe(Effect.andThen(({ transaction, store }) =>
+    Effect.try({
+      try: () => ({ transaction, request: fn(store) }),
+      catch: (cause) =>
+        cause instanceof Event ? catchError(cause) : new KeyValueStore.KeyValueStoreError({
+          message: `Unable to create request on store ${storeName}`,
+          method,
+          cause
+        })
+    })
+  ))
+
+function attachSignal<A>(
+  method: Method,
+  transaction: IDBTransaction,
+  _resume: (effect: Effect.Effect<A, KeyValueStore.KeyValueStoreError>) => void,
+  signal: AbortSignal
+) {
+  let done = false
+  function abortHandler() {
+    if (done) return
+    done = true
+    try {
+      transaction.abort()
+    } catch {
+    } finally {
+      signal.removeEventListener("abort", abortHandler)
+    }
+  }
+  signal.addEventListener("abort", abortHandler)
+
+  function resume(effect: Effect.Effect<A, KeyValueStore.KeyValueStoreError>) {
+    if (done || signal.aborted) return
+    signal.removeEventListener("abort", abortHandler)
+    done = true
+    _resume(effect)
+  }
+
+  transaction.onabort = () => {
+    resume(Effect.fail(
+      new KeyValueStore.KeyValueStoreError({
+        message: "Transaction aborted",
+        method,
+        cause: transaction.error
+      })
+    ))
+  }
+
+  return resume
+}
+
+const fromRequest = <A>(
+  method: Method,
+  transaction: IDBTransaction,
+  request: IDBRequest<A>,
+  catchError: (event: Event) => KeyValueStore.KeyValueStoreError
+): Effect.Effect<A, KeyValueStore.KeyValueStoreError> =>
+  Effect.callback<A, KeyValueStore.KeyValueStoreError, never>((_resume, signal) => {
+    const resume = attachSignal(method, transaction, _resume, signal)
+
+    request.onsuccess = () => resume(Effect.succeed(request.result))
+    request.onerror = (ev) => resume(Effect.fail(catchError(ev)))
+  })
+
+/**
+ * Creates a `KeyValueStore` layer that uses the browser's `indexedDB` api.
+ *
+ * Values are stored between sessions.
+ *
+ * @since 4.0.0
+ * @category Layers
+ */
+export const layerIndexedDb = (dbName: string, storeName: string, version: number) =>
+  Layer.effect(
+    KeyValueStore.KeyValueStore,
+    Effect.gen(function*() {
+      const database = yield* IDBDatabaseService
+
+      const read = <A>(
+        method: ReadMethod,
+        fn: (store: IDBObjectStore) => IDBRequest<A>,
+        catchError: (event: Event) => KeyValueStore.KeyValueStoreError
+      ): Effect.Effect<A, KeyValueStore.KeyValueStoreError> =>
+        makeRequest(database, storeName, method, fn, catchError, "readonly").pipe(
+          Effect.andThen(({ transaction, request }) => fromRequest(method, transaction, request, catchError))
+        )
+
+      const write = (
+        method: WriteMethod,
+        fn: (store: IDBObjectStore) => IDBRequest,
+        catchError: (event: Event) => KeyValueStore.KeyValueStoreError
+      ): Effect.Effect<void, KeyValueStore.KeyValueStoreError> =>
+        makeRequest(database, storeName, method, fn, catchError, "readwrite").pipe(Effect.andThen(({ transaction }) =>
+          Effect.callback<void, KeyValueStore.KeyValueStoreError, never>((_resume, signal) => {
+            const resume = attachSignal(method, transaction, _resume, signal)
+
+            transaction.oncomplete = () => resume(Effect.void)
+            transaction.onerror = (ev) => resume(Effect.fail(catchError(ev)))
+          })
+        ))
+
+      return KeyValueStore.makeStringOnly({
+        get: (key: string) =>
+          read(
+            "get",
+            (store) =>
+              store.get(key),
+            (cause) =>
+              new KeyValueStore.KeyValueStoreError({
+                message: `Unable to get item with key ${key}`,
+                method: "get",
+                cause
+              })
+          ).pipe(Effect.map((value) => typeof value === "string" ? value : undefined)),
+
+        set: (key: string, value: string) =>
+          write(
+            "set",
+            (store) => store.put(value, key),
+            (cause) =>
+              new KeyValueStore.KeyValueStoreError({
+                message: `Unable to set item with key ${key}`,
+                method: "set",
+                cause
+              })
+          ),
+
+        remove: (key: string) =>
+          write(
+            "remove",
+            (store) => store.delete(key),
+            (cause) =>
+              new KeyValueStore.KeyValueStoreError({
+                message: `Unable to delete item with key ${key}`,
+                method: "delete",
+                cause
+              })
+          ),
+
+        clear: write(
+          "clear",
+          (store) => store.clear(),
+          (cause) =>
+            new KeyValueStore.KeyValueStoreError({
+              message: `Unable to clear storage`,
+              method: "clear",
+              cause
+            })
+        ),
+
+        size: read(
+          "size",
+          (store) => store.count(),
+          (cause) =>
+            new KeyValueStore.KeyValueStoreError({
+              message: `Unable to get size`,
+              method: "size",
+              cause
+            })
+        )
+      })
+    })
+  ).pipe(Layer.provide(IDBDatabaseService.layer(dbName, storeName, version)))

--- a/packages/platform-browser/test/BrowserKeyValueStore.test.ts
+++ b/packages/platform-browser/test/BrowserKeyValueStore.test.ts
@@ -5,3 +5,15 @@ import { testLayer } from "effect-test/unstable/persistence/KeyValueStore.test"
 describe("KeyValueStore / layerLocalStorage", () => testLayer(BrowserKeyValueStore.layerLocalStorage))
 
 describe("KeyValueStore / layerSessionStorage", () => testLayer(BrowserKeyValueStore.layerSessionStorage))
+
+let id = 0
+const VERSION = 1
+
+describe(
+  "KeyValueStore / layerIndexedDb",
+  () =>
+    testLayer(() => {
+      const name = `test-db-${id++}`
+      return BrowserKeyValueStore.layerIndexedDb(name, `test-store-${name}`, VERSION)
+    })
+)

--- a/packages/platform-browser/vitest.setup.ts
+++ b/packages/platform-browser/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { defineWebWorkers } from "@vitest/web-worker/pure"
+import "fake-indexeddb/auto"
 
 defineWebWorkers({
   clone: "none"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,9 @@ importers:
       effect:
         specifier: workspace:^
         version: link:../effect
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       mock-xmlhttprequest:
         specifier: ^8.4.1
         version: 8.4.1
@@ -3742,6 +3745,10 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
@@ -9718,6 +9725,8 @@ snapshots:
       is-extendable: 0.1.1
 
   extendable-error@0.1.7: {}
+
+  fake-indexeddb@6.2.5: {}
 
   fast-check@3.23.2:
     dependencies:


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Introduced `layerIndexedDb` for persistent storage using IndexedDB.
- Added `fake-indexeddb` as a dependency for testing.
- Updated tests to include scenarios for IndexedDB.
- Minor adjustments in existing test structure for clarity.

Example usage with Effect Atom:

```typescript
import { Schema } from "effect"
import { BrowserKeyValueStore } from "@effect/platform-browser"
import { Atom } from "@effect-atom/atom"

const DB_NAME = "effect-atom"
const STORE_NAME = "kvs"
const VERSION = 1

const runtime = Atom.runtime(BrowerKeyValueStore.layerIndexedDb(DB_NAME, STORE_NAME, VERSION))

// Create an Atom that reads and writes to `IndexedDB`.
//
// It uses `Schema` to define the type of the value stored.
//
//       ┌─── Atom.Writable<boolean, boolean>
//       ▼
const flagAtom = Atom.kvs({
    runtime: runtime,
    key: "flag",
    schema: Schema.Boolean,
    defaultValue: () => false,
})

``` 