### PR TITLE
fix: remove ttl from swr combinator atom

### DIFF
--- a/.changeset/crisp-seas-warn.md
+++ b/.changeset/crisp-seas-warn.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+ensure transformed Atom's don't extend idle ttl

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1437,22 +1437,24 @@ export const transform: {
 } = dual(
   2,
   (<A, B>(self: Atom<A>, f: (get: Context, atom: Atom<A>) => B): Atom<B> =>
-    isWritable(self)
-      ? writable(
-        (get) => f(get, self),
-        function(ctx, value) {
-          ctx.set(self, value)
-        },
-        self.refresh ?? function(refresh) {
-          refresh(self)
-        }
-      )
-      : readable(
-        (get) => f(get, self),
-        self.refresh ?? function(refresh) {
-          refresh(self)
-        }
-      )) as any
+    removeTtl(
+      isWritable(self)
+        ? writable(
+          (get) => f(get, self),
+          function(ctx, value) {
+            ctx.set(self, value)
+          },
+          self.refresh ?? function(refresh) {
+            refresh(self)
+          }
+        )
+        : readable(
+          (get) => f(get, self),
+          self.refresh ?? function(refresh) {
+            refresh(self)
+          }
+        )
+    )) as any
 )
 
 /**
@@ -1594,10 +1596,7 @@ export const swr: {
     }
   ): Atom<AsyncResult.AsyncResult<A, E>> => {
     const staleTime = Duration.toMillis(Duration.fromInputUnsafe(options.staleTime))
-    const refresh = self.refresh ?? function(f: <A>(atom: Atom<A>) => void) {
-      f(self)
-    }
-    function read(get: Context) {
+    return transform(self, (get) => {
       const current = get.once(self)
       get.subscribe(self, (value) => {
         get.setSelf(value)
@@ -1622,12 +1621,7 @@ export const swr: {
         get.refresh(self)
       }
       return current
-    }
-    return (isWritable(self)
-      ? writable(read, (ctx, value) => {
-        ctx.set(self, value)
-      }, refresh)
-      : readable(read, refresh)).pipe(removeTtl)
+    })
   }
 ) as any
 


### PR DESCRIPTION
The swr combinator relies on the atom's read function, which won't get triggered if the atom is still alive. If the registry is configured with a `defaultIdleTTL`, the swr wrapper node survives unmount within the TTL window. And on remount the registry reuses the existing valid node, skipping swr.

This fix ensures the wrapper atom always opts out of TTL regardless of registry configuration.