### PR TITLE
fix(duration): accept `Duration.Input` in unit converstion getters

### DIFF
--- a/.changeset/fresh-pianos-hear.md
+++ b/.changeset/fresh-pianos-hear.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Duration.toSeconds`, `Duration.toMinutes`, `Duration.toHours`, `Duration.toDays`, and `Duration.toWeeks` to accept `Duration.Input`, aligning them with `Duration.toMillis`.

--- a/packages/effect/dtslint/Duration.tst.ts
+++ b/packages/effect/dtslint/Duration.tst.ts
@@ -1,0 +1,14 @@
+import { hole } from "effect"
+import * as Duration from "effect/Duration"
+import { describe, expect, it } from "tstyche"
+
+describe("Duration", () => {
+  it("unit getters accept Input", () => {
+    const input = hole<Duration.Input>()
+    expect(Duration.toSeconds(input)).type.toBe<number>()
+    expect(Duration.toMinutes(input)).type.toBe<number>()
+    expect(Duration.toHours(input)).type.toBe<number>()
+    expect(Duration.toDays(input)).type.toBe<number>()
+    expect(Duration.toWeeks(input)).type.toBe<number>()
+  })
+})

--- a/packages/effect/src/Duration.ts
+++ b/packages/effect/src/Duration.ts
@@ -633,8 +633,8 @@ export const toMillis = (self: Input): number =>
  * @since 2.0.0
  * @category getters
  */
-export const toSeconds = (self: Duration): number =>
-  match(self, {
+export const toSeconds = (self: Input): number =>
+  match(fromInputUnsafe(self), {
     onMillis: (millis) => millis / 1_000,
     onNanos: (nanos) => Number(nanos) / 1_000_000_000,
     onInfinity: () => Infinity,
@@ -655,8 +655,8 @@ export const toSeconds = (self: Duration): number =>
  * @since 3.8.0
  * @category getters
  */
-export const toMinutes = (self: Duration): number =>
-  match(self, {
+export const toMinutes = (self: Input): number =>
+  match(fromInputUnsafe(self), {
     onMillis: (millis) => millis / 60_000,
     onNanos: (nanos) => Number(nanos) / 60_000_000_000,
     onInfinity: () => Infinity,
@@ -677,8 +677,8 @@ export const toMinutes = (self: Duration): number =>
  * @since 3.8.0
  * @category getters
  */
-export const toHours = (self: Duration): number =>
-  match(self, {
+export const toHours = (self: Input): number =>
+  match(fromInputUnsafe(self), {
     onMillis: (millis) => millis / 3_600_000,
     onNanos: (nanos) => Number(nanos) / 3_600_000_000_000,
     onInfinity: () => Infinity,
@@ -699,8 +699,8 @@ export const toHours = (self: Duration): number =>
  * @since 3.8.0
  * @category getters
  */
-export const toDays = (self: Duration): number =>
-  match(self, {
+export const toDays = (self: Input): number =>
+  match(fromInputUnsafe(self), {
     onMillis: (millis) => millis / 86_400_000,
     onNanos: (nanos) => Number(nanos) / 86_400_000_000_000,
     onInfinity: () => Infinity,
@@ -721,8 +721,8 @@ export const toDays = (self: Duration): number =>
  * @since 3.8.0
  * @category getters
  */
-export const toWeeks = (self: Duration): number =>
-  match(self, {
+export const toWeeks = (self: Input): number =>
+  match(fromInputUnsafe(self), {
     onMillis: (millis) => millis / 604_800_000,
     onNanos: (nanos) => Number(nanos) / 604_800_000_000_000,
     onInfinity: () => Infinity,

--- a/packages/effect/test/Duration.test.ts
+++ b/packages/effect/test/Duration.test.ts
@@ -433,6 +433,16 @@ describe("Duration", () => {
     strictEqual(Duration.infinity.pipe(Duration.toSeconds), Infinity)
   })
 
+  it("to unit getters from Input", () => {
+    const minute: Duration.Input = "1 minute"
+    const day: Duration.Input = "1 day"
+    strictEqual(Duration.toSeconds(minute), 60)
+    strictEqual(Duration.toMinutes(minute), 1)
+    strictEqual(Duration.toHours(day), 24)
+    strictEqual(Duration.toDays(day), 1)
+    strictEqual(Duration.toWeeks("14 days"), 2)
+  })
+
   it("toNanos", () => {
     deepStrictEqual(Duration.nanos(1n).pipe(Duration.toNanos), 1n)
     assertUndefined(Duration.infinity.pipe(Duration.toNanos))


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Fix a typing inconsistency in `Duration` unit conversion getters: `toSeconds`, `toMinutes`, `toHours`, `toDays`, and `toWeeks` now accept `Duration.Input` (same as `toMillis`).
- Normalize those inputs via `fromInputUnsafe` before conversion, so string inputs like `"1 minute"` work consistently across all unit getters.
- Add regression coverage:
  - runtime test for `Duration.Input` string values in `packages/effect/test/Duration.test.ts`
  - type-level test in `packages/effect/dtslint/Duration.tst.ts`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

discord report ref: https://discord.com/channels/795981131316985866/1473717956092629185/1477657124891922444
