### PR TITLE
Add Headers.removeMany combinator

### DIFF
--- a/.changeset/add-headers-remove-many.md
+++ b/.changeset/add-headers-remove-many.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/http Headers: add `removeMany` combinator for removing multiple headers at once

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -260,6 +260,24 @@ export const remove: {
  * @since 4.0.0
  * @category combinators
  */
+export const removeMany: {
+  (keys: Iterable<string>): (self: Headers) => Headers
+  (self: Headers, keys: Iterable<string>): Headers
+} = dual<
+  (keys: Iterable<string>) => (self: Headers) => Headers,
+  (self: Headers, keys: Iterable<string>) => Headers
+>(2, (self, keys) => {
+  const out = make(self)
+  for (const key of keys) {
+    delete out[key.toLowerCase()]
+  }
+  return out
+})
+
+/**
+ * @since 4.0.0
+ * @category combinators
+ */
 export const redact: {
   (
     key: string | RegExp | ReadonlyArray<string | RegExp>

--- a/packages/effect/test/unstable/http/Headers.test.ts
+++ b/packages/effect/test/unstable/http/Headers.test.ts
@@ -34,6 +34,24 @@ describe("Headers", () => {
     deepStrictEqual(keys, ["foo"])
   })
 
+  it("remove", () => {
+    const headers = Headers.fromInput({ foo: "bar", baz: "qux", hello: "world" })
+    const result = Headers.remove(headers, "baz")
+    deepStrictEqual({ ...result }, { foo: "bar", hello: "world" })
+  })
+
+  it("removeMany", () => {
+    const headers = Headers.fromInput({ foo: "bar", baz: "qux", hello: "world" })
+    const result = Headers.removeMany(headers, ["baz", "hello"])
+    deepStrictEqual({ ...result }, { foo: "bar" })
+  })
+
+  it("removeMany normalizes keys to lowercase", () => {
+    const headers = Headers.fromInput({ "Content-Type": "text/plain", "X-Custom": "value", keep: "me" })
+    const result = Headers.removeMany(headers, ["Content-Type", "X-CUSTOM"])
+    deepStrictEqual({ ...result }, { keep: "me" })
+  })
+
   it("works with for..in based headers polyfills", () => {
     const effectHeaders = Headers.fromInput({ foo: "bar" })
     const nativeHeaders = new globalThis.Headers()


### PR DESCRIPTION
## Summary
- Add `Headers.removeMany` combinator that removes multiple headers at once, accepting an `Iterable<string>` of keys
- Follows the same dual/pattern as `HashMap.removeMany` and `Trie.removeMany`

## Test plan
- Added tests for `removeMany` (basic usage and case normalization)
- Added missing test for existing `remove`