### PR TITLE
Tied stdout and stderr sinks lifecycle to layer's

### DIFF
--- a/.changeset/vast-deserts-travel.md
+++ b/.changeset/vast-deserts-travel.md
@@ -2,4 +2,4 @@
 "@effect/platform-node-shared": patch
 ---
 
-Made stdout and stderr sinks from node.js's Stdio be able to take elements from more than one stream, effectively tying them to layer lifecycle. Previously both of them called .end() on underlying process.stdout and process.stdin the moment the first stream finished
+Add `endOnDone` option to Stdio stdout / stderr

--- a/packages/effect/src/Stdio.ts
+++ b/packages/effect/src/Stdio.ts
@@ -27,8 +27,12 @@ export const TypeId: TypeId = "~effect/Stdio"
 export interface Stdio {
   readonly [TypeId]: TypeId
   readonly args: Effect.Effect<ReadonlyArray<string>>
-  readonly stdout: Sink.Sink<void, string | Uint8Array, never, PlatformError>
-  readonly stderr: Sink.Sink<void, string | Uint8Array, never, PlatformError>
+  stdout(options?: {
+    readonly endOnDone?: boolean | undefined
+  }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
+  stderr(options?: {
+    readonly endOnDone?: boolean | undefined
+  }): Sink.Sink<void, string | Uint8Array, never, PlatformError>
   readonly stdin: Stream.Stream<Uint8Array, PlatformError>
 }
 /**
@@ -55,8 +59,8 @@ export const layerTest = (impl: Partial<Stdio>): Layer.Layer<Stdio> =>
     Stdio,
     make({
       args: Effect.succeed([]),
-      stdout: Sink.drain,
-      stderr: Sink.drain,
+      stdout: () => Sink.drain,
+      stderr: () => Sink.drain,
       stdin: Stream.empty,
       ...impl
     })

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -1181,7 +1181,7 @@ export const makeProtocolStdio = Effect.gen(function*() {
     )
 
     yield* Stream.fromQueue(queue).pipe(
-      Stream.run(stdio.stdout),
+      Stream.run(stdio.stdout()),
       Effect.retry(Schedule.spaced(500)),
       Effect.forkScoped
     )

--- a/packages/platform-node-shared/src/NodeStdio.ts
+++ b/packages/platform-node-shared/src/NodeStdio.ts
@@ -12,24 +12,12 @@ import { fromReadable } from "./NodeStream.ts"
  * @category Layers
  * @since 1.0.0
  */
-export const layer: Layer.Layer<Stdio.Stdio> = Layer.effect(
+export const layer: Layer.Layer<Stdio.Stdio> = Layer.succeed(
   Stdio.Stdio,
-  Effect.gen(function* () {
-    yield* Effect.addFinalizer(() =>
-      Effect.callback<void>((resume) => {
-        process.stdout.once("finish", () => resume(Effect.void))
-        process.stdout.end()
-      })
-    )
-    yield* Effect.addFinalizer(() =>
-      Effect.callback<void>((resume) => {
-        process.stderr.once("finish", () => resume(Effect.void))
-        process.stderr.end()
-      })
-    )
-    return Stdio.make({
-      args: Effect.sync(() => process.argv.slice(2)),
-      stdout: fromWritable({
+  Stdio.make({
+    args: Effect.sync(() => process.argv.slice(2)),
+    stdout: (options) =>
+      fromWritable({
         evaluate: () => process.stdout,
         onError: (cause) =>
           systemError({
@@ -38,9 +26,10 @@ export const layer: Layer.Layer<Stdio.Stdio> = Layer.effect(
             _tag: "Unknown",
             cause
           }),
-        endOnDone: false
+        endOnDone: options?.endOnDone ?? true
       }),
-      stderr: fromWritable({
+    stderr: (options) =>
+      fromWritable({
         evaluate: () => process.stderr,
         onError: (cause) =>
           systemError({
@@ -49,19 +38,18 @@ export const layer: Layer.Layer<Stdio.Stdio> = Layer.effect(
             _tag: "Unknown",
             cause
           }),
-        endOnDone: false
+        endOnDone: options?.endOnDone ?? true
       }),
-      stdin: fromReadable({
-        evaluate: () => process.stdin,
-        onError: (cause) =>
-          systemError({
-            module: "Stdio",
-            method: "stdin",
-            _tag: "Unknown",
-            cause
-          }),
-        closeOnDone: false
-      })
+    stdin: fromReadable({
+      evaluate: () => process.stdin,
+      onError: (cause) =>
+        systemError({
+          module: "Stdio",
+          method: "stdin",
+          _tag: "Unknown",
+          cause
+        }),
+      closeOnDone: false
     })
   })
 )


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Repro made by Valentine in Telegram group https://t.me/fp_ts/10318

```ts
import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
import * as NodeServices from "@effect/platform-node/NodeServices";
import * as Effect from "effect/Effect";
import * as Stdio from "effect/Stdio";
import * as Stream from "effect/Stream";

const main = Effect.gen(function* () {
  const stdio = yield* Stdio.Stdio;

  const cmd = Effect.fnUntraced(function* () {
    yield* Stream.fromIterable(
      "wefwefwefwefwefwefwefwefwefwefwefwefwefwefwefwefwef",
    ).pipe(Stream.run(stdio.stdout));
    console.log("❌");
  });

  yield* cmd();
  yield* cmd();
  yield* cmd();
}).pipe(Effect.provide([NodeServices.layer]));

NodeRuntime.runMain(main);
```

The code above crashes when it attempts to pipe another stream into stdout. The PR fixes that

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
