### PR TITLE
EFF-607 Fix Workflow.executionId after Schema.make removal

### DIFF
--- a/.changeset/olive-poems-visit.md
+++ b/.changeset/olive-poems-visit.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Workflow.executionId` to use schema `makeUnsafe` instead of the removed `.make` API.

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -374,7 +374,11 @@ export const make = <
           return yield* engine.register(self, execute)
         })
       ),
-    executionId: (payload) => makeExecutionId(self.payloadSchema.make(payload)),
+    executionId: (payload) =>
+      Effect.flatMap(
+        Effect.sync(() => self.payloadSchema.makeUnsafe(payload)),
+        makeExecutionId
+      ),
     withCompensation
   }
 

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -26,4 +26,16 @@ describe("WorkflowEngine", () => {
         Layer.provideMerge(WorkflowEngine.layerMemory)
       ))
     ))
+
+  it.effect("executionId matches execute id", () =>
+    Effect.gen(function*() {
+      const executionId = yield* IncrementWorkflow.executionId({ value: 1 })
+      const discardedExecutionId = yield* IncrementWorkflow.execute({ value: 1 }, { discard: true })
+
+      assert.strictEqual(discardedExecutionId, executionId)
+    }).pipe(
+      Effect.provide(IncrementWorkflowLayer.pipe(
+        Layer.provideMerge(WorkflowEngine.layerMemory)
+      ))
+    ))
 })


### PR DESCRIPTION
## Summary
- replace `Workflow.executionId` payload normalization to use `payloadSchema.makeUnsafe` through `Effect.sync`, fixing runtime `self.payloadSchema.make is not a function`
- add a regression test that checks `executionId` matches the `executionId` returned by `execute(..., { discard: true })`
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
- pnpm check:tsgo
- pnpm docgen