### PR TITLE
EFF-612: proxy function length in Effect.fn APIs

### DIFF
--- a/.changeset/clean-balloons-tan.md
+++ b/.changeset/clean-balloons-tan.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Proxy function arity from `Effect.fn` APIs so wrapped functions preserve the original `length` value.

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2337,6 +2337,22 @@ describe("Effect", () => {
         assert.deepStrictEqual(result, [1, "a"])
       })
     })
+
+    it("should proxy body length", () => {
+      const traced = Effect.fn(function*(a: string, b: number) {
+        return a.length + b
+      })
+      const named = Effect.fn("named")(function*(a: string, b: number, c: boolean) {
+        return c ? a.length + b : b
+      })
+      const untraced = Effect.fnUntraced(function*(a: string, b: number) {
+        return a.length + b
+      }, Effect.map((n) => n))
+
+      assert.strictEqual(traced.length, 2)
+      assert.strictEqual(named.length, 3)
+      assert.strictEqual(untraced.length, 2)
+    })
   })
 
   describe("catchReason", () => {

--- a/packages/effect/test/EffectEager.test.ts
+++ b/packages/effect/test/EffectEager.test.ts
@@ -129,6 +129,14 @@ describe("Effect Eager Operations", () => {
         assert.strictEqual(result, 20)
       }))
 
+    it("proxies body length", () => {
+      const fn = Effect.fnUntracedEager(function*(a: string, b: number, c: boolean) {
+        return c ? a.length + b : b
+      })
+
+      assert.strictEqual(fn.length, 3)
+    })
+
     it.effect("re-execution creates fresh iterators", () =>
       Effect.gen(function*() {
         let execCount = 0


### PR DESCRIPTION
## Summary
- preserve original function arity by proxying `length` from the body function in `Effect.fn`, `Effect.fnUntraced`, and `Effect.fnUntracedEager`
- add runtime regression tests covering traced, named, untraced, and eager wrappers to ensure returned functions report the original `length`
- add a changeset for `effect` patch release

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test packages/effect/test/EffectEager.test.ts
- pnpm check:tsgo
- pnpm docgen