### PR TITLE
EFF-668 Replace Effect.request resolver wrappers

### DIFF
--- a/.changeset/slow-berries-enjoy.md
+++ b/.changeset/slow-berries-enjoy.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Simplify internal and documented request usage by passing request resolvers directly to `Effect.request` instead of wrapping them with `Effect.succeed`.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7907,7 +7907,7 @@ export const withParentSpan: {
  * )
  *
  * const program = Effect.gen(function*() {
- *   const name = yield* Effect.request(GetUser({ id: 1 }), Effect.succeed(resolver))
+ *   const name = yield* Effect.request(GetUser({ id: 1 }), resolver)
  *   yield* Console.log(name)
  * })
  * ```

--- a/packages/effect/src/RequestResolver.ts
+++ b/packages/effect/src/RequestResolver.ts
@@ -181,7 +181,7 @@ const defaultKey = (_request: unknown): unknown => defaultKeyObject
  * )
  *
  * // Use the resolver to handle requests
- * const getUserEffect = Effect.request(GetUserRequest({ id: 123 }), Effect.succeed(UserResolver))
+ * const getUserEffect = Effect.request(GetUserRequest({ id: 123 }), UserResolver)
  * ```
  *
  * @since 2.0.0
@@ -276,7 +276,7 @@ const hashGroupKey = <A, K>(get: (entry: Request.Entry<A>) => K) => {
  * // Usage
  * const getSquareEffect = Effect.request(
  *   GetSquareRequest({ value: 5 }),
- *   Effect.succeed(SquareResolver)
+ *   SquareResolver
  * )
  * // Will resolve to 25
  * ```
@@ -319,7 +319,7 @@ export const fromFunction = <A extends Request.Any>(
  *
  * // Usage with multiple requests
  * const effects = [1, 2, 3].map((value) =>
- *   Effect.request(GetDoubleRequest({ value }), Effect.succeed(DoubleResolver))
+ *   Effect.request(GetDoubleRequest({ value }), DoubleResolver)
  * )
  * const batchedEffect = Effect.all(effects) // [2, 4, 6]
  * ```
@@ -370,7 +370,7 @@ export const fromFunctionBatched = <A extends Request.Any>(
  * // Usage
  * const getUserEffect = Effect.request(
  *   GetUserFromAPIRequest({ id: 123 }),
- *   Effect.succeed(UserAPIResolver)
+ *   UserAPIResolver
  * )
  * ```
  *
@@ -668,7 +668,7 @@ export const never: RequestResolver<never> = make(() => Effect.never)
  * // When more than 5 requests are made, they'll be split into multiple batches
  * const requests = Array.from(
  *   { length: 12 },
- *   (_, i) => Effect.request(GetDataRequest({ id: i }), Effect.succeed(limitedResolver))
+ *   (_, i) => Effect.request(GetDataRequest({ id: i }), limitedResolver)
  * )
  * ```
  *
@@ -718,15 +718,15 @@ export const batchN: {
  * const requests = [
  *   Effect.request(
  *     GetUserRequest({ userId: 1, department: "Engineering" }),
- *     Effect.succeed(groupedResolver)
+ *     groupedResolver
  *   ),
  *   Effect.request(
  *     GetUserRequest({ userId: 2, department: "Engineering" }),
- *     Effect.succeed(groupedResolver)
+ *     groupedResolver
  *   ),
  *   Effect.request(
  *     GetUserRequest({ userId: 3, department: "Marketing" }),
- *     Effect.succeed(groupedResolver)
+ *     groupedResolver
  *   )
  * ]
  * ```
@@ -841,7 +841,7 @@ export const race: {
  * )
  *
  * // Spans will automatically include batch size and request links
- * const effect = Effect.request(GetDataRequest({ id: 123 }), Effect.succeed(tracedResolver))
+ * const effect = Effect.request(GetDataRequest({ id: 123 }), tracedResolver)
  * ```
  *
  * @since 4.0.0
@@ -949,7 +949,7 @@ export const asCache: {
     capacity: options.capacity,
     timeToLive: options.timeToLive as any,
     requireServicesAt: options.requireServicesAt ?? "lookup" as ServiceMode,
-    lookup: (req: A) => internal.request(req, Effect.succeed(self))
+    lookup: (req: A) => internal.request(req, self)
   }) as any)
 
 /**

--- a/packages/effect/src/unstable/sql/SqlResolver.ts
+++ b/packages/effect/src/unstable/sql/SqlResolver.ts
@@ -51,9 +51,9 @@ export const request: {
 } = function() {
   if (arguments.length === 1) {
     const resolver = arguments[0]
-    return (payload: any) => Effect.request(SqlRequest(payload), Effect.succeed(resolver))
+    return (payload: any) => Effect.request(SqlRequest(payload), resolver)
   }
-  return Effect.request(SqlRequest(arguments[0]), Effect.succeed(arguments[1]))
+  return Effect.request(SqlRequest(arguments[0]), arguments[1])
 } as any
 
 /**


### PR DESCRIPTION
## Summary
- replace wrapped resolver call sites with direct resolver arguments in `SqlResolver.request` and `RequestResolver.asCache`
- update `Effect.request` / `RequestResolver` JSDoc examples to use `Effect.request(req, resolver)` instead of `Effect.succeed(resolver)` wrappers
- add a changeset for `effect` describing the cleanup

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Request.test.ts`
- `pnpm test packages/effect/test/unstable/sql/SqlSchema.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`