### PR TITLE
EFF-653 Fix failureMode return tool calls with OpenAI codec transformer

### DIFF
--- a/.changeset/dirty-hats-help.md
+++ b/.changeset/dirty-hats-help.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Avoid applying provider codec transformations to toolkit handler result schemas so `failureMode: "return"` tool calls can return `AiError` values without OpenAI structured output conversion failures.

--- a/packages/effect/src/unstable/ai/Toolkit.ts
+++ b/packages/effect/src/unstable/ai/Toolkit.ts
@@ -53,9 +53,7 @@ import type * as Scope from "../../Scope.ts"
 import * as ServiceMap from "../../ServiceMap.ts"
 import * as Stream from "../../Stream.ts"
 import * as AiError from "./AiError.ts"
-import { CurrentCodecTransformer } from "./internal/codec-transformer.ts"
-import type { CodecTransformer } from "./LanguageModel.ts"
-import * as Tool from "./Tool.ts"
+import type * as Tool from "./Tool.ts"
 
 const TypeId = "~effect/ai/Toolkit" as const
 
@@ -298,24 +296,18 @@ const Proto = {
         readonly encodeResult: (u: unknown) => Effect.Effect<unknown, Schema.SchemaError>
       }>()
 
-      const getSchemas = (tool: Tool.Any, transformer: CodecTransformer) => {
+      const getSchemas = (tool: Tool.Any) => {
         let schemas = schemasCache.get(tool)
         if (Predicate.isUndefined(schemas)) {
           const handler = services.mapUnsafe.get(tool.id)! as Tool.Handler<any>
           const resultSchema = tool.failureMode === "return"
             ? Schema.Union([tool.successSchema, tool.failureSchema, AiError.AiError])
             : tool.successSchema
-          // Do not apply the codec transformation to provider defined tools,
-          // as these are defined internal to the Effect AI SDK and should
-          // already have valid schemas
-          const transformedResultSchema = Tool.isProviderDefined(tool)
-            ? resultSchema
-            : transformer(resultSchema).codec
           const decodeParameters = Schema.isSchema(tool.parametersSchema)
             ? Schema.decodeUnknownEffect(tool.parametersSchema) as any
             : (u: unknown) => Effect.succeed(u)
-          const decodeResult = Schema.decodeUnknownEffect(transformedResultSchema) as any
-          const encodeResult = Schema.encodeUnknownEffect(transformedResultSchema) as any
+          const decodeResult = Schema.decodeUnknownEffect(resultSchema) as any
+          const encodeResult = Schema.encodeUnknownEffect(resultSchema) as any
           schemas = {
             services: handler.services,
             handler: handler.handler,
@@ -349,8 +341,7 @@ const Proto = {
         }
 
         // Fetch cached schemas / handlers for the tool
-        const codecTransformer = yield* CurrentCodecTransformer
-        const schemas = getSchemas(tool, codecTransformer)
+        const schemas = getSchemas(tool)
 
         // Decode the tool call parameters which will be passed to the handler
         const decodedParams = yield* schemas.decodeParameters(params).pipe(

--- a/packages/effect/test/unstable/ai/Tool.test.ts
+++ b/packages/effect/test/unstable/ai/Tool.test.ts
@@ -3,6 +3,7 @@ import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/v
 import { DateTime, Effect, Fiber, identity, Latch, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { AiError, LanguageModel, Response, Tool, Toolkit } from "effect/unstable/ai"
+import { toCodecOpenAI } from "effect/unstable/ai/OpenAiStructuredOutput"
 import * as TestUtils from "./utils.ts"
 
 describe("Tool", () => {
@@ -205,6 +206,47 @@ describe("Tool", () => {
               method: "FailureModeReturn.handle",
               reason: { _tag: "RateLimitError", metadata: {} }
             }
+          })
+        ])
+      }))
+
+    it.effect("should support failureMode return with OpenAI codec transformer", () =>
+      Effect.gen(function*() {
+        const toolkit = Toolkit.make(FailureModeReturn)
+
+        const toolResult = { testFailure: "failure-mode-return-tool" }
+        const handlers = toolkit.toLayer({
+          FailureModeReturn: () => Effect.fail(toolResult)
+        })
+
+        const toolCallId = "tool-123"
+        const toolName = "FailureModeReturn"
+
+        const response = yield* LanguageModel.generateText({
+          prompt: "Test",
+          toolkit
+        }).pipe(
+          TestUtils.withLanguageModel({
+            generateText: [{
+              type: "tool-call",
+              id: toolCallId,
+              name: toolName,
+              params: { testParam: "test-param" }
+            }]
+          }),
+          Effect.provide(handlers),
+          Effect.provideService(LanguageModel.CurrentCodecTransformer, toCodecOpenAI)
+        )
+
+        deepStrictEqual(response.toolResults, [
+          Response.makePart("tool-result", {
+            id: toolCallId,
+            name: toolName,
+            isFailure: true,
+            result: toolResult,
+            encodedResult: toolResult,
+            providerExecuted: false,
+            preliminary: false
           })
         ])
       }))


### PR DESCRIPTION
## Summary
- Stop applying provider codec transformations to toolkit handler result schemas; keep result encoding/decoding on the original tool result schema.
- This avoids OpenAI structured-output AST conversion errors when `failureMode: \"return\"` unions include `AiError`.
- Add a regression test in `Tool.test.ts` that runs tool-call resolution with `LanguageModel.CurrentCodecTransformer` set to `toCodecOpenAI` and verifies `failureMode: \"return\"` still returns tool results.
- Add a patch changeset for `effect`.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/Tool.test.ts
- pnpm check:tsgo
- pnpm docgen