### PR TITLE
EFF-649 Add Scheduler.PreventSchedulerYield reference

### DIFF
--- a/.changeset/nasty-geese-grow.md
+++ b/.changeset/nasty-geese-grow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Scheduler.PreventSchedulerYield` and expose it via `References` so fibers can skip scheduler `shouldYield` checks when needed.

--- a/packages/effect/src/Fiber.ts
+++ b/packages/effect/src/Fiber.ts
@@ -128,6 +128,7 @@ export interface Fiber<out A, out E = never> extends Pipeable {
   readonly minimumLogLevel: LogLevel
   readonly currentStackFrame?: StackFrame | undefined
   readonly maxOpsBeforeYield: number
+  readonly currentPreventYield: boolean
   readonly addObserver: (cb: (exit: Exit<A, E>) => void) => () => void
   readonly interruptUnsafe: (
     fiberId?: number | undefined,

--- a/packages/effect/src/References.ts
+++ b/packages/effect/src/References.ts
@@ -13,7 +13,7 @@
 import { constTrue, constUndefined } from "./Function.ts"
 import type { LogLevel, Severity } from "./LogLevel.ts"
 import type { ReadonlyRecord } from "./Record.ts"
-import { MaxOpsBeforeYield } from "./Scheduler.ts"
+import { MaxOpsBeforeYield, PreventSchedulerYield } from "./Scheduler.ts"
 import * as ServiceMap from "./ServiceMap.ts"
 import { CurrentTraceLevel, DisablePropagation, MinimumTraceLevel, type SpanLink, Tracer } from "./Tracer.ts"
 
@@ -38,6 +38,11 @@ export {
    * @category references
    */
   MinimumTraceLevel,
+  /**
+   * @since 4.0.0
+   * @category references
+   */
+  PreventSchedulerYield,
   /**
    * @since 4.0.0
    * @category references

--- a/packages/effect/src/Scheduler.ts
+++ b/packages/effect/src/Scheduler.ts
@@ -280,3 +280,15 @@ export class MixedScheduler implements Scheduler {
 export const MaxOpsBeforeYield = ServiceMap.Reference<number>("effect/Scheduler/MaxOpsBeforeYield", {
   defaultValue: () => 2048
 })
+
+/**
+ * A service reference that controls whether the runtime should bypass scheduler
+ * yield checks. When set to `true`, the fiber run loop won't call
+ * `Scheduler.shouldYield`.
+ *
+ * @since 4.0.0
+ * @category references
+ */
+export const PreventSchedulerYield = ServiceMap.Reference<boolean>("effect/Scheduler/PreventSchedulerYield", {
+  defaultValue: () => false
+})

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -537,6 +537,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
   currentStackFrame: StackFrame | undefined
   runtimeMetrics: Metric.FiberRuntimeMetricsService | undefined
   maxOpsBeforeYield!: number
+  currentPreventYield!: boolean
 
   getRef<X>(ref: ServiceMap.Reference<X>): X {
     return ServiceMap.getReferenceUnsafe(this.services, ref)
@@ -615,6 +616,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
         this.currentOpCount++
         if (
           !yielding &&
+          !this.currentPreventYield &&
           this.currentScheduler.shouldYield(this as any)
         ) {
           yielding = true
@@ -678,6 +680,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this.minimumLogLevel = this.getRef(MinimumLogLevel)
     this.currentStackFrame = services.mapUnsafe.get(CurrentStackFrame.key)
     this.maxOpsBeforeYield = this.getRef(Scheduler.MaxOpsBeforeYield)
+    this.currentPreventYield = this.getRef(Scheduler.PreventSchedulerYield)
     this.runtimeMetrics = services.mapUnsafe.get(InternalMetric.FiberRuntimeMetricsKey)
     const currentTracer = services.mapUnsafe.get(Tracer.TracerKey)
     this.currentTracerContext = currentTracer ? currentTracer["context"] : undefined

--- a/packages/effect/test/Scheduler.test.ts
+++ b/packages/effect/test/Scheduler.test.ts
@@ -1,11 +1,11 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import { MixedScheduler } from "effect/Scheduler"
+import * as Scheduler from "effect/Scheduler"
 
 describe("Scheduler", () => {
   it.effect("MixedScheduler orders by priority (sync)", () =>
     Effect.sync(() => {
-      const scheduler = new MixedScheduler("sync")
+      const scheduler = new Scheduler.MixedScheduler("sync")
       const order: Array<string> = []
 
       scheduler.scheduleTask(() => order.push("p0-1"), 0)
@@ -29,7 +29,7 @@ describe("Scheduler", () => {
 
   it.effect("MixedScheduler is FIFO within a priority", () =>
     Effect.sync(() => {
-      const scheduler = new MixedScheduler("sync")
+      const scheduler = new Scheduler.MixedScheduler("sync")
       const order: Array<number> = []
 
       scheduler.scheduleTask(() => order.push(1), 5)
@@ -39,5 +39,32 @@ describe("Scheduler", () => {
       scheduler.flush()
 
       assert.deepStrictEqual(order, [1, 2, 3])
+    }))
+
+  it.effect("PreventSchedulerYield disables shouldYield checks", () =>
+    Effect.gen(function*() {
+      let calls = 0
+      const scheduler: Scheduler.Scheduler = {
+        executionMode: "sync",
+        scheduleTask: (task) => {
+          task()
+        },
+        shouldYield: () => {
+          calls++
+          return false
+        }
+      }
+
+      yield* Effect.sync(() => undefined).pipe(
+        Effect.provideService(Scheduler.Scheduler, scheduler)
+      )
+      assert.strictEqual(calls > 0, true)
+
+      calls = 0
+      yield* Effect.sync(() => undefined).pipe(
+        Effect.provideService(Scheduler.Scheduler, scheduler),
+        Effect.provideService(Scheduler.PreventSchedulerYield, true)
+      )
+      assert.strictEqual(calls, 0)
     }))
 })


### PR DESCRIPTION
## Summary
- add `Scheduler.PreventSchedulerYield` with default `false` and expose it from `References`
- cache the reference on fibers as `fiber.currentPreventYield`
- skip `scheduler.shouldYield` checks when `currentPreventYield` is `true`
- add a scheduler runtime test covering enabled vs disabled `shouldYield` checks
- add a changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Scheduler.test.ts
- pnpm check:tsgo
- pnpm docgen