### PR TITLE
EFF-627 Forward reasoning config in openai-compat

### DIFF
--- a/.changeset/long-cameras-think.md
+++ b/.changeset/long-cameras-think.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Forward `OpenAiLanguageModel` `reasoning` config into chat-completions requests.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -855,6 +855,7 @@ export type ChatCompletionRequest = {
   readonly tools?: ReadonlyArray<ChatCompletionTool> | undefined
   readonly tool_choice?: ChatCompletionToolChoice | undefined
   readonly service_tier?: string | undefined
+  readonly reasoning?: unknown
   readonly stream?: boolean | undefined
   readonly stream_options?: {
     readonly include_usage?: boolean | undefined

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1209,6 +1209,7 @@ const toChatCompletionsRequest = (payload: CreateResponse): CreateResponseReques
       ? { parallel_tool_calls: payload.parallel_tool_calls }
       : undefined),
     ...(payload.service_tier !== undefined ? { service_tier: payload.service_tier } : undefined),
+    ...(payload.reasoning !== undefined ? { reasoning: payload.reasoning } : undefined),
     ...(responseFormat !== undefined ? { response_format: responseFormat } : undefined),
     ...(tools.length > 0 ? { tools } : undefined),
     ...(toolChoice !== undefined ? { tool_choice: toolChoice } : undefined)

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -48,6 +48,54 @@ describe("OpenAiLanguageModel", () => {
         assert.strictEqual(requestBody.messages[0]?.content, "hello")
       }))
 
+    it.effect("forwards reasoning config to chat completions request", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "stop",
+                    message: {
+                      role: "assistant",
+                      content: "Done"
+                    }
+                  }]
+                })
+              ))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({ prompt: "hello" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-5", {
+            reasoning: {
+              effort: "medium",
+              summary: "auto"
+            }
+          })),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const requestBody = yield* getRequestBody(capturedRequest)
+        assert.deepStrictEqual(requestBody.reasoning, {
+          effort: "medium",
+          summary: "auto"
+        })
+      }))
+
     it.effect("preserves multimodal user content order in chat payload", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined


### PR DESCRIPTION
## Summary
- forward `OpenAiLanguageModel` `reasoning` config into the chat-completions request payload in `toChatCompletionsRequest`
- add `reasoning?: unknown` to `ChatCompletionRequest` so the forwarded config is represented in compat request types
- add a regression test covering `OpenAiLanguageModel.model(..., { reasoning: ... })` request forwarding and add a patch changeset for `@effect/ai-openai-compat`

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen