### PR TITLE
EFF-618 Include full LLM output text in StructuredOutputError

### DIFF
--- a/.changeset/bright-planes-smash.md
+++ b/.changeset/bright-planes-smash.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `text` to `AiError.StructuredOutputError` and populate it from `LanguageModel.generateObject` so failed structured output decodes include the full LLM text.
+Add `responseText` to `AiError.StructuredOutputError` and populate it from `LanguageModel.generateObject` so failed structured output decodes include the full LLM text.

--- a/packages/effect/src/unstable/ai/AiError.ts
+++ b/packages/effect/src/unstable/ai/AiError.ts
@@ -757,7 +757,7 @@ export class InvalidOutputError extends Schema.ErrorClass<InvalidOutputError>(
  *
  * const error = new AiError.StructuredOutputError({
  *   description: "Expected a valid JSON object",
- *   text: "{\"foo\":}"
+ *   responseText: "{\"foo\":}"
  * })
  *
  * console.log(error.isRetryable) // true
@@ -773,7 +773,7 @@ export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputErr
 )({
   _tag: Schema.tag("StructuredOutputError"),
   description: Schema.String,
-  text: Schema.String,
+  responseText: Schema.String,
   metadata: providerMetadataWithDefaults<StructuredOutputErrorMetadata>(),
   usage: Schema.optional(UsageInfo)
 }) {
@@ -808,10 +808,10 @@ export class StructuredOutputError extends Schema.ErrorClass<StructuredOutputErr
    * @since 1.0.0
    * @category constructors
    */
-  static fromSchemaError(error: Schema.SchemaError, text: string): StructuredOutputError {
+  static fromSchemaError(error: Schema.SchemaError, responseText: string): StructuredOutputError {
     return new StructuredOutputError({
       description: error.message,
-      text
+      responseText
     })
   }
 

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1879,7 +1879,7 @@ const resolveStructuredOutput = Effect.fnUntraced(function*<
       method: "generateObject",
       reason: new AiError.StructuredOutputError({
         description: "No text content in response",
-        text
+        responseText: text
       })
     })
   }

--- a/packages/effect/test/unstable/ai/AiError.test.ts
+++ b/packages/effect/test/unstable/ai/AiError.test.ts
@@ -394,7 +394,7 @@ describe("AiError", () => {
       it("should be retryable", () => {
         const error = new AiError.StructuredOutputError({
           description: "Invalid JSON structure",
-          text: "{\"invalid\":}"
+          responseText: "{\"invalid\":}"
         })
         assert.isTrue(error.isRetryable)
       })
@@ -402,7 +402,7 @@ describe("AiError", () => {
       it("should format message with description", () => {
         const error = new AiError.StructuredOutputError({
           description: "Expected a valid JSON object",
-          text: "{\"test\":true}"
+          responseText: "{\"test\":true}"
         })
         assert.match(error.message, /Structured output validation failed/)
         assert.match(error.message, /Expected a valid JSON object/)
@@ -411,7 +411,7 @@ describe("AiError", () => {
       it("should have _tag set correctly", () => {
         const error = new AiError.StructuredOutputError({
           description: "Test error",
-          text: "{\"foo\":\"bar\"}"
+          responseText: "{\"foo\":\"bar\"}"
         })
         assert.strictEqual(error._tag, "StructuredOutputError")
       })
@@ -429,7 +429,7 @@ describe("AiError", () => {
               const parseError = AiError.StructuredOutputError.fromSchemaError(cause.error, "{\"name\":123}")
               assert.strictEqual(parseError._tag, "StructuredOutputError")
               assert.isString(parseError.description)
-              assert.strictEqual(parseError.text, "{\"name\":123}")
+              assert.strictEqual(parseError.responseText, "{\"name\":123}")
             }
           }
         }))
@@ -780,13 +780,13 @@ describe("AiError", () => {
       Effect.gen(function*() {
         const error = new AiError.StructuredOutputError({
           description: "Invalid JSON structure",
-          text: "{\"invalid\":}"
+          responseText: "{\"invalid\":}"
         })
         const encoded = yield* Schema.encodeEffect(AiError.StructuredOutputError)(error)
         const decoded = yield* Schema.decodeEffect(AiError.StructuredOutputError)(encoded)
         assert.strictEqual(decoded._tag, "StructuredOutputError")
         assert.strictEqual(decoded.description, "Invalid JSON structure")
-        assert.strictEqual(decoded.text, "{\"invalid\":}")
+        assert.strictEqual(decoded.responseText, "{\"invalid\":}")
       }))
 
     it.effect("UnsupportedSchemaError roundtrip", () =>

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -121,7 +121,7 @@ describe("LanguageModel", () => {
 
         strictEqual(error.reason._tag, "StructuredOutputError")
         if (error.reason._tag === "StructuredOutputError") {
-          strictEqual(error.reason.text, "{\"count\":\"oops\"}")
+          strictEqual(error.reason.responseText, "{\"count\":\"oops\"}")
         }
       }))
   })


### PR DESCRIPTION
## Summary
- add a required `responseText` field to `AiError.StructuredOutputError` and preserve it in `fromSchemaError`
- keep `LanguageModel.generateObject` structured output resolution attaching full concatenated model text to both no-text and schema-decode structured output failures
- update `AiError` and `LanguageModel` regression tests to assert `responseText` is preserved end-to-end
- include a changeset for `effect` patch release

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/AiError.test.ts
- pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen