### PR TITLE
EFF-672 Ctrl-u should clear cli Prompt inputs

### DIFF
--- a/.changeset/clean-goats-wave.md
+++ b/.changeset/clean-goats-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Ctrl-U` line clearing support to editable CLI prompts.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2483,6 +2483,11 @@ const processNumberBackspace = (state: NumberState) => {
   }))
 }
 
+const processNumberClear = (state: NumberState) =>
+  Effect.succeed(Action.NextFrame({
+    state: { ...state, cursor: 0, value: "", error: undefined }
+  }))
+
 const defaultIntProcessor = (input: string, state: NumberState) => {
   if (state.value.length === 0 && input === "-") {
     return Effect.succeed(Action.NextFrame({
@@ -2536,6 +2541,9 @@ const handleRenderInteger = (options: IntegerOptionsReq) => {
 
 const handleProcessInteger = (options: IntegerOptionsReq) => {
   return (input: Terminal.UserInput, state: NumberState) => {
+    if (input.key.ctrl && input.key.name === "u") {
+      return processNumberClear(state)
+    }
     switch (input.key.name) {
       case "backspace": {
         return processNumberBackspace(state)
@@ -2606,6 +2614,9 @@ const handleRenderFloat = (options: FloatOptionsReq) => {
 
 const handleProcessFloat = (options: FloatOptionsReq) => {
   return (input: Terminal.UserInput, state: NumberState) => {
+    if (input.key.ctrl && input.key.name === "u") {
+      return processNumberClear(state)
+    }
     switch (input.key.name) {
       case "backspace": {
         return processNumberBackspace(state)
@@ -2956,6 +2967,9 @@ const processAutoCompleteBackspace = <A>(state: AutoCompleteState, options: Auto
   return Effect.succeed(Action.NextFrame({ state: updateAutoCompleteState(state, options, query) }))
 }
 
+const processAutoCompleteClear = <A>(state: AutoCompleteState, options: AutoCompleteOptionsReq<A>) =>
+  Effect.succeed(Action.NextFrame({ state: updateAutoCompleteState(state, options, "") }))
+
 const processAutoCompleteInput = <A>(input: string, state: AutoCompleteState, options: AutoCompleteOptionsReq<A>) => {
   if (input.length === 0) {
     return Effect.succeed(Action.Beep())
@@ -3039,6 +3053,9 @@ const handleSelectProcess = <A>(options: SelectOptionsReq<A>) => {
 
 const handleAutoCompleteProcess = <A>(options: AutoCompleteOptionsReq<A>) => {
   return (input: Terminal.UserInput, state: AutoCompleteState) => {
+    if (input.key.ctrl && input.key.name === "u") {
+      return processAutoCompleteClear(state, options)
+    }
     switch (input.key.name) {
       case "k":
       case "up": {
@@ -3211,6 +3228,13 @@ const processTextBackspace = (state: TextState) => {
   )
 }
 
+const processTextClear = (state: TextState) =>
+  Effect.succeed(
+    Action.NextFrame({
+      state: { ...state, cursor: 0, value: "", error: undefined }
+    })
+  )
+
 const processTextCursorLeft = (state: TextState) => {
   if (state.cursor <= 0) {
     return Effect.succeed(Action.Beep())
@@ -3272,6 +3296,9 @@ const handleTextRender = (options: TextOptionsReq) => {
 
 const handleTextProcess = (options: TextOptionsReq) => {
   return (input: Terminal.UserInput, state: TextState) => {
+    if (input.key.ctrl && input.key.name === "u") {
+      return processTextClear(state)
+    }
     switch (input.key.name) {
       case "backspace": {
         return processTextBackspace(state)

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -64,6 +64,19 @@ describe("Prompt.float", () => {
       assert.isTrue(rendered.includes("12.5"))
       assert.isFalse(rendered.includes("parsed"))
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("clears the current input on ctrl-u", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.float({ message: "Rate" })
+
+      yield* MockTerminal.inputText("12.5")
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputText("7.25")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, 7.25)
+    }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.text", () => {
@@ -79,6 +92,22 @@ describe("Prompt.text", () => {
 
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "Jane Doe")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("clears the current input on ctrl-u", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({
+        message: "Name",
+        default: "Jane"
+      })
+
+      yield* MockTerminal.inputText(" Doe")
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputText("John")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "John")
     }).pipe(Effect.provide(TestLayer)))
 })
 
@@ -152,6 +181,35 @@ describe("Prompt.autoComplete", () => {
       assert.isTrue(expandedFrame !== undefined)
       assert.isFalse(narrowedFrame?.includes("Beta"))
       assert.isTrue(expandedFrame?.includes("Beta"))
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("clears the filter input on ctrl-u", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.autoComplete({
+        message: "Pick item",
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" },
+          { title: "Delta", value: "delta" }
+        ]
+      })
+
+      yield* MockTerminal.inputText("al")
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "alpha")
+
+      const output = yield* TestConsole.logLines
+      const frames = toFrames(output)
+      const narrowedFrame = findFrame(frames, "[filter: al]")
+      const clearedFrame = findFrame(frames, "[filter: type to filter]")
+
+      assert.isTrue(narrowedFrame !== undefined)
+      assert.isTrue(clearedFrame !== undefined)
+      assert.isFalse(narrowedFrame?.includes("Beta"))
+      assert.isTrue(clearedFrame?.includes("Beta"))
     }).pipe(Effect.provide(TestLayer)))
 
   it.effect("renders empty message and beeps on submit with no matches", () =>


### PR DESCRIPTION
## Summary
- add Ctrl-U clearing for editable CLI prompt buffers in text/password, integer/float, and autocomplete prompts
- add prompt regressions covering text defaults, numeric input, and autocomplete filter clearing
- add a patch changeset for the prompt behavior fix

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Prompt.test.ts
- pnpm check:tsgo
- pnpm docgen