### PR TITLE
EFF-604 Add Effect.findFirst and Effect.findFirstFilter

### DIFF
--- a/.changeset/three-ravens-jam.md
+++ b/.changeset/three-ravens-jam.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Effect.findFirst` and `Effect.findFirstFilter` for short-circuiting effectful searches over iterables.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1,5 +1,5 @@
 /** @effect-diagnostics floatingEffect:skip-file */
-import { type Cause, Data, Effect, type Option, pipe, type Scope, type Types } from "effect"
+import { type Cause, Data, Effect, type Option, pipe, Result, type Scope, type Types } from "effect"
 import { describe, expect, it } from "tstyche"
 
 // Fixtures
@@ -423,5 +423,41 @@ describe("Effect.partition", () => {
       Effect.partition((n) => n % 2 === 0 ? Effect.fail(n) : Effect.succeed(`${n}`))
     )
     expect(result).type.toBe<Effect.Effect<[excluded: Array<number>, satisfying: Array<string>], never, never>>()
+  })
+})
+
+describe("Effect.findFirst", () => {
+  it("data-first", () => {
+    const result = Effect.findFirst(
+      [1, 2, 3],
+      (n) => Effect.succeed(n > 1)
+    )
+    expect(result).type.toBe<Effect.Effect<Option.Option<number>, never, never>>()
+  })
+
+  it("data-last", () => {
+    const result = pipe(
+      [1, 2, 3],
+      Effect.findFirst((n) => Effect.succeed(n > 1))
+    )
+    expect(result).type.toBe<Effect.Effect<Option.Option<number>, never, never>>()
+  })
+})
+
+describe("Effect.findFirstFilter", () => {
+  it("data-first", () => {
+    const result = Effect.findFirstFilter(
+      [1, 2, 3],
+      (n, i) => Effect.succeed(i > 0 ? Result.succeed(`${n}`) : Result.failVoid)
+    )
+    expect(result).type.toBe<Effect.Effect<Option.Option<string>, never, never>>()
+  })
+
+  it("data-last", () => {
+    const result = pipe(
+      [1, 2, 3],
+      Effect.findFirstFilter((n, i) => Effect.succeed(i > 0 ? Result.succeed(n.toString()) : Result.failVoid))
+    )
+    expect(result).type.toBe<Effect.Effect<Option.Option<string>, never, never>>()
   })
 })

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -870,6 +870,54 @@ export const validate: {
 } = internal.validate
 
 /**
+ * Returns the first element that satisfies an effectful predicate.
+ *
+ * The predicate receives the element and its index. Evaluation short-circuits
+ * as soon as an element matches.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ *
+ * const program = Effect.findFirst([1, 2, 3, 4], (n) => Effect.succeed(n > 2))
+ *
+ * Effect.runPromise(program).then(console.log)
+ * // { _id: 'Option', _tag: 'Some', value: 3 }
+ * ```
+ *
+ * @since 2.0.0
+ * @category Collecting
+ */
+export const findFirst: {
+  <A, E, R>(
+    predicate: (a: NoInfer<A>, i: number) => Effect<boolean, E, R>
+  ): (elements: Iterable<A>) => Effect<Option<A>, E, R>
+  <A, E, R>(
+    elements: Iterable<A>,
+    predicate: (a: NoInfer<A>, i: number) => Effect<boolean, E, R>
+  ): Effect<Option<A>, E, R>
+} = internal.findFirst
+
+/**
+ * Returns the first value that passes an effectful `FilterEffect`.
+ *
+ * The filter receives the element and index. Evaluation short-circuits on the
+ * first `Result.succeed` and returns the transformed value in `Option.some`.
+ *
+ * @since 4.0.0
+ * @category Collecting
+ */
+export const findFirstFilter: {
+  <A, B, X, E, R>(
+    filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R, [i: number]>
+  ): (elements: Iterable<A>) => Effect<Option<B>, E, R>
+  <A, B, X, E, R>(
+    elements: Iterable<A>,
+    filter: Filter.FilterEffect<NoInfer<A>, B, X, E, R, [i: number]>
+  ): Effect<Option<B>, E, R>
+} = internal.findFirstFilter
+
+/**
  * Executes an effectful operation for each element in an `Iterable`.
  *
  * **Details**


### PR DESCRIPTION
## Summary
- add `Effect.findFirst` with v3-compatible, sequential short-circuiting semantics for effectful predicates
- add `Effect.findFirstFilter` for short-circuiting effectful `FilterEffect` searches that return transformed values
- add runtime and type-level coverage in `packages/effect/test/Effect.test.ts` and `packages/effect/dtslint/Effect.tst.ts`, plus a patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/dtslint/Effect.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`