### PR TITLE
EFF-676 Add HttpServerResponse.fromClientResponse

### DIFF
--- a/.changeset/chilled-mice-wash.md
+++ b/.changeset/chilled-mice-wash.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `HttpServerResponse.fromClientResponse` for directly converting client responses into server responses.

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -860,8 +860,11 @@ class ServerHttpClientResponse extends Inspectable.Class implements HttpClientRe
     return this.response.status
   }
 
+  private cachedHeaders?: Headers.Headers
   get headers(): Headers.Headers {
-    return this.response.headers
+    return this.cachedHeaders ??= this.response.body._tag === "FormData"
+      ? Headers.merge(this.response.headers, Headers.fromInput(this.getFormDataResponse().headers))
+      : this.response.headers
   }
 
   get cookies(): Cookies.Cookies {
@@ -909,8 +912,9 @@ class ServerHttpClientResponse extends Inspectable.Class implements HttpClientRe
         return Stream.unwrap(Effect.map(this.bytes, Stream.succeed))
       }
       case "FormData": {
+        const response = this.getFormDataResponse()
         return Stream.fromReadableStream({
-          evaluate: () => new Response(body.formData, { headers: this.headers }).body!,
+          evaluate: () => response.body!,
           onError: (cause) => this.decodeError(cause)
         })
       }
@@ -1012,12 +1016,51 @@ class ServerHttpClientResponse extends Inspectable.Class implements HttpClientRe
       })
     })
   }
+
+  private formDataResponse?: Response
+  private getFormDataResponse(): Response {
+    return this.formDataResponse ??= new Response((this.response.body as Body.FormData).formData)
+  }
 }
 
 const textDecoder = new TextDecoder()
 
+/**
+ * @since 4.0.0
+ * @category conversions
+ */
+export const fromClientResponse = (
+  response: HttpClientResponse.HttpClientResponse
+): HttpServerResponse => {
+  const headers = Headers.remove(response.headers, "set-cookie")
+  return makeResponse({
+    status: response.status,
+    headers,
+    cookies: response.cookies,
+    body: Body.stream(
+      Stream.catchIf(response.stream, isEmptyBodyError, () => Stream.empty),
+      Headers.get(headers, "content-type"),
+      getContentLength(headers)
+    )
+  })
+}
+
 const isReadableStream = (u: unknown): u is ReadableStream<Uint8Array> =>
   typeof ReadableStream !== "undefined" && u instanceof ReadableStream
