### PR TITLE
EFF-625 Add Model.BooleanSqlite schema

### DIFF
--- a/.changeset/bright-dogs-fail.md
+++ b/.changeset/bright-dogs-fail.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Model.BooleanSqlite`, a model field schema that uses `0 | 1` encoding for database variants and plain `boolean` encoding for JSON variants.

--- a/packages/effect/dtslint/VariantSchema.tst.ts
+++ b/packages/effect/dtslint/VariantSchema.tst.ts
@@ -46,4 +46,15 @@ describe("Model", () => {
     expect(Model.Union).type.toBeCallableWith([first, second])
     expect(Model.Union).type.not.toBeCallableWith(first, second)
   })
+
+  it("BooleanSqlite uses bit encoding for database variants", () => {
+    const User = Model.Struct({
+      active: Model.BooleanSqlite
+    })
+    const select = Model.extract(User, "select")
+    const json = Model.extract(User, "json")
+
+    expect<Schema.Codec.Encoded<typeof select>>().type.toBe<{ readonly active: 0 | 1 }>()
+    expect<Schema.Codec.Encoded<typeof json>>().type.toBe<{ readonly active: boolean }>()
+  })
 })

--- a/packages/effect/src/unstable/schema/Model.ts
+++ b/packages/effect/src/unstable/schema/Model.ts
@@ -303,6 +303,37 @@ export const FieldOption: <Field extends VariantSchema.Field<any> | Schema.Top>(
 
 /**
  * @since 4.0.0
+ * @category booleans
+ */
+export interface BooleanSqlite extends
+  VariantSchema.Field<{
+    readonly select: Schema.BooleanFromBit
+    readonly insert: Schema.BooleanFromBit
+    readonly update: Schema.BooleanFromBit
+    readonly json: Schema.Boolean
+    readonly jsonCreate: Schema.Boolean
+    readonly jsonUpdate: Schema.Boolean
+  }>
+{}
+
+/**
+ * A schema for sqlite booleans that are represented as `0 | 1` in database
+ * variants and `boolean` in JSON variants.
+ *
+ * @since 4.0.0
+ * @category booleans
+ */
+export const BooleanSqlite: BooleanSqlite = Field({
+  select: Schema.BooleanFromBit,
+  insert: Schema.BooleanFromBit,
+  update: Schema.BooleanFromBit,
+  json: Schema.Boolean,
+  jsonCreate: Schema.Boolean,
+  jsonUpdate: Schema.Boolean
+})
+
+/**
+ * @since 4.0.0
  * @category date & time
  */
 export interface Date extends Schema.decodeTo<Schema.instanceOf<DateTime.Utc>, Schema.String> {}

--- a/packages/effect/test/unstable/schema/VariantSchema.test.ts
+++ b/packages/effect/test/unstable/schema/VariantSchema.test.ts
@@ -29,4 +29,22 @@ describe("Model", () => {
     assert.deepStrictEqual(Object.keys(Model.extract(InsertOnly, "insert").fields), ["value"])
     assert.deepStrictEqual(Object.keys(Model.extract(InsertOnly, "select").fields), [])
   })
+
+  it("BooleanSqlite uses bit values for database variants", () => {
+    const User = Model.Struct({
+      active: Model.BooleanSqlite
+    })
+
+    const select = Model.extract(User, "select")
+    const json = Model.extract(User, "json")
+    const encodeSelect = Schema.encodeSync(select)
+    const decodeSelect = Schema.decodeSync(select)
+    const encodeJson = Schema.encodeSync(json)
+    const decodeJson = Schema.decodeSync(json)
+
+    assert.deepStrictEqual(encodeSelect({ active: true }), { active: 1 })
+    assert.deepStrictEqual(decodeSelect({ active: 0 }), { active: false })
+    assert.deepStrictEqual(encodeJson({ active: true }), { active: true })
+    assert.deepStrictEqual(decodeJson({ active: false }), { active: false })
+  })
 })


### PR DESCRIPTION
## Summary
- add `Model.BooleanSqlite` in `effect/unstable/schema` with `Schema.BooleanFromBit` for database variants and `Schema.Boolean` for json variants
- add runtime coverage in `VariantSchema.test.ts` for select/json encode and decode behavior
- add dtslint coverage for encoded type differences across variants and include a patch changeset