### PR TITLE
Add Schema Result decode and encode helpers

### DIFF
--- a/.changeset/schema-result-combinators.md
+++ b/.changeset/schema-result-combinators.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Schema: add `decodeUnknownResult` / `decodeResult` and `encodeUnknownResult` / `encodeResult` helpers for synchronous `Result`-based parsing.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -767,6 +767,18 @@ export const decodeOption = Parser.decodeOption
  * @category Decoding
  * @since 4.0.0
  */
+export const decodeUnknownResult = Parser.decodeUnknownResult
+
+/**
+ * @category Decoding
+ * @since 4.0.0
+ */
+export const decodeResult = Parser.decodeResult
+
+/**
+ * @category Decoding
+ * @since 4.0.0
+ */
 export const decodeUnknownPromise = Parser.decodeUnknownPromise
 
 /**
@@ -840,6 +852,18 @@ export const encodeUnknownOption = Parser.encodeUnknownOption
  * @since 4.0.0
  */
 export const encodeOption = Parser.encodeOption
+
+/**
+ * @category Encoding
+ * @since 4.0.0
+ */
+export const encodeUnknownResult = Parser.encodeUnknownResult
+
+/**
+ * @category Encoding
+ * @since 4.0.0
+ */
+export const encodeResult = Parser.encodeResult
 
 /**
  * @category Encoding

--- a/packages/effect/src/SchemaParser.ts
+++ b/packages/effect/src/SchemaParser.ts
@@ -208,6 +208,24 @@ export const decodeOption: <S extends Schema.Top & { readonly DecodingServices: 
  * @category Decoding
  * @since 4.0.0
  */
+export function decodeUnknownResult<S extends Schema.Top & { readonly DecodingServices: never }>(
+  schema: S
+): (input: unknown, options?: AST.ParseOptions) => Result.Result<S["Type"], Issue.Issue> {
+  return asResult(decodeUnknownEffect(schema))
+}
+
+/**
+ * @category Decoding
+ * @since 4.0.0
+ */
+export const decodeResult: <S extends Schema.Top & { readonly DecodingServices: never }>(
+  schema: S
+) => (input: S["Encoded"], options?: AST.ParseOptions) => Result.Result<S["Type"], Issue.Issue> = decodeUnknownResult
+
+/**
+ * @category Decoding
+ * @since 4.0.0
+ */
 export function decodeUnknownSync<S extends Schema.Top & { readonly DecodingServices: never }>(
   schema: S
 ): (input: unknown, options?: AST.ParseOptions) => S["Type"] {
@@ -297,6 +315,24 @@ export const encodeOption: <S extends Schema.Top & { readonly EncodingServices: 
  * @category Encoding
  * @since 4.0.0
  */
+export function encodeUnknownResult<S extends Schema.Top & { readonly EncodingServices: never }>(
+  schema: S
+): (input: unknown, options?: AST.ParseOptions) => Result.Result<S["Encoded"], Issue.Issue> {
+  return asResult(encodeUnknownEffect(schema))
+}
+
+/**
+ * @category Encoding
+ * @since 4.0.0
+ */
+export const encodeResult: <S extends Schema.Top & { readonly EncodingServices: never }>(
+  schema: S
+) => (input: S["Type"], options?: AST.ParseOptions) => Result.Result<S["Encoded"], Issue.Issue> = encodeUnknownResult
+
+/**
+ * @category Encoding
+ * @since 4.0.0
+ */
 export function encodeUnknownSync<S extends Schema.Top & { readonly EncodingServices: never }>(
   schema: S
 ): (input: unknown, options?: AST.ParseOptions) => S["Encoded"] {
@@ -341,6 +377,23 @@ export function asOption<T, E, R>(
 ): (input: E, options?: AST.ParseOptions) => Option.Option<T> {
   const parserExit = asExit(parser)
   return (input: E, options?: AST.ParseOptions) => Exit.getSuccess(parserExit(input, options))
+}
+
+function asResult<T, E, R>(
+  parser: (input: E, options?: AST.ParseOptions) => Effect.Effect<T, Issue.Issue, R>
+): (input: E, options?: AST.ParseOptions) => Result.Result<T, Issue.Issue> {
+  const parserExit = asExit(parser)
+  return (input: E, options?: AST.ParseOptions) => {
+    const exit = parserExit(input, options)
+    if (Exit.isSuccess(exit)) {
+      return Result.succeed(exit.value)
+    }
+    const error = Cause.findError(exit.cause)
+    if (Result.isFailure(error)) {
+      throw Cause.squash(error.failure)
+    }
+    return Result.fail(error.success)
+  }
 }
 
 function asSync<T, E, R>(

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -6422,6 +6422,63 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
     })
   })
 
+  describe("decodeUnknownResult / encodeUnknownResult", () => {
+    it("FiniteFromString", () => {
+      const schema = Schema.FiniteFromString
+      const decodeUnknownResult = Schema.decodeUnknownResult(schema)
+      const encodeUnknownResult = Schema.encodeUnknownResult(schema)
+
+      const r1 = decodeUnknownResult("1")
+      assertTrue(Result.isSuccess(r1))
+      strictEqual(r1.success, 1)
+
+      const r2 = decodeUnknownResult(null)
+      assertTrue(Result.isFailure(r2))
+      strictEqual(r2.failure.toString(), "Expected string, got null")
+
+      const r3 = encodeUnknownResult(1)
+      assertTrue(Result.isSuccess(r3))
+      strictEqual(r3.success, "1")
+
+      const r4 = encodeUnknownResult(null)
+      assertTrue(Result.isFailure(r4))
+      strictEqual(r4.failure.toString(), "Expected number, got null")
+    })
+  })
+
+  describe("decodeUnknownResult", () => {
+    it("should throw on async decoding", () => {
+      const AsyncString = Schema.String.pipe(Schema.decode({
+        decode: new SchemaGetter.Getter((os: Option.Option<string>) =>
+          Effect.gen(function*() {
+            yield* Effect.sleep("10 millis")
+            return os
+          })
+        ),
+        encode: SchemaGetter.passthrough()
+      }))
+      const schema = AsyncString
+
+      throws(() => SchemaParser.decodeUnknownResult(schema)("1"))
+    })
+
+    it("should throw on missing dependency", () => {
+      class MagicNumber extends ServiceMap.Service<MagicNumber, number>()("MagicNumber") {}
+      const DepString = Schema.Number.pipe(Schema.decode({
+        decode: SchemaGetter.onSome((n) =>
+          Effect.gen(function*() {
+            const magicNumber = yield* MagicNumber
+            return Option.some(n * magicNumber)
+          })
+        ),
+        encode: SchemaGetter.passthrough()
+      }))
+      const schema = DepString
+
+      throws(() => SchemaParser.decodeUnknownResult(schema as any)(1))
+    })
+  })
+
   describe("decodeUnknownExit", () => {
     it("should throw on async decoding", () => {
       const AsyncString = Schema.String.pipe(Schema.decode({


### PR DESCRIPTION
## Summary
- add `SchemaParser.decodeUnknownResult` / `decodeResult` and `encodeUnknownResult` / `encodeResult` for synchronous `Result`-based parsing
- re-export the new Result-based helpers from `Schema`
- ensure `asResult` maps typed parse errors to `Result.fail(issue)` and throws for defect-only causes
- add schema tests for success / typed failure behavior and throw behavior for async decoders and missing dependencies
- add a patch changeset for `effect`

## Testing
- `pnpm lint-fix`
- `pnpm test packages/effect/test/schema/Schema.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`