### PR TITLE
EFF-601: add separate AiError metadata types

### DIFF
--- a/.changeset/eighty-poets-draw.md
+++ b/.changeset/eighty-poets-draw.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+"@effect/ai-anthropic": patch
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+"@effect/ai-openrouter": patch
+---
+
+Add dedicated AiError metadata interfaces per reason so provider packages can safely augment metadata without conflicting module declarations.

--- a/packages/ai/anthropic/src/AnthropicError.ts
+++ b/packages/ai/anthropic/src/AnthropicError.ts
@@ -61,51 +61,43 @@ export type AnthropicRateLimitMetadata = AnthropicErrorMetadata & {
 }
 
 declare module "effect/unstable/ai/AiError" {
-  export interface RateLimitError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicRateLimitMetadata | null
-    }
+  export interface RateLimitErrorMetadata {
+    readonly anthropic?: AnthropicRateLimitMetadata | null
   }
 
-  export interface QuotaExhaustedError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface QuotaExhaustedErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface AuthenticationError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface AuthenticationErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface ContentPolicyError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface ContentPolicyErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface InvalidRequestError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface InvalidRequestErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface InternalProviderError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface InternalProviderErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface InvalidOutputError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface InvalidOutputErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 
-  export interface UnknownError {
-    readonly metadata: {
-      readonly anthropic?: AnthropicErrorMetadata | null
-    }
+  export interface StructuredOutputErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
+  }
+
+  export interface UnsupportedSchemaErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
+  }
+
+  export interface UnknownErrorMetadata {
+    readonly anthropic?: AnthropicErrorMetadata | null
   }
 }

--- a/packages/ai/openai-compat/src/OpenAiError.ts
+++ b/packages/ai/openai-compat/src/OpenAiError.ts
@@ -52,51 +52,43 @@ export type OpenAiRateLimitMetadata = OpenAiErrorMetadata & {
 }
 
 declare module "effect/unstable/ai/AiError" {
-  export interface RateLimitError {
-    readonly metadata: {
-      readonly openai?: OpenAiRateLimitMetadata | null
-    }
+  export interface RateLimitErrorMetadata {
+    readonly openai?: OpenAiRateLimitMetadata | null
   }
 
-  export interface QuotaExhaustedError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface QuotaExhaustedErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface AuthenticationError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface AuthenticationErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface ContentPolicyError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface ContentPolicyErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InvalidRequestError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InvalidRequestErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InternalProviderError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InternalProviderErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InvalidOutputError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InvalidOutputErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface UnknownError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface StructuredOutputErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
+  }
+
+  export interface UnsupportedSchemaErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
+  }
+
+  export interface UnknownErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 }

--- a/packages/ai/openai/src/OpenAiError.ts
+++ b/packages/ai/openai/src/OpenAiError.ts
@@ -57,51 +57,43 @@ export type OpenAiRateLimitMetadata = OpenAiErrorMetadata & {
 }
 
 declare module "effect/unstable/ai/AiError" {
-  export interface RateLimitError {
-    readonly metadata: {
-      readonly openai?: OpenAiRateLimitMetadata | null
-    }
+  export interface RateLimitErrorMetadata {
+    readonly openai?: OpenAiRateLimitMetadata | null
   }
 
-  export interface QuotaExhaustedError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface QuotaExhaustedErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface AuthenticationError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface AuthenticationErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface ContentPolicyError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface ContentPolicyErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InvalidRequestError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InvalidRequestErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InternalProviderError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InternalProviderErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface InvalidOutputError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface InvalidOutputErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 
-  export interface UnknownError {
-    readonly metadata: {
-      readonly openai?: OpenAiErrorMetadata | null
-    }
+  export interface StructuredOutputErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
+  }
+
+  export interface UnsupportedSchemaErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
+  }
+
+  export interface UnknownErrorMetadata {
+    readonly openai?: OpenAiErrorMetadata | null
   }
 }

