### PR TITLE
EFF-611 Fix LanguageModel.generateText toolkit error channel

### DIFF
--- a/.changeset/sharp-peas-march.md
+++ b/.changeset/sharp-peas-march.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix AI tool handler error typing so `LanguageModel.generateText` with a toolkit exposes wrapped `AiError` values rather than leaking raw `AiErrorReason` in the error channel.

--- a/packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts
@@ -1,0 +1,33 @@
+import type { Effect } from "effect"
+import { Schema } from "effect"
+import { type AiError, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
+import { describe, expect, it } from "tstyche"
+
+const FailureModeErrorTool = Tool.make("FailureModeErrorTool", {
+  parameters: Schema.Struct({
+    input: Schema.String
+  }),
+  success: Schema.Struct({
+    output: Schema.String
+  }),
+  failure: Schema.Struct({
+    message: Schema.String
+  })
+})
+
+describe("LanguageModel", () => {
+  describe("generateText", () => {
+    it("tool handlers do not leak AiErrorReason into the error channel", () => {
+      const toolkit = Toolkit.make(FailureModeErrorTool)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type ProgramError = typeof program extends Effect.Effect<any, infer E, any> ? E : never
+
+      expect<ProgramError>().type.toBe<AiError.AiError | { readonly message: string }>()
+      expect<Extract<ProgramError, AiError.AiErrorReason>>().type.toBe<never>()
+    })
+  })
+})

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1236,7 +1236,6 @@ export const make: (params: ConstructorParams) => Effect.Effect<Service> = Effec
     const queue = yield* Queue.make<
       Response.StreamPart<Tools>,
       | AiError.AiError
-      | AiError.AiErrorReason
       | Cause.Done
       | Schema.SchemaError
     >()

--- a/packages/effect/src/unstable/ai/Tool.ts
+++ b/packages/effect/src/unstable/ai/Tool.ts
@@ -952,7 +952,7 @@ export type HandlerError<T> = T extends Tool<
   infer _Name,
   infer _Config,
   infer _Requirements
-> ? _Config["failureMode"] extends "error" ? _Config["failure"]["Type"] | AiError.AiError | AiError.AiErrorReason
+> ? _Config["failureMode"] extends "error" ? _Config["failure"]["Type"] | AiError.AiError
   : never
   : never
 


### PR DESCRIPTION
## Summary
- remove `AiErrorReason` from `Tool.HandlerError` so toolkit-backed `LanguageModel.generateText` / `streamText` expose wrapped `AiError` values instead of raw reason classes
- align `LanguageModel` internal stream queue error typing with normalized tool-handler errors
- add a dtslint regression at `packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts` and include an `effect` patch changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/Tool.test.ts
- pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts
- pnpm test-types packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts
- pnpm check:tsgo
- pnpm docgen