+
+const isEmptyBodyError = (
+  error: HttpClientError.HttpClientError
+): error is HttpClientError.HttpClientError =>
+  HttpClientError.isHttpClientError(error) && error.reason._tag === "EmptyBodyError"
+
+const getContentLength = (headers: Headers.Headers): number | undefined => {
+  const contentLength = Headers.get(headers, "content-length")
+  if (contentLength === undefined) {
+    return undefined
+  }
+  const parsed = Number(contentLength)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
 
 const Proto: Omit<
   HttpServerResponse,

--- a/packages/effect/test/unstable/http/HttpServerResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpServerResponse.test.ts
@@ -1,51 +1,76 @@
-import { describe, test } from "@effect/vitest"
-import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { assert, describe, it } from "@effect/vitest"
 import { Effect, References, Stream } from "effect"
-import { HttpClientRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpClientRequest, HttpClientResponse, HttpServerResponse } from "effect/unstable/http"
 
 describe("HttpServerResponse", () => {
-  test("toClientResponse", async () => {
-    const request = HttpClientRequest.get("http://localhost:3000/todos/1")
-    const response = HttpServerResponse.jsonUnsafe({ foo: "bar" }, { status: 201 }).pipe(
-      HttpServerResponse.setHeader("x-test", "ok"),
-      HttpServerResponse.setCookieUnsafe("session", "123")
-    )
-    const clientResponse = HttpServerResponse.toClientResponse(response, { request })
+  it.effect("fromClientResponse preserves status, headers, cookies, and json", () =>
+    Effect.gen(function*() {
+      const request = HttpClientRequest.get("http://localhost:3000/todos/1")
+      const clientResponse = HttpServerResponse.toClientResponse(
+        HttpServerResponse.jsonUnsafe({ foo: "bar" }, { status: 201 }).pipe(
+          HttpServerResponse.setHeader("x-test", "ok"),
+          HttpServerResponse.setCookieUnsafe("session", "123")
+        ),
+        { request }
+      )
 
-    strictEqual(clientResponse.request, request)
-    strictEqual(clientResponse.status, 201)
-    strictEqual(clientResponse.headers["content-type"], "application/json")
-    strictEqual(clientResponse.headers["x-test"], "ok")
-    strictEqual(clientResponse.cookies.cookies.session?.value, "123")
-    deepStrictEqual(await Effect.runPromise(clientResponse.json), { foo: "bar" })
-  })
+      const response = HttpServerResponse.fromClientResponse(clientResponse)
+      const roundTrip = HttpServerResponse.toClientResponse(response, { request })
 
-  test("toClientResponse stream", async () => {
-    const clientResponse = HttpServerResponse.toClientResponse(
-      HttpServerResponse.stream(
-        Stream.fromEffect(References.CurrentConcurrency.asEffect()).pipe(
-          Stream.map(String),
-          Stream.encodeText
+      assert.strictEqual(response.status, 201)
+      assert.strictEqual(response.headers["content-type"], "application/json")
+      assert.strictEqual(response.headers["x-test"], "ok")
+      assert.strictEqual(response.headers["set-cookie"], undefined)
+      assert.strictEqual(response.cookies.cookies.session?.value, "123")
+      assert.deepStrictEqual(yield* roundTrip.json, { foo: "bar" })
+    }))
+
+  it.effect("fromClientResponse preserves stream requirements", () =>
+    Effect.gen(function*() {
+      const clientResponse = HttpServerResponse.toClientResponse(
+        HttpServerResponse.stream(
+          Stream.fromEffect(References.CurrentConcurrency.asEffect()).pipe(
+            Stream.map(String),
+            Stream.encodeText
+          )
         )
       )
-    )
 
-    strictEqual(
-      await Effect.runPromise(clientResponse.text.pipe(
+      const response = HttpServerResponse.fromClientResponse(clientResponse)
+      const roundTrip = HttpServerResponse.toClientResponse(response)
+      const text = yield* roundTrip.text.pipe(
         Effect.provideService(References.CurrentConcurrency, 420)
-      )),
-      "420"
-    )
-  })
+      )
 
-  test("toClientResponse formData", async () => {
-    const formData = new FormData()
-    formData.set("foo", "bar")
+      assert.strictEqual(text, "420")
+    }))
 
-    const clientResponse = HttpServerResponse.toClientResponse(
-      HttpServerResponse.formData(formData)
-    )
+  it.effect("fromClientResponse preserves formData bodies", () =>
+    Effect.gen(function*() {
+      const formData = new FormData()
+      formData.set("foo", "bar")
 
-    strictEqual((await Effect.runPromise(clientResponse.formData)).get("foo"), "bar")
-  })
+      const response = HttpServerResponse.fromClientResponse(
+        HttpServerResponse.toClientResponse(HttpServerResponse.formData(formData))
+      )
+      const roundTrip = HttpServerResponse.toClientResponse(response)
+      const parsed = yield* roundTrip.formData
+
+      assert.strictEqual(
+        response.headers["content-type"]?.startsWith("multipart/form-data; boundary="),
+        true
+      )
+      assert.strictEqual(parsed.get("foo"), "bar")
+    }))
+
+  it.effect("fromClientResponse turns empty client bodies into empty server streams", () =>
+    Effect.gen(function*() {
+      const request = HttpClientRequest.get("http://localhost:3000/empty")
+      const clientResponse = HttpClientResponse.fromWeb(request, new Response(null, { status: 200 }))
+      const response = HttpServerResponse.fromClientResponse(clientResponse)
+      const roundTrip = HttpServerResponse.toClientResponse(response, { request })
+
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(yield* roundTrip.text, "")
+    }))
 })


### PR DESCRIPTION
## Summary
- add `HttpServerResponse.fromClientResponse` as a direct client-response to server-response conversion
- preserve cookies, headers, empty bodies, and stream-backed bodies without routing through web conversions
- cover json, stream, form-data, and empty-body round trips in `HttpServerResponse` tests

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpServerResponse.test.ts
- pnpm check:tsgo
- pnpm docgen