### PR TITLE
EFF-620 fix SqlSchema request typing for findAll APIs

### DIFF
--- a/.changeset/friendly-donuts-cheer.md
+++ b/.changeset/friendly-donuts-cheer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use `Req["Type"]` as the request input for `SqlSchema.findAll` and `SqlSchema.findNonEmpty` to match `findOne` and `findOneOption`.

--- a/packages/effect/src/unstable/sql/SqlSchema.ts
+++ b/packages/effect/src/unstable/sql/SqlSchema.ts
@@ -23,7 +23,7 @@ export const findAll = <Req extends Schema.Top, Res extends Schema.Top, E, R>(
   const encodeRequest = Schema.encodeEffect(options.Request)
   const decode = Schema.decodeUnknownEffect(Schema.mutable(Schema.Array(options.Result)))
   return (
-    request: Req["Encoded"]
+    request: Req["Type"]
   ): Effect.Effect<
     Array<Res["Type"]>,
     E | Schema.SchemaError,
@@ -46,7 +46,7 @@ export const findNonEmpty = <Req extends Schema.Top, Res extends Schema.Top, E, 
 ) => {
   const find = findAll(options)
   return (
-    request: Req["Encoded"]
+    request: Req["Type"]
   ): Effect.Effect<
     Arr.NonEmptyArray<Res["Type"]>,
     E | Schema.SchemaError | Cause.NoSuchElementError,

--- a/packages/effect/test/unstable/sql/SqlSchema.test.ts
+++ b/packages/effect/test/unstable/sql/SqlSchema.test.ts
@@ -6,6 +6,34 @@ import * as Schema from "effect/Schema"
 import * as SqlSchema from "effect/unstable/sql/SqlSchema"
 
 describe("SqlSchema", () => {
+  describe("findAll", () => {
+    it.effect("accepts request type and returns decoded rows", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.findAll({
+          Request: Schema.NumberFromString,
+          Result: Schema.Struct({ value: Schema.String }),
+          execute: (request) => Effect.succeed([{ value: `id:${request}` }])
+        })
+
+        const result = yield* query(1)
+        assert.deepStrictEqual(result, [{ value: "id:1" }])
+      }))
+  })
+
+  describe("findNonEmpty", () => {
+    it.effect("accepts request type and returns decoded non-empty rows", () =>
+      Effect.gen(function*() {
+        const query = SqlSchema.findNonEmpty({
+          Request: Schema.NumberFromString,
+          Result: Schema.Struct({ value: Schema.String }),
+          execute: (request) => Effect.succeed([{ value: `id:${request}` }])
+        })
+
+        const result = yield* query(1)
+        assert.deepStrictEqual(result, [{ value: "id:1" }])
+      }))
+  })
+
   describe("findOneOption", () => {
     it.effect("returns Option.some when a row exists", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- change `SqlSchema.findAll` and `SqlSchema.findNonEmpty` to accept `Req[\"Type\"]` request inputs, matching `findOne` and `findOneOption`
- keep internal request encoding behavior unchanged (`Schema.encodeEffect`) before delegating to `execute`
- add regression tests using `Schema.NumberFromString` to verify typed request input and encoded execution values
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/sql/SqlSchema.test.ts
- pnpm check:tsgo
- pnpm docgen