### PR TITLE
EFF-608: support vitest v3 and v4 peer dependency

### DIFF
--- a/.changeset/cyan-radios-switch.md
+++ b/.changeset/cyan-radios-switch.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Broaden the `vitest` peer dependency range to support both v3 and v4.

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "effect": "workspace:^",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.0",


### PR DESCRIPTION
## Summary
- broadened `@effect/vitest` peer dependency range from `^3.0.0` to `^3.0.0 || ^4.0.0`
- added a changeset for `@effect/vitest` patch release

## Validation
- pnpm lint-fix
- pnpm test packages/vitest/test/index.test.ts
- pnpm check:tsgo
- pnpm docgen