### PR TITLE
EFF-619 add regression for --log-level=<value> arg parsing

### DIFF
--- a/.changeset/strong-foxes-jam.md
+++ b/.changeset/strong-foxes-jam.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add a regression test for unstable CLI parsing to ensure `--log-level=<value>` does not swallow subsequent arguments.

--- a/packages/effect/test/unstable/cli/LogLevel.test.ts
+++ b/packages/effect/test/unstable/cli/LogLevel.test.ts
@@ -151,6 +151,23 @@ describe("LogLevel", () => {
       assert.deepStrictEqual(seen, [Option.none(), Option.some("warn")])
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("should not swallow subsequent args with --log-level=<value>", () =>
+    Effect.gen(function*() {
+      const seen: Array<Option.Option<string>> = []
+      const command = Command.make("test", {
+        name: Flag.string("name").pipe(Flag.optional)
+      }, ({ name }) =>
+        Effect.sync(() => {
+          seen.push(name)
+        }))
+
+      const runCommand = Command.runWith(command, { version: "1.0.0" })
+
+      yield* runCommand(["--log-level=debug", "--name=hello"])
+
+      assert.deepStrictEqual(seen, [Option.some("hello")])
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("should apply log level to subcommands", () =>
     Effect.gen(function*() {
       const parentCommand = Command.make("parent", {


### PR DESCRIPTION
## Summary
- add unstable CLI regression coverage proving `--log-level=<value>` does not consume the next argument
- reproduce the reported shape by running with `--log-level=debug --name=hello` and assert the command still receives `name`
- include an `effect` patch changeset documenting the parser regression guard

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/LogLevel.test.ts
- pnpm check:tsgo
- pnpm docgen