--- a/packages/ai/openrouter/src/OpenRouterError.ts
+++ b/packages/ai/openrouter/src/OpenRouterError.ts
@@ -42,51 +42,43 @@ export type OpenRouterRateLimitMetadata = OpenRouterErrorMetadata & {
 }
 
 declare module "effect/unstable/ai/AiError" {
-  export interface RateLimitError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterRateLimitMetadata | null
-    }
+  export interface RateLimitErrorMetadata {
+    readonly openrouter?: OpenRouterRateLimitMetadata | null
   }
 
-  export interface QuotaExhaustedError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface QuotaExhaustedErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface AuthenticationError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface AuthenticationErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface ContentPolicyError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface ContentPolicyErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface InvalidRequestError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface InvalidRequestErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface InternalProviderError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface InternalProviderErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface InvalidOutputError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface InvalidOutputErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 
-  export interface UnknownError {
-    readonly metadata: {
-      readonly openrouter?: OpenRouterErrorMetadata | null
-    }
+  export interface StructuredOutputErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
+  }
+
+  export interface UnsupportedSchemaErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
+  }
+
+  export interface UnknownErrorMetadata {
+    readonly openrouter?: OpenRouterErrorMetadata | null
   }
 }

--- a/packages/effect/dtslint/AiError.tst.ts
+++ b/packages/effect/dtslint/AiError.tst.ts
@@ -1,0 +1,49 @@
+import { AiError } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+declare module "effect/unstable/ai/AiError" {
+  interface RateLimitErrorMetadata {
+    readonly providerA?: {
+      readonly retryId: string
+    } | null
+  }
+
+  interface QuotaExhaustedErrorMetadata {
+    readonly providerA?: {
+      readonly quotaId: string
+    } | null
+  }
+}
+
+declare module "effect/unstable/ai/AiError" {
+  interface RateLimitErrorMetadata {
+    readonly providerB?: {
+      readonly resetAt: string
+    } | null
+  }
+
+  interface QuotaExhaustedErrorMetadata {
+    readonly providerB?: {
+      readonly orgId: string
+    } | null
+  }
+}
+
+describe("AiError metadata augmentation", () => {
+  it("merges metadata for the same reason across providers", () => {
+    const error = new AiError.RateLimitError({})
+
+    expect(error.metadata.providerA?.retryId).type.toBe<string | undefined>()
+    expect(error.metadata.providerB?.resetAt).type.toBe<string | undefined>()
+  })
+
+  it("keeps reason metadata interfaces independent", () => {
+    const error = new AiError.QuotaExhaustedError({})
+
+    expect(error.metadata.providerA?.quotaId).type.toBe<string | undefined>()
+    expect(error.metadata.providerB?.orgId).type.toBe<string | undefined>()
+
+    type ProviderAQuotaMetadata = NonNullable<NonNullable<typeof error.metadata.providerA>>
+    expect<keyof ProviderAQuotaMetadata>().type.toBe<"quotaId">()
+  })
+})

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -89,8 +89,11 @@ import { HttpRequestDetails, HttpResponseDetails } from "./Response.ts"
 
 const ReasonTypeId = "~effect/unstable/ai/AiError/Reason" as const
 
