### PR TITLE
EFF-664 Add primitive for Effect.map

### DIFF
--- a/.changeset/large-shoes-hug.md
+++ b/.changeset/large-shoes-hug.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Optimize `Effect.map` with a dedicated runtime primitive to reduce intermediate allocations for pure mapping chains.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -79,6 +79,7 @@ import {
   exitSucceed,
   ExitTypeId,
   Fail,
+  identifier,
   InterruptorStackTrace,
   isCause,
   isDieReason,
@@ -1672,8 +1673,35 @@ export const map: {
   <A, E, R, B>(
     self: Effect.Effect<A, E, R>,
     f: (a: A) => B
-  ): Effect.Effect<B, E, R> => flatMap(self, (a) => succeed(internalCall(() => f(a))))
+  ): Effect.Effect<B, E, R> => mapPrimitive(self, f)
 )
+
+const mapPrimitive: <A, E, R, B>(
+  self: Effect.Effect<A, E, R>,
+  f: (a: A) => B
+) => Effect.Effect<B, E, R> = makePrimitive({
+  op: "Map",
+  single: false,
+  [evaluate](fiber): Primitive {
+    fiber._stack.push(this)
+    return this[args][0] as any
+  },
+  [contA](value, fiber): Primitive | Yield {
+    let mapped = internalCall(() => this[args][1](value))
+    let cont = fiber.getCont(contA)
+    while (cont) {
+      if (cont[identifier] !== "Map") {
+        return cont[contA](mapped, fiber)
+      }
+      const f = (cont as Primitive & {
+        readonly [args]: readonly [Effect.Effect<any, any, any>, (a: any) => any]
+      })[args][1]
+      mapped = internalCall(() => f(mapped))
+      cont = fiber.getCont(contA)
+    }
+    return fiber.yieldWith(exitSucceed(mapped))
+  }
+})
 
 /** @internal */
 export const mapEager: {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -69,6 +69,16 @@ describe("Effect", () => {
     assert.strictEqual(result, 1)
   })
 
+  it.effect("map is stack safe for long chains", () =>
+    Effect.gen(function*() {
+      let effect: Effect.Effect<number> = Effect.succeed(0)
+      for (let i = 0; i < 10_000; i++) {
+        effect = Effect.map(effect, (n) => n + 1)
+      }
+      const result = yield* effect
+      assert.strictEqual(result, 10_000)
+    }))
+
   it("acquireUseRelease interrupt", async () => {
     let acquire = false
     let use = false


### PR DESCRIPTION
## Summary
- add a dedicated `Map` primitive for `Effect.map` so pure mapping avoids allocating intermediate `succeed(...)` effects
- make map continuation forwarding iterative for consecutive `Map` frames to preserve stack safety on long map chains
- add a runtime regression in `Effect.test.ts` for a 10,000-step `Effect.map` chain and include a patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`