### PR TITLE
EFF-630 Add expireCookie APIs for HTTP cookies

### DIFF
--- a/.changeset/smart-timers-fly.md
+++ b/.changeset/smart-timers-fly.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Add `Cookies.expireCookie` and `HttpServerResponse.clearCookie` / `clearCookieUnsafe` for emitting expired cookies.
+Add `Cookies.expireCookie` / `expireCookieUnsafe` and `HttpServerResponse.expireCookie` / `expireCookieUnsafe` for emitting expired cookies.

--- a/packages/effect/src/unstable/http/Cookies.ts
+++ b/packages/effect/src/unstable/http/Cookies.ts
@@ -621,6 +621,36 @@ export const expireCookie: {
 )
 
 /**
+ * Add an expired cookie to a Cookies object, throwing an error if invalid
+ *
+ * @since 4.0.0
+ * @category combinators
+ */
+export const expireCookieUnsafe: {
+  (
+    name: string,
+    options?: Omit<NonNullable<Cookie["options"]>, "expires" | "maxAge">
+  ): (self: Cookies) => Cookies
+  (
+    self: Cookies,
+    name: string,
+    options?: Omit<NonNullable<Cookie["options"]>, "expires" | "maxAge">
+  ): Cookies
+} = dual(
+  (args) => isCookies(args[0]),
+  (
+    self: Cookies,
+    name: string,
+    options?: Omit<NonNullable<Cookie["options"]>, "expires" | "maxAge">
+  ): Cookies =>
+    setUnsafe(self, name, "", {
+      ...options,
+      maxAge: 0,
+      expires: new Date(0)
+    })
+)
+
+/**
  * Add multiple cookies to a Cookies object
  *
  * @since 4.0.0

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -490,7 +490,7 @@ export const setCookie: {
  * @since 4.0.0
  * @category combinators
  */
-export const clearCookie: {
+export const expireCookie: {
   (
     name: string,
     options?: Omit<NonNullable<Cookies.Cookie["options"]>, "expires" | "maxAge">
@@ -553,7 +553,7 @@ export const setCookieUnsafe: {
  * @since 4.0.0
  * @category combinators
  */
-export const clearCookieUnsafe: {
+export const expireCookieUnsafe: {
   (
     name: string,
     options?: Omit<NonNullable<Cookies.Cookie["options"]>, "expires" | "maxAge">
@@ -572,11 +572,7 @@ export const clearCookieUnsafe: {
   ): HttpServerResponse =>
     makeResponse({
       ...self,
-      cookies: Cookies.setUnsafe(self.cookies, name, "", {
-        ...options,
-        maxAge: 0,
-        expires: new Date(0)
-      })
+      cookies: Cookies.expireCookieUnsafe(self.cookies, name, options)
     })
 )
 

--- a/packages/effect/test/unstable/http/Cookies.test.ts
+++ b/packages/effect/test/unstable/http/Cookies.test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from "@effect/vitest"
+import { deepStrictEqual } from "@effect/vitest/utils"
 import { Schema } from "effect"
 import { TestSchema } from "effect/testing"
 import { Cookies } from "effect/unstable/http"
@@ -8,6 +9,20 @@ describe("Cookies", () => {
   it("expireCookie", () => {
     assertSuccess(
       Cookies.expireCookie(Cookies.empty, "session", { path: "/", secure: true }),
+      Cookies.fromReadonlyRecord({
+        session: Cookies.makeCookieUnsafe("session", "", {
+          path: "/",
+          secure: true,
+          maxAge: 0,
+          expires: new Date(0)
+        })
+      })
+    )
+  })
+
+  it("expireCookieUnsafe", () => {
+    deepStrictEqual(
+      Cookies.expireCookieUnsafe(Cookies.empty, "session", { path: "/", secure: true }),
       Cookies.fromReadonlyRecord({
         session: Cookies.makeCookieUnsafe("session", "", {
           path: "/",

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -35,11 +35,11 @@ describe("Http/App", () => {
       })
     })
 
-    test("clearCookie", async () => {
+    test("expireCookie", async () => {
       const handler = HttpEffect.toWebHandler(
         HttpServerResponse.empty().pipe(
-          HttpServerResponse.clearCookie("foo", { path: "/" }),
-          Effect.map(HttpServerResponse.clearCookieUnsafe("bar"))
+          HttpServerResponse.expireCookie("foo", { path: "/" }),
+          Effect.map(HttpServerResponse.expireCookieUnsafe("bar"))
         )
       )
       const response = await handler(new Request("http://localhost:3000/"))


### PR DESCRIPTION
## Summary
- add `Cookies.expireCookieUnsafe(name, options?)` alongside `Cookies.expireCookie(name, options?)` so both safe/unsafe cookie-map APIs can emit expired cookies
- rename response combinators to `HttpServerResponse.expireCookie` and `HttpServerResponse.expireCookieUnsafe`, with unsafe response path delegating to `Cookies.expireCookieUnsafe`
- update unstable HTTP regression tests and changeset text to match the renamed APIs

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/Cookies.test.ts
- pnpm test packages/effect/test/unstable/http/HttpEffect.test.ts
- pnpm check:tsgo
- pnpm docgen