### PR TITLE
EFF-624 Default Effect.services<R>() to Effect.services<never>()

### DIFF
--- a/.changeset/soft-comics-wink.md
+++ b/.changeset/soft-comics-wink.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Default `Effect.services()` to `Effect.services<never>()` when no type parameter is provided.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1,5 +1,16 @@
 /** @effect-diagnostics floatingEffect:skip-file */
-import { type Cause, Data, Effect, Fiber, type Option, pipe, Result, type Scope, type Types } from "effect"
+import {
+  type Cause,
+  Data,
+  Effect,
+  Fiber,
+  type Option,
+  pipe,
+  Result,
+  type Scope,
+  type ServiceMap,
+  type Types
+} from "effect"
 import { describe, expect, it } from "tstyche"
 
 // Fixtures
@@ -250,6 +261,13 @@ describe("Effect.catchNoSuchElement", () => {
   it("yields never when NoSuchElementError is the only error", () => {
     const result = pipe(onlyNoSuch, Effect.catchNoSuchElement)
     expect(result).type.toBe<Effect.Effect<Option.Option<number>>>()
+  })
+})
+
+describe("Effect.services", () => {
+  it("defaults R to never", () => {
+    const result = Effect.services()
+    expect(result).type.toBe<Effect.Effect<ServiceMap.ServiceMap<never>, never, never>>()
   })
 })
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -5518,7 +5518,7 @@ export const isSuccess: <A, E, R>(self: Effect<A, E, R>) => Effect<boolean, neve
  * @since 2.0.0
  * @category Environment
  */
-export const services: <R>() => Effect<ServiceMap.ServiceMap<R>, never, R> = internal.services
+export const services: <R = never>() => Effect<ServiceMap.ServiceMap<R>, never, R> = internal.services
 
 /**
  * Transforms the current service map using the provided function.


### PR DESCRIPTION
## Summary
- default `Effect.services` in the public `Effect.ts` API to `<R = never>` so `Effect.services()` is equivalent to `Effect.services<never>()`
- add a dtslint regression in `packages/effect/dtslint/Effect.tst.ts` asserting the no-arg call infers `Effect.Effect<ServiceMap.ServiceMap<never>, never, never>`
- include a patch changeset for `effect`

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types packages/effect/dtslint/Effect.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`