### PR TITLE
EFF-616 Fix Effect.forkScoped Scope requirements

### DIFF
--- a/.changeset/neat-taxis-notice.md
+++ b/.changeset/neat-taxis-notice.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Effect.forkScoped` data-first typings to include `Scope` in requirements.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1,5 +1,5 @@
 /** @effect-diagnostics floatingEffect:skip-file */
-import { type Cause, Data, Effect, type Option, pipe, Result, type Scope, type Types } from "effect"
+import { type Cause, Data, Effect, Fiber, type Option, pipe, Result, type Scope, type Types } from "effect"
 import { describe, expect, it } from "tstyche"
 
 // Fixtures
@@ -264,6 +264,25 @@ describe("Effect.annotateLogsScoped", () => {
   it("returns a scoped effect for record input", () => {
     const result = Effect.annotateLogsScoped({ requestId: "req-123", attempt: 1 })
     expect(result).type.toBe<Effect.Effect<void, never, Scope.Scope>>()
+  })
+})
+
+describe("Effect.forkScoped", () => {
+  it("adds Scope to requirements in data-first usage", () => {
+    const result = pipe(
+      Effect.forkScoped(string),
+      Effect.flatMap(Fiber.join)
+    )
+    expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1" | Scope.Scope>>()
+  })
+
+  it("adds Scope to requirements in data-last usage", () => {
+    const result = pipe(
+      string,
+      Effect.forkScoped(),
+      Effect.flatMap(Fiber.join)
+    )
+    expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1" | Scope.Scope>>()
   })
 })
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -8082,7 +8082,7 @@ export const forkScoped: <
     readonly startImmediately?: boolean | undefined
     readonly uninterruptible?: boolean | "inherit" | undefined
   } | undefined
-) => [Arg] extends [Effect<infer _A, infer _E, infer _R>] ? Effect<Fiber<_A, _E>, never, _R>
+) => [Arg] extends [Effect<infer _A, infer _E, infer _R>] ? Effect<Fiber<_A, _E>, never, _R | Scope>
   : <A, E, R>(self: Effect<A, E, R>) => Effect<Fiber<A, E>, never, R | Scope> = internal.forkScoped
 
 /**

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4950,7 +4950,8 @@ export const forkScoped: {
       readonly startImmediately?: boolean | undefined
       readonly uninterruptible?: boolean | "inherit" | undefined
     } | undefined
-  ): [Arg] extends [Effect.Effect<infer _A, infer _E, infer _R>] ? Effect.Effect<Fiber.Fiber<_A, _E>, never, _R>
+  ): [Arg] extends [Effect.Effect<infer _A, infer _E, infer _R>] ?
+    Effect.Effect<Fiber.Fiber<_A, _E>, never, _R | Scope.Scope>
     : <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<Fiber.Fiber<A, E>, never, R | Scope.Scope>
 } = dual((args) => isEffect(args[0]), <A, E, R>(
   self: Effect.Effect<A, E, R>,


### PR DESCRIPTION
## Summary
- fix `Effect.forkScoped` data-first typing to include `Scope` in the requirements, matching runtime behavior and data-last typing
- align the internal `forkScoped` dual signature so exported and internal types stay consistent
- add type-level regression tests for both data-first and data-last `forkScoped` usage, and include a patch changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test-types packages/effect/dtslint/Effect.tst.ts
- pnpm check:tsgo
- pnpm docgen