### PR TITLE
fix: RateLimiter.layerStoreMemory shares state across layer provisions

### DIFF
--- a/.changeset/fix-ratelimiter-shared-memory-store.md
+++ b/.changeset/fix-ratelimiter-shared-memory-store.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix RateLimiter.layerStoreMemory creating independent state per layer build


### PR DESCRIPTION
## Summary

- Hoist `fixedCounters` and `tokenBuckets` Maps to module scope so `layerStoreMemory` shares rate limiter state across separate `Effect.provide` calls
- Add regression tests for both fixed-window and token-bucket state sharing
- Use unique keys per existing test to prevent cross-test state pollution


**Similar issues may still occur in:** 
`packages/effect/src/unstable/persistence/KeyValueStore.ts`
`packages/effect/src/unstable/persistence/PersistedQueue.ts`
`packages/effect/src/unstable/persistence/Persistence.ts`

Closes #1562