### PR TITLE
EFF-629 openai-compat: allow custom model/request properties

### DIFF
--- a/.changeset/few-birds-matter.md
+++ b/.changeset/few-birds-matter.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Allow custom request properties in openai-compat model config and chat request types, and forward model-level custom properties to chat-completions payloads.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -860,6 +860,7 @@ export type ChatCompletionRequest = {
   readonly stream_options?: {
     readonly include_usage?: boolean | undefined
   } | undefined
+  readonly [x: string]: unknown
 }
 /**
  * @since 1.0.0

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -101,6 +101,7 @@ export class Config extends ServiceMap.Service<
        * Defaults to `true`.
        */
       readonly strictJsonSchema?: boolean | undefined
+      readonly [x: string]: unknown
     }
   >
 >()("@effect/ai-openai-compat/OpenAiLanguageModel/Config") {}
@@ -1198,6 +1199,7 @@ const toChatCompletionsRequest = (payload: CreateResponse): CreateResponseReques
   const toolChoice = toChatToolChoice(payload.tool_choice)
 
   return {
+    ...extractCustomRequestProperties(payload),
     model: payload.model ?? "",
     messages: messages.length > 0 ? messages : [{ role: "user", content: "" }],
     ...(payload.temperature !== undefined ? { temperature: payload.temperature } : undefined),
@@ -1214,6 +1216,47 @@ const toChatCompletionsRequest = (payload: CreateResponse): CreateResponseReques
     ...(tools.length > 0 ? { tools } : undefined),
     ...(toolChoice !== undefined ? { tool_choice: toolChoice } : undefined)
   }
+}
+
+const createResponseKnownProperties = new Set<string>([
+  "metadata",
+  "top_logprobs",
+  "temperature",
+  "top_p",
+  "user",
+  "safety_identifier",
+  "prompt_cache_key",
+  "service_tier",
+  "prompt_cache_retention",
+  "previous_response_id",
+  "model",
+  "reasoning",
+  "background",
+  "max_output_tokens",
+  "max_tool_calls",
+  "text",
+  "tools",
+  "tool_choice",
+  "truncation",
+  "input",
+  "include",
+  "parallel_tool_calls",
+  "store",
+  "instructions",
+  "stream",
+  "conversation",
+  "modalities",
+  "seed"
+])
+
+const extractCustomRequestProperties = (payload: CreateResponse): Record<string, unknown> => {
+  const customProperties: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(payload)) {
+    if (!createResponseKnownProperties.has(key)) {
+      customProperties[key] = value
+    }
+  }
+  return customProperties
 }
 
 const toChatResponseFormat = (

--- a/packages/ai/openai-compat/test/OpenAiClient.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiClient.test.ts
@@ -45,6 +45,41 @@ describe("OpenAiClient", () => {
         assert.strictEqual(body.messages[0]?.content, "hello")
       }))
 
+    it.effect("passes custom chat-completions request properties through", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const client = yield* OpenAiClient.make({
+          apiKey: Redacted.make("sk-test-key")
+        }).pipe(
+          Effect.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, 200, makeChatCompletion()))
+            })
+          ))
+        )
+
+        yield* client.createResponse({
+          model: "gpt-4o-mini",
+          messages: [{ role: "user", content: "hello" }],
+          provider_feature: {
+            enabled: true
+          }
+        })
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const body = yield* getRequestBody(capturedRequest)
+        assert.deepStrictEqual(body.provider_feature, {
+          enabled: true
+        })
+      }))
+
     it.effect("uses /embeddings path and decodes permissive embedding payloads", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -96,6 +96,52 @@ describe("OpenAiLanguageModel", () => {
         })
       }))
 
+    it.effect("forwards custom model config properties to chat completions request", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "stop",
+                    message: {
+                      role: "assistant",
+                      content: "Done"
+                    }
+                  }]
+                })
+              ))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({ prompt: "hello" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini", {
+            vendor_setting: {
+              mode: "strict"
+            }
+          })),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const requestBody = yield* getRequestBody(capturedRequest)
+        assert.deepStrictEqual(requestBody.vendor_setting, {
+          mode: "strict"
+        })
+      }))
+
     it.effect("preserves multimodal user content order in chat payload", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined


### PR DESCRIPTION
## Summary
- add string index signatures to openai-compat request/config surfaces so provider-specific fields are accepted in both `OpenAiLanguageModel.model(..., config)` and `OpenAiClient.createResponse(...)`
- forward custom model config fields through `toChatCompletionsRequest` while preserving existing mappings for known OpenAI-compatible fields
- add regression tests for custom-property pass-through in both language-model and raw client request paths

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai-compat/test/OpenAiClient.test.ts
- pnpm test packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen