### PR TITLE
Set TaggedErrorClass error name to tag

### DIFF
--- a/.changeset/short-cows-relate.md
+++ b/.changeset/short-cows-relate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure `Schema.TaggedErrorClass` instances set `error.name` to the configured tag, even when the class name differs.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -8347,7 +8347,7 @@ export const TaggedErrorClass: {
     schema: Struct.Fields | Struct<Struct.Fields>,
     annotations?: Annotations.Declaration<any, readonly [Struct<Struct.Fields>]>
   ): any => {
-    return ErrorClass(identifier ?? tagValue)(
+    const self = ErrorClass(identifier ?? tagValue)(
       isStruct(schema) ?
         schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
           unsafePreserveChecks: true
@@ -8355,6 +8355,8 @@ export const TaggedErrorClass: {
         TaggedStruct(tagValue, schema),
       annotations
     )
+    ;(self.prototype as any).name = tagValue
+    return self
   }
 }
 

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -5748,6 +5748,14 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
   })
 
   describe("TaggedErrorClass", () => {
+    it("sets the error name to the tag", () => {
+      class DifferentClassName extends Schema.TaggedErrorClass<DifferentClassName>()("TaggedErrorName", {}) {}
+
+      const err = new DifferentClassName()
+      strictEqual(err._tag, "TaggedErrorName")
+      strictEqual(err.name, "TaggedErrorName")
+    })
+
     it("fields argument", async () => {
       class E extends Schema.TaggedErrorClass<E>()("E", {
         id: Schema.Number


### PR DESCRIPTION
## Summary
- update `Schema.TaggedErrorClass` to assign `prototype.name` from the provided tag so instances consistently report the tagged error name
- add schema runtime coverage asserting `.name` follows the tag even when the class name differs
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/schema/Schema.test.ts
- pnpm check:tsgo
- pnpm docgen