### PR TITLE
EFF-615 Fix HttpApi.prefix endpoint type propagation

### DIFF
--- a/.changeset/yellow-dingos-jump.md
+++ b/.changeset/yellow-dingos-jump.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpApi.prefix` so it updates endpoint path types the same way `HttpApiGroup.prefix` does.

--- a/packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts
@@ -100,6 +100,32 @@ describe("HttpApiClient", () => {
       // @ts-expect-error!
       builder("users", "POST /users/:id", { params: { id: "123" }, query: { page: "1" } })
     })
+
+    it("should reflect api-level prefix in endpoint keys", () => {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("users")
+            .add(
+              HttpApiEndpoint.get("getUser", "/users/:id", {
+                params: {
+                  id: Schema.FiniteFromString
+                }
+              })
+            )
+        )
+        .prefix("/v1")
+
+      const builder = HttpApiClient.urlBuilder<typeof Api>()
+
+      const prefixedUrl = builder("users", "GET /v1/users/:id", {
+        params: { id: "123" }
+      })
+
+      expect<typeof prefixedUrl>().type.toBe<string>()
+
+      // @ts-expect-error!
+      builder("users", "GET /users/:id", { params: { id: "123" } })
+    })
   })
 
   describe("headers option", () => {

--- a/packages/effect/src/unstable/httpapi/HttpApi.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApi.ts
@@ -57,7 +57,7 @@ export interface HttpApi<
   /**
    * Prefix all endpoints in the `HttpApi`.
    */
-  prefix<const Prefix extends PathInput>(prefix: Prefix): HttpApi<Id, Groups>
+  prefix<const Prefix extends PathInput>(prefix: Prefix): HttpApi<Id, HttpApiGroup.AddPrefix<Groups, Prefix>>
 
   /**
    * Add a middleware to a `HttpApi`. It will be applied to all endpoints in the


### PR DESCRIPTION
## Summary
- update `HttpApi.prefix` return typing to apply `HttpApiGroup.AddPrefix`, so api-level prefixes flow into endpoint path types
- add dtslint coverage proving `HttpApiClient.urlBuilder` accepts prefixed keys after `HttpApi.prefix` and rejects unprefixed ones
- include a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
- pnpm test-types packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts
- pnpm check:tsgo
- pnpm docgen