### PR TITLE
pre-pull testcontainer images in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,6 +120,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Pre-pull test container images
+        run: |
+          docker pull testcontainers/ryuk:0.14.0 &
+          docker pull ghcr.io/tursodatabase/libsql-server:main &
+          docker pull postgres:alpine &
+          docker pull mysql:lts &
+          docker pull vitess/vttestserver:mysql80 &
+          docker pull redis:alpine &
+          wait
+
       - name: Install dependencies
         if: matrix.runtime == 'Node'
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

- Pre-pull all Docker images used by testcontainers (including the Ryuk reaper sidecar) in parallel before tests run
- Addresses two flaky CI failure modes:
  - **Hook timeout**: the vitest `beforeAll` hook has a 30s timeout that must cover image pull + container start — cold pulls frequently exceed this on loaded runners
  - **Reaper connection failure**: testcontainers starts a Ryuk sidecar container for cleanup, but has a hardcoded 4s TCP connection timeout — if Ryuk's image isn't cached, the pull eats into this window

Images pre-pulled: `testcontainers/ryuk:0.14.0`, `ghcr.io/tursodatabase/libsql-server:main`, `postgres:alpine`, `mysql:lts`, `vitess/vttestserver:mysql80`, `redis:alpine`