### PR TITLE
Unwrap `_Success` schema to enable field access 

### DIFF
--- a/.changeset/heavy-loops-cut.md
+++ b/.changeset/heavy-loops-cut.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Unwrap `_Success` schema to enable field access.

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -66,7 +66,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
           readonly reactivityKeys?: ReadonlyArray<unknown> | ReadonlyRecord<string, ReadonlyArray<unknown>> | undefined
         }
       >,
-      WithResponse extends true ? [_Success, HttpClientResponse] : _Success,
+      WithResponse extends true ? [_Success["Type"], HttpClientResponse] : _Success["Type"],
       _Error | HttpClientError.HttpClientError | SchemaError
     >
     : never
@@ -123,7 +123,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
     >
   ] ? Atom.Atom<
       AsyncResult.AsyncResult<
-        WithResponse extends true ? [_Success, HttpClientResponse] : _Success,
+        WithResponse extends true ? [_Success["Type"], HttpClientResponse] : _Success["Type"],
         _Error | HttpClientError.HttpClientError | SchemaError
       >
     >


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Unwraps the `_Success` schema returned by several methods in the `AtomHttpApi` module, enabling field access that was previously unavailable, for example, if it was an instance of `Schema.Struct`.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
