### PR TITLE
EFF-610 Expose chunkSize option in Stream.fromIterable

### DIFF
--- a/.changeset/neat-snails-wash.md
+++ b/.changeset/neat-snails-wash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Expose a `chunkSize` option on `Stream.fromIterable` to control emitted chunk boundaries when constructing streams from iterables.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -963,6 +963,10 @@ export const fromIteratorSucceed = <A>(iterator: IterableIterator<A>, maxChunkSi
 /**
  * Creates a new `Stream` from an iterable collection of values.
  *
+ * **Options**
+ *
+ * - `chunkSize`: Maximum number of values emitted per chunk.
+ *
  * @example
  * ```ts
  * import { Console, Effect, Stream } from "effect"
@@ -982,10 +986,15 @@ export const fromIteratorSucceed = <A>(iterator: IterableIterator<A>, maxChunkSi
  * @since 2.0.0
  * @category Constructors
  */
-export const fromIterable = <A>(iterable: Iterable<A>): Stream<A> =>
-  Array.isArray(iterable)
+export const fromIterable = <A>(
+  iterable: Iterable<A>,
+  options?: {
+    readonly chunkSize?: number | undefined
+  }
+): Stream<A> =>
+  Array.isArray(iterable) && options?.chunkSize === undefined
     ? fromArray(iterable)
-    : fromChannel(Channel.fromIterableArray(iterable))
+    : fromChannel(Channel.fromIterableArray(iterable, options?.chunkSize))
 
 /**
  * Creates a stream from an effect producing an iterable of values.

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -148,6 +148,24 @@ describe("Stream", () => {
         const result = yield* Stream.range(3, 3).pipe(Stream.runCollect)
         assert.deepStrictEqual(result, [3])
       }))
+
+    it.effect("fromIterable - emits array as one chunk by default", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.fromIterable([1, 2, 3, 4]).pipe(
+          Stream.chunks,
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(result, [[1, 2, 3, 4]])
+      }))
+
+    it.effect("fromIterable - supports chunkSize option", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.fromIterable([1, 2, 3, 4, 5], { chunkSize: 2 }).pipe(
+          Stream.chunks,
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(result, [[1, 2], [3, 4], [5]])
+      }))
   })
 
   describe("encoding", () => {


### PR DESCRIPTION
## Summary
- add an optional `chunkSize` option to `Stream.fromIterable` and forward it to `Channel.fromIterableArray`
- preserve existing array behavior when no option is provided by keeping the `fromArray` fast path
- add constructor tests for default array chunk behavior and explicit `chunkSize` chunking
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Stream.test.ts
- pnpm check:tsgo
- pnpm docgen