### PR TITLE
EFF-678 Remove placeholder text from Prompt inputs

### DIFF
--- a/.changeset/silver-emus-smoke.md
+++ b/.changeset/silver-emus-smoke.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove placeholder fallback behavior from CLI prompt inputs now that default values are prefilled.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -3102,10 +3102,6 @@ interface TextState {
   readonly error: string | undefined
 }
 
-const getValue = (state: TextState, options: TextOptionsReq): string => {
-  return state.value.length > 0 ? state.value : options.default
-}
-
 const renderClearScreen = Effect.fnUntraced(function*(state: TextState, options: TextOptionsReq) {
   const terminal = yield* Terminal.Terminal
   const columns = yield* terminal.columns
@@ -3126,7 +3122,7 @@ const renderTextInput = (
   submitted: boolean,
   renderOptions?: RenderOptions | undefined
 ) => {
-  const text = getValue(nextState, options)
+  const text = nextState.value
   if (renderOptions?.plain === true) {
     switch (options.type) {
       case "hidden": {
@@ -3263,11 +3259,10 @@ const processTab = (state: TextState, options: TextOptionsReq) => {
   if (state.value === options.default) {
     return Effect.succeed(Action.Beep())
   }
-  const value = getValue(state, options)
-  const cursor = value.length
+  const value = state.value.length === 0 ? options.default : state.value
   return Effect.succeed(
     Action.NextFrame({
-      state: { ...state, value, cursor, error: undefined }
+      state: { ...state, value, cursor: value.length, error: undefined }
     })
   )
 }
@@ -3311,7 +3306,7 @@ const handleTextProcess = (options: TextOptionsReq) => {
       }
       case "enter":
       case "return": {
-        const value = getValue(state, options)
+        const value = state.value
         return Effect.match(options.validate(value), {
           onFailure: (error) =>
             Action.NextFrame({

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -109,6 +109,27 @@ describe("Prompt.text", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, "John")
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not render or submit the cleared default value", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({
+        message: "Name",
+        default: "Jane"
+      })
+
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "")
+
+      const output = yield* TestConsole.logLines
+      const frames = toFrames(output)
+      const lastFrame = frames.at(-1)
+
+      assert.isTrue(lastFrame !== undefined)
+      assert.isFalse(lastFrame?.includes("Jane"))
+    }).pipe(Effect.provide(TestLayer)))
 })
 
 describe("Prompt.password", () => {
@@ -124,6 +145,20 @@ describe("Prompt.password", () => {
 
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(Redacted.value(result), "secret123")
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("does not submit the cleared default value", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.password({
+        message: "Password",
+        default: "secret"
+      })
+
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(Redacted.value(result), "")
     }).pipe(Effect.provide(TestLayer)))
 })
 


### PR DESCRIPTION
## Summary
- remove the fallback placeholder/default rendering path from CLI text prompt inputs now that defaults are prefilled
- keep cleared text and password prompts empty on submit instead of restoring the previous default value
- add CLI prompt regressions for clearing prefilled defaults and include a patch changeset
