### PR TITLE
docs(schema): align *Exit API docs with actual exports

### DIFF
--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -6579,16 +6579,16 @@ const schema = Schema.toType(Schema.String)
 
 - `decodeUnknown` -> `decodeUnknownEffect`
 - `decode` -> `decodeEffect`
-- `decodeUnknownEither` -> `decodeUnknownResult`
-- `decodeEither` -> `decodeResult`
+- `decodeUnknownEither` -> `decodeUnknownExit`
+- `decodeEither` -> `decodeExit`
 - `encodeUnknown` -> `encodeUnknownEffect`
 - `encode` -> `encodeEffect`
-- `encodeUnknownEither` -> `encodeUnknownResult`
-- `encodeEither` -> `encodeResult`
+- `encodeUnknownEither` -> `encodeUnknownExit`
+- `encodeEither` -> `encodeExit`
 
 Reasons:
 
-- `Either` is now `Result`
+- `Either` is now `Result` (the `*Either` decode/encode APIs are renamed to `*Exit` because they return `Exit` with full `Cause` errors, not `Result`)
 - `decode` is now an API that defines a transformation between schemas.
 
 ## Decoding / Encoding API Removal


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The migration guide incorrectly listed decode/encode API renames as `*Either` → `*Result`, but the actual implementation uses `*Exit`:
| Incorrect (docs) | Correct (implementation) |
|-----------------|------------------------|
| decodeUnknownEither → decodeUnknownResult | decodeUnknownEither → decodeUnknownExit |
| decodeEither → decodeResult | decodeEither → decodeExit |
| encodeUnknownEither → encodeUnknownResult | encodeUnknownEither → encodeUnknownExit |
| encodeEither → encodeResult | encodeEither → encodeExit |