-const constEmptyObjectOption = () => Option.some({})
-const constEmptyObject = () => ({})
+const providerMetadataWithDefaults = <Metadata extends ProviderMetadata>() =>
+  (ProviderMetadata as unknown as typeof ProviderMetadata & Schema.Schema<Metadata>).pipe(
+    Schema.withConstructorDefault(() => Option.some({} as Metadata)),
+    Schema.withDecodingDefault(() => ({} as Metadata))
+  )
 
 const redactHeaders = (headers: Record<string, string>): Record<string, string> => {
   const redacted = redact(headers) as Record<string, string | Redacted.Redacted>
@@ -259,6 +262,86 @@ export const ProviderMetadata: Schema.$Record<
 export type ProviderMetadata = typeof ProviderMetadata.Type
 
 /**
+ * Provider-specific metadata attached to `RateLimitError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface RateLimitErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `QuotaExhaustedError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface QuotaExhaustedErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `AuthenticationError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface AuthenticationErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `ContentPolicyError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface ContentPolicyErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `InvalidRequestError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface InvalidRequestErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `InternalProviderError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface InternalProviderErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `InvalidOutputError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface InvalidOutputErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `StructuredOutputError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface StructuredOutputErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `UnsupportedSchemaError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface UnsupportedSchemaErrorMetadata extends ProviderMetadata {}
+
+/**
+ * Provider-specific metadata attached to `UnknownError`.
+ *
+ * @since 1.0.0
+ * @category provider options
+ */
+export interface UnknownErrorMetadata extends ProviderMetadata {}
+
+/**
  * Token usage information from AI operations.
  *
  * @since 1.0.0
@@ -313,10 +396,7 @@ export class RateLimitError extends Schema.ErrorClass<RateLimitError>(
 )({
   _tag: Schema.tag("RateLimitError"),
   retryAfter: Schema.optional(Schema.Duration),
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<RateLimitErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -364,10 +444,7 @@ export class QuotaExhaustedError extends Schema.ErrorClass<QuotaExhaustedError>(
 )({
   _tag: Schema.tag("QuotaExhaustedError"),
   resetAt: Schema.optional(Schema.DateTimeUtc),
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<QuotaExhaustedErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -417,10 +494,7 @@ export class AuthenticationError extends Schema.ErrorClass<AuthenticationError>(
 )({
   _tag: Schema.tag("AuthenticationError"),
   kind: Schema.Literals(["InvalidKey", "ExpiredKey", "MissingKey", "InsufficientPermissions", "Unknown"]),
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<AuthenticationErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -475,10 +549,7 @@ export class ContentPolicyError extends Schema.ErrorClass<ContentPolicyError>(
 )({
   _tag: Schema.tag("ContentPolicyError"),
   description: Schema.String,
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<ContentPolicyErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -530,10 +601,7 @@ export class InvalidRequestError extends Schema.ErrorClass<InvalidRequestError>(
   parameter: Schema.optional(Schema.String),
   constraint: Schema.optional(Schema.String),
   description: Schema.optional(Schema.String),
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<InvalidRequestErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -585,10 +653,7 @@ export class InternalProviderError extends Schema.ErrorClass<InternalProviderErr
 )({
   _tag: Schema.tag("InternalProviderError"),
   description: Schema.String,
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<InternalProviderErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**
@@ -636,10 +701,7 @@ export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
 )({
   _tag: Schema.tag("InvalidOutputError"),
   description: Schema.String,
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<InvalidOutputErrorMetadata>(),
   usage: Schema.optional(UsageInfo)
 }) {
   /**
@@ -710,10 +772,7 @@ export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputErr
 )({
   _tag: Schema.tag("StructuredOutputError"),
   description: Schema.String,
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<StructuredOutputErrorMetadata>(),
   usage: Schema.optional(UsageInfo)
 }) {
   /**
@@ -785,10 +844,7 @@ export class UnsupportedSchemaError extends Schema.ErrorClass<UnsupportedSchemaE
 )({
   _tag: Schema.tag("UnsupportedSchemaError"),
   description: Schema.String,
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  )
+  metadata: providerMetadataWithDefaults<UnsupportedSchemaErrorMetadata>()
 }) {
   /**
    * @since 1.0.0
@@ -835,10 +891,7 @@ export class UnknownError extends Schema.ErrorClass<UnknownError>(
 )({
   _tag: Schema.tag("UnknownError"),
   description: Schema.optional(Schema.String),
-  metadata: ProviderMetadata.pipe(
-    Schema.withConstructorDefault(constEmptyObjectOption),
-    Schema.withDecodingDefault(constEmptyObject)
-  ),
+  metadata: providerMetadataWithDefaults<UnknownErrorMetadata>(),
   http: Schema.optional(HttpContext)
 }) {
   /**


### PR DESCRIPTION
## Summary
- add per-reason metadata interfaces in `AiError` (`RateLimitErrorMetadata`, `QuotaExhaustedErrorMetadata`, etc.) and wire each reason schema to its dedicated metadata type
- switch provider augmentations (`openai`, `openai-compat`, `anthropic`, `openrouter`) to extend the new metadata interfaces instead of redeclaring reason class fields
- add dtslint coverage proving metadata augmentation merges across multiple providers without collisions and add a changeset for all affected packages

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/AiError.test.ts
- pnpm test-types packages/effect/dtslint/AiError.tst.ts
- pnpm check:tsgo
- pnpm docgen