### PR TITLE
EFF-602 Revert Effect.partition to v3 behavior

### DIFF
--- a/.changeset/itchy-toes-promise.md
+++ b/.changeset/itchy-toes-promise.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Revert `Effect.partition` to Effect v3 behavior by accumulating failures from the effect error channel and never failing.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1,5 +1,5 @@
 /** @effect-diagnostics floatingEffect:skip-file */
-import { type Cause, Data, Effect, type Option, pipe, Result, type Scope, type Types } from "effect"
+import { type Cause, Data, Effect, type Option, pipe, type Scope, type Types } from "effect"
 import { describe, expect, it } from "tstyche"
 
 // Fixtures
@@ -412,7 +412,7 @@ describe("Effect.partition", () => {
   it("data-first", () => {
     const result = Effect.partition(
       [1, 2, 3],
-      (n) => Effect.succeed(n % 2 === 0 ? Result.fail(`${n}`) : Result.succeed(n))
+      (n) => n % 2 === 0 ? Effect.fail(`${n}`) : Effect.succeed(n)
     )
     expect(result).type.toBe<Effect.Effect<[excluded: Array<string>, satisfying: Array<number>], never, never>>()
   })
@@ -420,7 +420,7 @@ describe("Effect.partition", () => {
   it("data-last", () => {
     const result = pipe(
       [1, 2, 3],
-      Effect.partition((n) => Effect.succeed(n % 2 === 0 ? Result.fail(n) : Result.succeed(`${n}`)))
+      Effect.partition((n) => n % 2 === 0 ? Effect.fail(n) : Effect.succeed(`${n}`))
     )
     expect(result).type.toBe<Effect.Effect<[excluded: Array<number>, satisfying: Array<string>], never, never>>()
   })

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -763,7 +763,7 @@ export const all: <
 ) => All.Return<Arg, O> = internal.all
 
 /**
- * Applies an effectful `Filter` to each element and partitions failures and
+ * Applies an effectful function to each element and partitions failures and
  * successes.
  *
  * The returned tuple is `[excluded, satisfying]`, where:
@@ -776,10 +776,10 @@ export const all: <
  *
  * @example
  * ```ts
- * import { Effect, Result } from "effect"
+ * import { Effect } from "effect"
  *
  * const program = Effect.partition([0, 1, 2, 3], (n) =>
- *   Effect.succeed(n % 2 === 0 ? Result.fail(`${n} is even`) : Result.succeed(n))
+ *   n % 2 === 0 ? Effect.fail(`${n} is even`) : Effect.succeed(n)
  * )
  *
  * Effect.runPromise(program).then(console.log)
@@ -790,15 +790,15 @@ export const all: <
  * @category Collecting
  */
 export const partition: {
-  <A, Pass, Fail, E, R>(
-    filter: Filter.FilterEffect<NoInfer<A>, Pass, Fail, E, R, [i: number]>,
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect<B, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
-  ): (elements: Iterable<A>) => Effect<[excluded: Array<Fail>, satisfying: Array<Pass>], E, R>
-  <A, Pass, Fail, E, R>(
+  ): (elements: Iterable<A>) => Effect<[excluded: Array<E>, satisfying: Array<B>], never, R>
+  <A, B, E, R>(
     elements: Iterable<A>,
-    filter: Filter.FilterEffect<NoInfer<A>, Pass, Fail, E, R, [i: number]>,
+    f: (a: A, i: number) => Effect<B, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
-  ): Effect<[excluded: Array<Fail>, satisfying: Array<Pass>], E, R>
+  ): Effect<[excluded: Array<E>, satisfying: Array<B>], never, R>
 } = internal.partition
 
 /**

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4214,24 +4214,24 @@ export const all = <
 
 /** @internal */
 export const partition: {
-  <A, Pass, Fail, E, R>(
-    filter: Filter.FilterEffect<NoInfer<A>, Pass, Fail, E, R, [i: number]>,
+  <A, B, E, R>(
+    f: (a: A, i: number) => Effect.Effect<B, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
-  ): (elements: Iterable<A>) => Effect.Effect<[excluded: Array<Fail>, satisfying: Array<Pass>], E, R>
-  <A, Pass, Fail, E, R>(
+  ): (elements: Iterable<A>) => Effect.Effect<[excluded: Array<E>, satisfying: Array<B>], never, R>
+  <A, B, E, R>(
     elements: Iterable<A>,
-    filter: Filter.FilterEffect<NoInfer<A>, Pass, Fail, E, R, [i: number]>,
+    f: (a: A, i: number) => Effect.Effect<B, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
-  ): Effect.Effect<[excluded: Array<Fail>, satisfying: Array<Pass>], E, R>
+  ): Effect.Effect<[excluded: Array<E>, satisfying: Array<B>], never, R>
 } = dual(
   (args) => isIterable(args[0]) && !isEffect(args[0]),
-  <A, Pass, Fail, E, R>(
+  <A, B, E, R>(
     elements: Iterable<A>,
-    filter: Filter.FilterEffect<A, Pass, Fail, E, R, [i: number]>,
+    f: (a: A, i: number) => Effect.Effect<B, E, R>,
     options?: { readonly concurrency?: Concurrency | undefined }
-  ): Effect.Effect<[excluded: Array<Fail>, satisfying: Array<Pass>], E, R> =>
+  ): Effect.Effect<[excluded: Array<E>, satisfying: Array<B>], never, R> =>
     map(
-      forEach(elements, filter, options),
+      forEach(elements, (a, i) => result(f(a, i)), options),
       (results) => Arr.partition(results, identity)
     )
 )
@@ -4279,7 +4279,7 @@ export const validate: {
     } | undefined
   ): Effect.Effect<Array<B> | void, Arr.NonEmptyArray<E>, R> =>
     flatMap(
-      partition(elements, (a, i) => result(f(a, i)), { concurrency: options?.concurrency }),
+      partition(elements, f, { concurrency: options?.concurrency }),
       ([excluded, satisfying]) => {
         if (Arr.isArrayNonEmpty(excluded)) {
           return fail(excluded)

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -413,7 +413,7 @@ describe("Effect", () => {
     it.effect("collects only successes", () =>
       Effect.gen(function*() {
         const values = [0, 1, 2, 3, 4]
-        const [excluded, satisfying] = yield* Effect.partition(values, (n) => Effect.succeed(Result.succeed(n)))
+        const [excluded, satisfying] = yield* Effect.partition(values, Effect.succeed)
         assert.deepStrictEqual(excluded, [])
         assert.deepStrictEqual(satisfying, values)
       }))
@@ -421,7 +421,7 @@ describe("Effect", () => {
     it.effect("collects only failures", () =>
       Effect.gen(function*() {
         const values = [0, 1, 2, 3, 4]
-        const [excluded, satisfying] = yield* Effect.partition(values, (n) => Effect.succeed(Result.fail(n)))
+        const [excluded, satisfying] = yield* Effect.partition(values, Effect.fail)
         assert.deepStrictEqual(excluded, values)
         assert.deepStrictEqual(satisfying, [])
       }))
@@ -430,7 +430,7 @@ describe("Effect", () => {
       Effect.gen(function*() {
         const values = [0, 1, 2, 3, 4, 5]
         const [excluded, satisfying] = yield* Effect.partition(values, (n) =>
-          Effect.succeed(n % 2 === 0 ? Result.fail(n) : Result.succeed(n)))
+          n % 2 === 0 ? Effect.fail(n) : Effect.succeed(n))
         assert.deepStrictEqual(excluded, [0, 2, 4])
         assert.deepStrictEqual(satisfying, [1, 3, 5])
       }))
@@ -440,7 +440,7 @@ describe("Effect", () => {
         const values = [0, 1, 2, 3, 4, 5]
         const [excluded, satisfying] = yield* Effect.partition(
           values,
-          (n) => Effect.succeed(n % 2 === 0 ? Result.fail(n) : Result.succeed(n)),
+          (n) => n % 2 === 0 ? Effect.fail(n) : Effect.succeed(n),
           { concurrency: "unbounded" }
         )
         assert.deepStrictEqual(excluded, [0, 2, 4])


### PR DESCRIPTION
## Summary
- restore `Effect.partition` to v3 semantics by collecting failures from the effect error channel and returning `Effect<[excluded, satisfying], never, R>`
- update `internal.partition` and `validate` to use `Effect.result` wrapping internally so partition itself never fails
- update runtime and type-level partition tests, and add a patch changeset for `effect`

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/dtslint/Effect.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`