### PR TITLE
feat(schema): add Schema.opaqueBrand for fully opaque primitive types

### DIFF
--- a/.changeset/tame-wombats-juggle.md
+++ b/.changeset/tame-wombats-juggle.md
@@ -2,4 +2,4 @@
 "effect": minor
 ---
 
-Add `Schema.opaqueBrand` for fully opaque primitive types. It keeps `Schema.brand` runtime behavior while returning an opaque `Brand.Brand<B>` type instead of exposing the primitive base type.
+Add `Schema.newtype` for fully opaque types with `NewtypeBrand<K, From>` carrier. Unlike `Schema.brand`, which exposes the underlying type, `newtype` produces a fully opaque type while carrying the original type as a phantom for recovery via `NewtypeFrom<T>`. Uses a separate `newtypes` annotation independent of `brands`.

--- a/packages/effect/dtslint/schema/Schema.tst.ts
+++ b/packages/effect/dtslint/schema/Schema.tst.ts
@@ -124,11 +124,13 @@ describe("Schema", () => {
       expect(Schema.revealCodec(schema)).type.toBe<Schema.Codec<string & Brand.Brand<"a">, string, never, never>>()
     })
 
-    it("opaqueBrand", () => {
-      const schema = Schema.String.pipe(Schema.opaqueBrand("a"))
-      expect(schema.makeUnsafe).type.toBe<MakeUnsafe<string, Brand.Brand<"a">>>()
-      expect(schema).type.toBe<Schema.opaqueBrand<Schema.String, "a">>()
-      expect(Schema.revealCodec(schema)).type.toBe<Schema.Codec<Brand.Brand<"a">, string, never, never>>()
+    it("newtype", () => {
+      const schema = Schema.String.pipe(Schema.newtype("a"))
+      expect(schema.makeUnsafe).type.toBe<MakeUnsafe<string, Schema.NewtypeBrand<"a", string>>>()
+      expect(schema).type.toBe<Schema.newtype<Schema.String, "a">>()
+      expect(Schema.revealCodec(schema)).type.toBe<
+        Schema.Codec<Schema.NewtypeBrand<"a", string>, string, never, never>
+      >()
     })
 
     it("refine", () => {
@@ -1346,28 +1348,28 @@ describe("Schema", () => {
     })
   })
 
-  describe("opaqueBrand", () => {
-    it("brand", () => {
-      const schema = Schema.Number.pipe(Schema.opaqueBrand("MyBrand"))
+  describe("newtype", () => {
+    it("basic", () => {
+      const schema = Schema.Number.pipe(Schema.newtype("MyBrand"))
       expect(Schema.revealCodec(schema)).type.toBe<
-        Schema.Codec<Brand.Brand<"MyBrand">, number, never, never>
+        Schema.Codec<Schema.NewtypeBrand<"MyBrand", number>, number, never, never>
       >()
-      expect(schema).type.toBe<Schema.opaqueBrand<Schema.Number, "MyBrand">>()
-      expect(schema.annotate({})).type.toBe<Schema.opaqueBrand<Schema.Number, "MyBrand">>()
+      expect(schema).type.toBe<Schema.newtype<Schema.Number, "MyBrand">>()
+      expect(schema.annotate({})).type.toBe<Schema.newtype<Schema.Number, "MyBrand">>()
     })
 
-    it("rebrands existing brands", () => {
-      const schema = Schema.Number.pipe(Schema.brand("MyBrand"), Schema.opaqueBrand("MyBrand2"))
+    it("over existing brand", () => {
+      const schema = Schema.Number.pipe(Schema.brand("MyBrand"), Schema.newtype("MyBrand2"))
       expect(Schema.revealCodec(schema)).type.toBe<
-        Schema.Codec<Brand.Brand<"MyBrand2">, number, never, never>
+        Schema.Codec<Schema.NewtypeBrand<"MyBrand2", number & Brand.Brand<"MyBrand">>, number, never, never>
       >()
       expect(schema).type.toBe<
-        Schema.opaqueBrand<Schema.brand<Schema.Number, "MyBrand">, "MyBrand2">
+        Schema.newtype<Schema.brand<Schema.Number, "MyBrand">, "MyBrand2">
       >()
     })
 
     it("is not assignable to stringly APIs", () => {
-      const WorkspaceIdSchema = Schema.String.pipe(Schema.opaqueBrand("WorkspaceId"))
+      const WorkspaceIdSchema = Schema.String.pipe(Schema.newtype("WorkspaceId"))
       type WorkspaceId = typeof WorkspaceIdSchema.Type
 
       const takesWorkspaceId = (workspaceId: WorkspaceId) => workspaceId
@@ -1376,6 +1378,12 @@ describe("Schema", () => {
       expect(takesWorkspaceId).type.toBeCallableWith(WorkspaceIdSchema.makeUnsafe("workspace_1"))
       expect(takesWorkspaceId).type.not.toBeCallableWith("directory_1")
       expect(takesDirectoryId).type.not.toBeCallableWith(WorkspaceIdSchema.makeUnsafe("workspace_1"))
+    })
+
+    it("NewtypeFrom extracts the original type", () => {
+      const schema = Schema.String.pipe(Schema.newtype("UserId"))
+      type UserId = typeof schema.Type
+      expect<Schema.NewtypeFrom<UserId>>().type.toBe<string>()
     })
   })
 

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2687,18 +2687,46 @@ export function brand<B extends string>(identifier: B) {
 /**
  * @since 4.0.0
  */
-export interface opaqueBrand<S extends Top, B extends string> extends
+export const NewtypeTypeId = "effect/Schema/Newtype" as const
+
+/**
+ * @since 4.0.0
+ */
+export type NewtypeTypeId = typeof NewtypeTypeId
+
+/**
+ * A phantom type that carries both the newtype key `K` and the original type `From`.
+ * Unlike `Brand.Brand<B>`, which only carries the brand key, `NewtypeBrand` lets
+ * tooling recover the original type via `NewtypeFrom<T>`.
+ *
+ * @since 4.0.0
+ */
+export interface NewtypeBrand<in out Key extends string, out From> {
+  readonly [NewtypeTypeId]: { readonly key: Key; readonly from: From }
+}
+
+/**
+ * Extracts the original type from a `NewtypeBrand`.
+ *
+ * @since 4.0.0
+ */
+export type NewtypeFrom<N> = N extends NewtypeBrand<any, infer A> ? A : never
+
+/**
+ * @since 4.0.0
+ */
+export interface newtype<S extends Top, B extends string> extends
   Bottom<
-    Brand.Brand<B>,
+    NewtypeBrand<B, S["Type"]>,
     S["Encoded"],
     S["DecodingServices"],
     S["EncodingServices"],
     S["ast"],
-    opaqueBrand<S, B>,
+    newtype<S, B>,
     S["~type.make.in"],
-    Brand.Brand<B>,
+    NewtypeBrand<B, S["Type"]>,
     S["~type.parameters"],
-    Brand.Brand<B>,
+    NewtypeBrand<B, S["Type"]>,
     S["~type.mutability"],
     S["~type.optionality"],
     S["~type.constructor.default"],
@@ -2712,14 +2740,14 @@ export interface opaqueBrand<S extends Top, B extends string> extends
 }
 
 /**
- * Adds an opaque brand to a schema.
+ * Adds a newtype wrapper to a schema, producing a fully opaque type.
  *
  * @category Branding
  * @since 4.0.0
  */
-export function opaqueBrand<B extends string>(identifier: B) {
-  return <S extends Top>(schema: S): opaqueBrand<S["~rebuild.out"], B> =>
-    make(AST.brand(schema.ast, identifier), { schema, identifier })
+export function newtype<B extends string>(identifier: B) {
+  return <S extends Top>(schema: S): newtype<S["~rebuild.out"], B> =>
+    make(AST.newtype(schema.ast, identifier), { schema, identifier })
 }
 
 /**
@@ -9302,6 +9330,10 @@ export declare namespace Annotations {
      * Accumulated brands when multiple brands are added with `Schema.brand`.
      */
     readonly brands?: ReadonlyArray<string> | undefined
+    /**
+     * Accumulated newtypes when multiple newtypes are added with `Schema.newtype`.
+     */
+    readonly newtypes?: ReadonlyArray<string> | undefined
     readonly toArbitrary?:
       | ToArbitrary.Declaration<T, TypeParameters>
       | undefined

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2725,6 +2725,13 @@ export function brand(ast: AST, brand: string): AST {
   return annotate(ast, { brands })
 }
 
+/** @internal */
+export function newtype(ast: AST, identifier: string): AST {
+  const existing = InternalAnnotations.resolveNewtypes(ast)
+  const newtypes = existing ? [...existing, identifier] : [identifier]
+  return annotate(ast, { newtypes })
+}
+
 /**
  * Maps over the array but will return the original array if no changes occur.
  * @internal

--- a/packages/effect/src/SchemaRepresentation.ts
+++ b/packages/effect/src/SchemaRepresentation.ts
@@ -88,7 +88,7 @@
  */
 import * as Arr from "./Array.ts"
 import { format, formatPropertyKey } from "./Formatter.ts"
-import { collectBrands } from "./internal/schema/annotations.ts"
+import { collectBrands, collectNewtypes } from "./internal/schema/annotations.ts"
 import * as InternalRepresentation from "./internal/schema/representation.ts"
 import { unescapeToken } from "./JsonPointer.ts"
 import type * as JsonSchema from "./JsonSchema.ts"
@@ -2387,8 +2387,9 @@ export function toCodeDocument(multiDocument: MultiDocument, options?: {
     switch (s._tag) {
       default:
         return makeCode(
-          g.runtime + toRuntimeAnnotate(s.annotations) + toRuntimeBrand(s.annotations),
-          g.Type + toTypeBrand(s.annotations)
+          g.runtime + toRuntimeAnnotate(s.annotations) + toRuntimeBrand(s.annotations) +
+            toRuntimeNewtype(s.annotations),
+          g.Type + toTypeBrand(s.annotations) + toTypeNewtype(s.annotations)
         )
       case "Reference":
         return g
@@ -2400,8 +2401,9 @@ export function toCodeDocument(multiDocument: MultiDocument, options?: {
       case "Objects":
       case "Suspend":
         return makeCode(
-          g.runtime + toRuntimeAnnotate(s.annotations) + toRuntimeBrand(s.annotations) + toRuntimeChecks(s.checks),
-          g.Type + toTypeBrand(s.annotations) + toTypeChecks(s.checks)
+          g.runtime + toRuntimeAnnotate(s.annotations) + toRuntimeBrand(s.annotations) +
+            toRuntimeNewtype(s.annotations) + toRuntimeChecks(s.checks),
+          g.Type + toTypeBrand(s.annotations) + toTypeNewtype(s.annotations) + toTypeChecks(s.checks)
         )
     }
   }
@@ -2611,6 +2613,13 @@ export function toCodeDocument(multiDocument: MultiDocument, options?: {
     return brands.map((b) => ` & Brand.Brand<${format(b)}>`).join("")
   }
 
+  function toTypeNewtype(annotations: Schema.Annotations.Annotations | undefined): string {
+    const newtypes = collectNewtypes(annotations)
+    if (newtypes.length === 0) return ""
+    addImport(`import type * as Schema from "effect/Schema"`)
+    return newtypes.map((n) => ` & Schema.NewtypeBrand<${format(n)}, unknown>`).join("")
+  }
+
   function toTypeChecks(checks: ReadonlyArray<Check<Meta>>): string {
     return checks.map((c) => toTypeCheck(c)).join("")
   }
@@ -2618,7 +2627,7 @@ export function toCodeDocument(multiDocument: MultiDocument, options?: {
   function toTypeCheck(check: Check<Meta>): string {
     switch (check._tag) {
       case "Filter":
-        return toTypeBrand(check.annotations)
+        return toTypeBrand(check.annotations) + toTypeNewtype(check.annotations)
       case "FilterGroup": {
         return toTypeChecks(check.checks)
       }
@@ -2626,7 +2635,9 @@ export function toCodeDocument(multiDocument: MultiDocument, options?: {
   }
 
   function toRuntimeChecks(checks: ReadonlyArray<Check<Meta>>): string {
-    return checks.map((c) => `.check(${toRuntimeCheck(c)})` + toRuntimeBrand(c.annotations)).join("")
+    return checks.map((c) =>
+      `.check(${toRuntimeCheck(c)})` + toRuntimeBrand(c.annotations) + toRuntimeNewtype(c.annotations)
+    ).join("")
   }
 
   function toRuntimeCheck(check: Check<Meta>): string {
@@ -2819,7 +2830,8 @@ const toCodeAnnotationsBlacklist: Set<string> = new Set([
   ...toJsonAnnotationsBlacklist,
   "typeConstructor",
   "generation",
-  "brands"
+  "brands",
+  "newtypes"
 ])
 
 function toRuntimeAnnotations(annotations: Schema.Annotations.Annotations | undefined): string {
@@ -2836,6 +2848,11 @@ function toRuntimeAnnotations(annotations: Schema.Annotations.Annotations | unde
 function toRuntimeBrand(annotations: Schema.Annotations.Annotations | undefined): string {
   const brands = collectBrands(annotations)
   return brands.length > 0 ? `.pipe(${brands.map((b) => `Schema.brand(${format(b)})`).join(", ")})` : ""
+}
+
+function toRuntimeNewtype(annotations: Schema.Annotations.Annotations | undefined): string {
+  const newtypes = collectNewtypes(annotations)
+  return newtypes.length > 0 ? `.pipe(${newtypes.map((n) => `Schema.newtype(${format(n)})`).join(", ")})` : ""
 }
 
 function toRuntimeAnnotate(annotations: Schema.Annotations.Annotations | undefined): string {

--- a/packages/effect/src/internal/schema/annotations.ts
+++ b/packages/effect/src/internal/schema/annotations.ts
@@ -25,6 +25,9 @@ export const resolveDescription = resolveAt<string>("description")
 export const resolveBrands = resolveAt<ReadonlyArray<string>>("brands")
 
 /** @internal */
+export const resolveNewtypes = resolveAt<ReadonlyArray<string>>("newtypes")
+
+/** @internal */
 export const getExpected = memoize((ast: AST.AST): string => {
   const identifier = resolveIdentifier(ast)
   if (typeof identifier === "string") return identifier
@@ -34,4 +37,9 @@ export const getExpected = memoize((ast: AST.AST): string => {
 /** @internal */
 export function collectBrands(annotations: Schema.Annotations.Annotations | undefined): ReadonlyArray<string> {
   return annotations !== undefined && Array.isArray(annotations.brands) ? annotations.brands : []
+}
+
+/** @internal */
+export function collectNewtypes(annotations: Schema.Annotations.Annotations | undefined): ReadonlyArray<string> {
+  return annotations !== undefined && Array.isArray(annotations.newtypes) ? annotations.newtypes : []
 }

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -7540,9 +7540,9 @@ describe("Check", () => {
       deepStrictEqual(schema.ast.annotations?.brands, ["Positive", "Int"])
     })
 
-    it("opaque brand", async () => {
-      const schema = Schema.String.pipe(Schema.opaqueBrand("Positive"))
-      deepStrictEqual(schema.ast.annotations?.brands, ["Positive"])
+    it("newtype", async () => {
+      const schema = Schema.String.pipe(Schema.newtype("Positive"))
+      deepStrictEqual(schema.ast.annotations?.newtypes, ["Positive"])
     })
 
     it("override the default identifier", async () => {


### PR DESCRIPTION
NOTICE: this PR description was written by robots under the supervision of Kit Langton

## Type
- [x] Feature

## Description
This PR adds `Schema.opaqueBrand` for fully opaque primitive types.

- Runtime behavior matches `Schema.brand` (same validation / AST branding).
- Type output is opaque: `Brand.Brand<B>` instead of `T & Brand.Brand<B>`.
- Type-level behavior is rebranding: previous brand composition is replaced by the new opaque brand.

## Why
In incremental migrations, we want strict boundaries between new typed IDs and old stringly APIs.

Example: `WorkspaceId` should not be passable to legacy functions like `directoryId: string`.
`Schema.opaqueBrand` enforces that boundary.

## Example
```ts
type WorkspaceIdTransparent = string & Brand.Brand<"WorkspaceId">
type WorkspaceIdOpaque = Brand.Brand<"WorkspaceId">

declare const legacyDirectoryApi: (directoryId: string) => void
declare const workspaceIdOpaque: WorkspaceIdOpaque

legacyDirectoryApi(workspaceIdOpaque) // type error
```

## Tests
- Added runtime coverage for `Schema.opaqueBrand` branding metadata.
- Added dtslint coverage for opaque output type, rebranding behavior, and non-assignability to stringly APIs.