### PR TITLE
EFF-622: Expose fallback parameter in Effect.catchTags

### DIFF
--- a/.changeset/quick-dragons-fix.md
+++ b/.changeset/quick-dragons-fix.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Expose the optional `orElse` fallback parameter in `Effect.catchTags`.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -206,6 +206,41 @@ describe("Effect.catchReasons", () => {
   })
 })
 
+describe("Effect.catchTags", () => {
+  it("supports fallback in data-last usage", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchTags(
+        {
+          AiError: (error) => {
+            expect(error).type.toBe<AiError>()
+            return Effect.succeed("ok")
+          }
+        },
+        (error) => {
+          expect(error).type.toBe<OtherError>()
+          return Effect.fail(new SimpleError({ code: 1 }))
+        }
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  it("supports fallback in data-first usage", () => {
+    const result = Effect.catchTags(
+      mixedEffect,
+      {
+        AiError: () => Effect.succeed(1)
+      },
+      (error) => {
+        expect(error).type.toBe<OtherError>()
+        return Effect.succeed(2)
+      }
+    )
+    expect(result).type.toBe<Effect.Effect<string | number>>()
+  })
+})
+
 describe("Effect.catchNoSuchElement", () => {
   it("removes NoSuchElementError from the error channel", () => {
     const result = pipe(noSuchOrOther, Effect.catchNoSuchElement)

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2790,7 +2790,8 @@ export const catchTag: {
  * once. Instead of using {@link catchTag} multiple times, you can pass an
  * object where each key is an error type's `_tag`, and the value is the handler
  * for that specific error. This allows you to catch and recover from multiple
- * error types in a single call.
+ * error types in a single call. You can also provide a fallback handler for
+ * unhandled errors.
  *
  * The error type must have a readonly `_tag` field to use `catchTag`. This
  * field is used to identify and match errors.
@@ -2827,21 +2828,27 @@ export const catchTags: {
     E,
     Cases extends
       & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
-      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never })
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
+    A2 = never,
+    E2 = Exclude<E, { _tag: keyof Cases }>,
+    R2 = never
   >(
-    cases: Cases
+    cases: Cases,
+    orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Effect<A2, E2, R2>) | undefined
   ): <A, R>(
     self: Effect<A, E, R>
   ) => Effect<
     | A
+    | A2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
-    | Exclude<E, { _tag: keyof Cases }>
+    | E2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
     | R
+    | R2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]
@@ -2852,20 +2859,26 @@ export const catchTags: {
     A,
     Cases extends
       & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
-      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never })
+      & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
+    A2 = never,
+    E2 = Exclude<E, { _tag: keyof Cases }>,
+    R2 = never
   >(
     self: Effect<A, E, R>,
-    cases: Cases
+    cases: Cases,
+    orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Effect<A2, E2, R2>) | undefined
   ): Effect<
     | A
+    | A2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
-    | Exclude<E, { _tag: keyof Cases }>
+    | E2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
     | R
+    | R2
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, any, infer R> ? R : never
     }[keyof Cases]

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1647,6 +1647,25 @@ describe("Effect", () => {
         assert.strictEqual(yield* effect, 2)
       }))
 
+    it.effect("catchTags orElse", () =>
+      Effect.gen(function*() {
+        let error: ErrorA | ErrorB | ErrorC = new ErrorA()
+        const effect = Effect.failSync(() => error).pipe(
+          Effect.catchTags(
+            {
+              A: (_) => Effect.succeed(1),
+              B: (_) => Effect.succeed(2)
+            },
+            (_) => Effect.succeed(3)
+          )
+        )
+        assert.strictEqual(yield* effect, 1)
+        error = new ErrorB()
+        assert.strictEqual(yield* effect, 2)
+        error = new ErrorC()
+        assert.strictEqual(yield* effect, 3)
+      }))
+
     it.effect("tapErrorTag", () =>
       Effect.gen(function*() {
         let error: ErrorA | ErrorB | ErrorC = new ErrorA()


### PR DESCRIPTION
## Summary
- expose the optional orElse fallback parameter in the public Effect.catchTags API (data-first and data-last overloads)
- align public catchTags typing with existing internal runtime support for fallback handling
- add runtime and type-level regression coverage for Effect.catchTags with an orElse fallback

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test-types packages/effect/dtslint/Effect.tst.ts
- pnpm check:tsgo
- pnpm docgen