### PR TITLE
pass full error to catchReason/catchReasons callbacks across Effect, …

### DIFF
--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -11,8 +11,12 @@ class QuotaExceededError extends Data.TaggedError("QuotaExceededError")<{
   readonly limit: number
 }> {}
 
+class UnknownAiModelError extends Data.TaggedError("UnknownAiModelError")<{
+  readonly model: string
+}> {}
+
 class AiError extends Data.TaggedError("AiError")<{
-  readonly reason: RateLimitError | QuotaExceededError
+  readonly reason: RateLimitError | QuotaExceededError | UnknownAiModelError
 }> {}
 
 class OtherError extends Data.TaggedError("OtherError")<{
@@ -32,7 +36,7 @@ declare const onlyNoSuch: Effect.Effect<number, Cause.NoSuchElementError>
 describe("Types", () => {
   describe("ReasonOf", () => {
     it("extracts reason type", () => {
-      expect<Types.ReasonOf<AiError>>().type.toBe<RateLimitError | QuotaExceededError>()
+      expect<Types.ReasonOf<AiError>>().type.toBe<RateLimitError | QuotaExceededError | UnknownAiModelError>()
     })
 
     it("returns never for errors without reason", () => {
@@ -43,7 +47,7 @@ describe("Types", () => {
   describe("ReasonTags", () => {
     it("extracts reason tags", () => {
       expect<Types.ReasonTags<AiError> & unknown>().type.toBe<
-        "RateLimitError" | "QuotaExceededError"
+        "RateLimitError" | "QuotaExceededError" | "UnknownAiModelError"
       >()
     })
 
@@ -78,7 +82,8 @@ describe("Effect.catchReason", () => {
     pipe(
       aiEffect,
       Effect.catchReason("AiError", "RateLimitError", (_reason, error) => {
-        expect(error).type.toBe<AiError>()
+        expect(error.reason).type.toBeAssignableTo<RateLimitError>()
+        expect(error.reason).type.toBeAssignableFrom<RateLimitError>()
         return Effect.succeed("ok")
       })
     )
@@ -92,7 +97,8 @@ describe("Effect.catchReason", () => {
         "RateLimitError",
         () => Effect.succeed("ok"),
         (_reason, error) => {
-          expect(error).type.toBe<AiError>()
+          expect(error.reason).type.toBeAssignableTo<QuotaExceededError | UnknownAiModelError>()
+          expect(error.reason).type.toBeAssignableFrom<QuotaExceededError | UnknownAiModelError>()
           return Effect.succeed("ok")
         }
       )
@@ -130,11 +136,13 @@ describe("Effect.catchReasons", () => {
       aiEffect,
       Effect.catchReasons("AiError", {
         RateLimitError: (_r, error) => {
-          expect(error).type.toBe<AiError>()
+          expect(error.reason).type.toBeAssignableTo<RateLimitError>()
+          expect(error.reason).type.toBeAssignableFrom<RateLimitError>()
           return Effect.succeed("")
         },
         QuotaExceededError: (_r, error) => {
-          expect(error).type.toBe<AiError>()
+          expect(error.reason).type.toBeAssignableTo<QuotaExceededError>()
+          expect(error.reason).type.toBeAssignableFrom<QuotaExceededError>()
           return Effect.succeed("")
         }
       })
@@ -171,7 +179,7 @@ describe("Effect.catchReasons", () => {
           return Effect.succeed("")
         }
       }, (others) => {
-        expect(others).type.toBe<QuotaExceededError>()
+        expect(others).type.toBe<QuotaExceededError | UnknownAiModelError>()
         return Effect.succeed("")
       })
     )
@@ -184,7 +192,8 @@ describe("Effect.catchReasons", () => {
       Effect.catchReasons("AiError", {
         RateLimitError: () => Effect.succeed("")
       }, (_others, error) => {
-        expect(error).type.toBe<AiError>()
+        expect(error.reason).type.toBeAssignableTo<QuotaExceededError | UnknownAiModelError>()
+        expect(error.reason).type.toBeAssignableFrom<QuotaExceededError | UnknownAiModelError>()
         return Effect.succeed("")
       })
     )
@@ -285,13 +294,13 @@ describe("Effect.tapErrorTag", () => {
 describe("Effect.unwrapReason", () => {
   it("replaces parent error with reasons", () => {
     const result = pipe(aiEffect, Effect.unwrapReason("AiError"))
-    expect(result).type.toBe<Effect.Effect<string, RateLimitError | QuotaExceededError>>()
+    expect(result).type.toBe<Effect.Effect<string, RateLimitError | QuotaExceededError | UnknownAiModelError>>()
   })
 
   it("preserves other errors in union", () => {
     const result = pipe(mixedEffect, Effect.unwrapReason("AiError"))
     expect(result).type.toBe<
-      Effect.Effect<string, RateLimitError | QuotaExceededError | OtherError>
+      Effect.Effect<string, RateLimitError | QuotaExceededError | UnknownAiModelError | OtherError>
     >()
   })
 })

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -4384,12 +4384,12 @@ export const catchReason: {
     reasonTag: RK,
     f: (
       reason: Types.ExtractReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-      error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+      error: Types.NarrowReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
     ) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>,
     orElse?:
       | ((
         reason: Types.ExcludeReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-        error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+        error: Types.OmitReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): <
@@ -4440,12 +4440,12 @@ export const catchReason: {
     reasonTag: RK,
     f: (
       reason: Types.ExtractReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-      error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+      error: Types.NarrowReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
     ) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>,
     orElse?:
       | ((
         reason: Types.ExcludeReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-        error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+        error: Types.OmitReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<
@@ -4487,12 +4487,12 @@ export const catchReason: {
   reasonTag: RK,
   f: (
     reason: Types.ExtractReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-    error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+    error: Types.NarrowReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
   ) => Channel<OutElem1, OutErr1, OutDone1, InElem1, InErr1, InDone1, Env1>,
   orElse?:
     | ((
       reason: Types.ExcludeReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-      error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+      error: Types.OmitReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
     ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
     | undefined
 ): Channel<
@@ -4539,7 +4539,7 @@ export const catchReasons: {
     Cases extends {
       [RK in Types.ReasonTags<Types.ExtractTag<Types.NoInfer<OutErr>, K>>]+?: (
         reason: Types.ExtractReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>,
-        error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+        error: Types.NarrowReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, RK>
       ) => Channel<any, any, any, any, any, any, any>
     },
     OutElem2 = Types.unassigned,
@@ -4555,7 +4555,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: Types.ExcludeReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, Extract<keyof Cases, string>>,
-        error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+        error: Types.OmitReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, Extract<keyof Cases, string>>
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): <OutElem, OutDone, InElem, InErr, InDone, Env>(
@@ -4616,7 +4616,7 @@ export const catchReasons: {
     Cases extends {
       [RK in Types.ReasonTags<Types.ExtractTag<OutErr, K>>]+?: (
         reason: Types.ExtractReason<Types.ExtractTag<OutErr, K>, RK>,
-        error: Types.ExtractTag<OutErr, K>
+        error: Types.NarrowReason<Types.ExtractTag<OutErr, K>, RK>
       ) => Channel<any, any, any, any, any, any, any>
     },
     OutElem2 = Types.unassigned,
@@ -4633,7 +4633,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: Types.ExcludeReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, Extract<keyof Cases, string>>,
-        error: Types.ExtractTag<Types.NoInfer<OutErr>, K>
+        error: Types.OmitReason<Types.ExtractTag<Types.NoInfer<OutErr>, K>, Extract<keyof Cases, string>>
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -116,7 +116,9 @@ import type {
   ExcludeTag,
   ExtractReason,
   ExtractTag,
+  NarrowReason,
   NoInfer,
+  OmitReason,
   ReasonOf,
   ReasonTags,
   Simplify,
@@ -2872,11 +2874,14 @@ export const catchReason: {
   >(
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>, error: ExtractTag<NoInfer<E>, K>) => Effect<A2, E2, R2>,
+    f: (
+      reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
+      error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
+    ) => Effect<A2, E2, R2>,
     orElse?:
       | ((
         reasons: ExcludeReason<ExtractTag<NoInfer<E>, K>, RK>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, RK>
       ) => Effect<A3, E3, R3>)
       | undefined
   ): <A, R>(
@@ -2898,8 +2903,10 @@ export const catchReason: {
     self: Effect<A, E, R>,
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect<A2, E2, R2>,
-    orElse?: ((reasons: ExcludeReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect<A3, E3, R3>) | undefined
+    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: NarrowReason<ExtractTag<E, K>, RK>) => Effect<A2, E2, R2>,
+    orElse?:
+      | ((reasons: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Effect<A3, E3, R3>)
+      | undefined
   ): Effect<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
 } = internal.catchReason
 
@@ -2944,7 +2951,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<NoInfer<E>, K>>]+?: (
         reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
       ) => Effect<any, any, any>
     },
     A2 = unassigned,
@@ -2956,7 +2963,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Effect<A2, E2, R2>)
       | undefined
   ): <A, R>(
@@ -2986,7 +2993,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<E, K>>]+?: (
         reason: ExtractReason<ExtractTag<E, K>, RK>,
-        error: ExtractTag<E, K>
+        error: NarrowReason<ExtractTag<E, K>, RK>
       ) => Effect<any, any, any>
     },
     A2 = unassigned,
@@ -2999,7 +3006,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Effect<A2, E2, R2>)
       | undefined
   ): Effect<

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -48,7 +48,9 @@ import type {
   ExcludeTag,
   ExtractReason,
   ExtractTag,
+  NarrowReason,
   NoInfer,
+  OmitReason,
   ReasonTags,
   Tags,
   unassigned
@@ -5014,9 +5016,15 @@ export const catchReason: {
   >(
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>, error: ExtractTag<NoInfer<E>, K>) => Stream<A2, E2, R2>,
+    f: (
+      reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
+      error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
+    ) => Stream<A2, E2, R2>,
     orElse?:
-      | ((reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, RK>, error: ExtractTag<NoInfer<E>, K>) => Stream<A3, E3, R3>)
+      | ((
+        reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, RK>,
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, RK>
+      ) => Stream<A3, E3, R3>)
       | undefined
   ): <A, R>(
     self: Stream<A, E, R>
@@ -5037,8 +5045,10 @@ export const catchReason: {
     self: Stream<A, E, R>,
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Stream<A2, E2, R2>,
-    orElse?: ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Stream<A3, E3, R3>) | undefined
+    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: NarrowReason<ExtractTag<E, K>, RK>) => Stream<A2, E2, R2>,
+    orElse?:
+      | ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Stream<A3, E3, R3>)
+      | undefined
   ): Stream<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
 } = dual(
   (args) => isStream(args[0]),
@@ -5058,8 +5068,10 @@ export const catchReason: {
     self: Stream<A, E, R>,
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Stream<A2, E2, R2>,
-    orElse?: ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Stream<A3, E3, R3>) | undefined
+    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: NarrowReason<ExtractTag<E, K>, RK>) => Stream<A2, E2, R2>,
+    orElse?:
+      | ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Stream<A3, E3, R3>)
+      | undefined
   ): Stream<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3> =>
     fromChannel(
       Channel.catchReason(
@@ -5120,7 +5132,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<NoInfer<E>, K>>]+?: (
         reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
       ) => Stream<any, any, any>
     },
     A2 = unassigned,
@@ -5132,7 +5144,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Stream<A2, E2, R2>)
       | undefined
   ): <A, R>(self: Stream<A, E, R>) => Stream<
@@ -5160,7 +5172,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<E, K>>]+?: (
         reason: ExtractReason<ExtractTag<E, K>, RK>,
-        error: ExtractTag<E, K>
+        error: NarrowReason<ExtractTag<E, K>, RK>
       ) => Stream<any, any, any>
     },
     A2 = unassigned,
@@ -5173,7 +5185,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Stream<A2, E2, R2>)
       | undefined
   ): Stream<

--- a/packages/effect/src/Types.ts
+++ b/packages/effect/src/Types.ts
@@ -928,6 +928,72 @@ export type ExtractReason<E, K extends string> = E extends { readonly reason: in
   : never
 
 /**
+ * Narrows a specific reason variant by its `_tag` from an error's `reason`
+ * field.
+ *
+ * - Use to narrow down to a single reason variant from a nested error type.
+ * - Returns `never` if `E` has no matching reason variant.
+ *
+ * **Example** (Narrowing a reason variant)
+ *
+ * ```ts
+ * import type { Types } from "effect"
+ *
+ * type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+ * type ApiError = { readonly _tag: "ApiError"; readonly reason: RateLimitError | QuotaError }
+ *
+ * type Result = Types.NarrowReason<ApiError, "RateLimitError">
+ * // ApiError & { readonly reason: { readonly _tag: "RateLimitError"; readonly retryAfter: number } }
+ * ```
+ *
+ * @see {@link ExcludeReason}
+ * @see {@link ReasonOf}
+ * @see {@link ReasonTags}
+ *
+ * @since 4.0.0
+ * @category types
+ */
+export type NarrowReason<E, K extends string> = E extends { readonly reason: infer R }
+  ? R extends { readonly _tag: infer T } ? K extends T ? E & { readonly reason: R } : never
+  : never
+  : never
+
+/**
+ * Narrows an error's `reason` field to exclude a specific reason variant by
+ * its `_tag`.
+ *
+ * - Use to narrow the error to only the remaining reason variants after
+ *   excluding the matched one.
+ * - Returns `never` if `E` has no `reason` field or no remaining variants.
+ *
+ * **Example** (Omitting a reason variant)
+ *
+ * ```ts
+ * import type { Types } from "effect"
+ *
+ * type RateLimitError = { readonly _tag: "RateLimitError"; readonly retryAfter: number }
+ * type QuotaError = { readonly _tag: "QuotaError"; readonly limit: number }
+ * type ApiError = { readonly _tag: "ApiError"; readonly reason: RateLimitError | QuotaError }
+ *
+ * type Result = Types.OmitReason<ApiError, "RateLimitError">
+ * // ApiError & { readonly reason: { readonly _tag: "QuotaError"; readonly limit: number } }
+ * ```
+ *
+ * @see {@link NarrowReason}
+ * @see {@link ExcludeReason}
+ * @see {@link ReasonOf}
+ * @see {@link ReasonTags}
+ *
+ * @since 4.0.0
+ * @category types
+ */
+export type OmitReason<E, K extends string> = E extends { readonly reason: infer R }
+  ? R extends { readonly _tag: infer T } ? K extends T ? never : E & { readonly reason: R }
+  : never
+  : never
+
+/**
  * Excludes a specific reason variant by its `_tag` from an error's `reason`
  * field.
  *

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -50,7 +50,9 @@ import type {
   ExcludeTag,
   ExtractReason,
   ExtractTag,
+  NarrowReason,
   NoInfer,
+  OmitReason,
   ReasonOf,
   ReasonTags,
   Simplify,
@@ -2826,12 +2828,12 @@ export const catchReason: {
     reasonTag: RK,
     f: (
       reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
-      error: ExtractTag<NoInfer<E>, K>
+      error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
     ) => Effect.Effect<A2, E2, R2>,
     orElse?:
       | ((
         reasons: ExcludeReason<ExtractTag<NoInfer<E>, K>, RK>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, RK>
       ) => Effect.Effect<A3, E3, R3>)
       | undefined
   ): <A, R>(
@@ -2857,9 +2859,15 @@ export const catchReason: {
     self: Effect.Effect<A, E, R>,
     errorTag: K,
     reasonTag: RK,
-    f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect.Effect<A2, E2, R2>,
+    f: (
+      reason: ExtractReason<ExtractTag<E, K>, RK>,
+      error: NarrowReason<ExtractTag<E, K>, RK>
+    ) => Effect.Effect<A2, E2, R2>,
     orElse?:
-      | ((reasons: ExcludeReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect.Effect<A3, E3, R3>)
+      | ((
+        reasons: ExcludeReason<ExtractTag<E, K>, RK>,
+        error: OmitReason<ExtractTag<E, K>, RK>
+      ) => Effect.Effect<A3, E3, R3>)
       | undefined
   ): Effect.Effect<
     A | A2 | Exclude<A3, unassigned>,
@@ -2886,7 +2894,10 @@ export const catchReason: {
     reasonTag: RK,
     f: (reason: ExtractReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect.Effect<A2, E2, R2>,
     orElse?:
-      | ((reasons: ExcludeReason<ExtractTag<E, K>, RK>, error: ExtractTag<E, K>) => Effect.Effect<A3, E3, R3>)
+      | ((
+        reasons: ExcludeReason<ExtractTag<E, K>, RK>,
+        error: OmitReason<ExtractTag<E, K>, RK>
+      ) => Effect.Effect<A3, E3, R3>)
       | undefined
   ): Effect.Effect<
     A | A2 | Exclude<A3, unassigned>,
@@ -2912,7 +2923,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<NoInfer<E>, K>>]+?: (
         reason: ExtractReason<ExtractTag<NoInfer<E>, K>, RK>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: NarrowReason<ExtractTag<NoInfer<E>, K>, RK>
       ) => Effect.Effect<any, any, any>
     },
     A2 = unassigned,
@@ -2924,7 +2935,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Effect.Effect<A2, E2, R2>)
       | undefined
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
@@ -2952,7 +2963,7 @@ export const catchReasons: {
     Cases extends {
       [RK in ReasonTags<ExtractTag<E, K>>]+?: (
         reason: ExtractReason<ExtractTag<E, K>, RK>,
-        error: ExtractTag<E, K>
+        error: NarrowReason<ExtractTag<E, K>, RK>
       ) => Effect.Effect<any, any, any>
     },
     A2 = unassigned,
@@ -2965,7 +2976,7 @@ export const catchReasons: {
     orElse?:
       | ((
         reason: ExcludeReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>,
-        error: ExtractTag<NoInfer<E>, K>
+        error: OmitReason<ExtractTag<NoInfer<E>, K>, Extract<keyof Cases, string>>
       ) => Effect.Effect<A2, E2, R2>)
       | undefined
   ): Effect.Effect<


### PR DESCRIPTION
…Channel, and Stream

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Another option would be to instead of passing the plain reason to the handler, change it to pass in the error & {reason: PickedReason }, but I kinda see good use cases for both, wdyt?
