### PR TITLE
EFF-680: abort HttpClient requests after partial stream consumption

### DIFF
--- a/.changeset/itchy-radios-poke.md
+++ b/.changeset/itchy-radios-poke.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Abort HTTP client requests when response streams are consumed only partially.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -6,7 +6,6 @@ import * as Cause from "../../Cause.ts"
 import { Clock } from "../../Clock.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
-import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
 import { constant, constFalse, constTrue, dual, flow, identity } from "../../Function.ts"
 import * as Inspectable from "../../Inspectable.ts"
@@ -1469,12 +1468,12 @@ class InterruptibleResponse implements HttpClientResponse.HttpClientResponse {
   get stream() {
     return Stream.suspend(() => {
       responseRegistry.unregister(this.original)
-      return Stream.onExit(this.original.stream, (exit) => {
-        if (Exit.hasInterrupts(exit)) {
+      return Stream.ensuring(
+        this.original.stream,
+        Effect.sync(() => {
           this.controller.abort()
-        }
-        return Effect.void
-      })
+        })
+      )
     })
   }
 

--- a/packages/effect/test/unstable/http/HttpClient.test.ts
+++ b/packages/effect/test/unstable/http/HttpClient.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
-import { Effect, Fiber, Layer, Ref } from "effect"
+import { Effect, Fiber, Layer, Ref, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { RateLimiter } from "effect/unstable/persistence"
@@ -34,6 +34,38 @@ describe("HttpClient", () => {
         const retryClient = client.pipe(HttpClient.retryTransient({ retryOn: "errors-only", times: 2 }))
         yield* retryClient.get("http://test/").pipe(Effect.ignore)
         strictEqual(yield* Ref.get(attempts), 1)
+      }))
+  })
+
+  describe("stream", () => {
+    it.effect("aborts the request when the response stream ends early", () =>
+      Effect.gen(function*() {
+        let signal: AbortSignal | undefined
+        const client = HttpClient.make((request, _url, requestSignal) =>
+          Effect.sync(() => {
+            signal = requestSignal
+            return HttpClientResponse.fromWeb(
+              request,
+              new Response(
+                new ReadableStream<Uint8Array>({
+                  pull(controller) {
+                    controller.enqueue(Uint8Array.of(1))
+                  }
+                }),
+                { status: 200 }
+              )
+            )
+          })
+        )
+
+        const response = yield* client.get("http://test/")
+        const chunks = yield* response.stream.pipe(
+          Stream.take(5),
+          Stream.runCollect
+        )
+
+        assert.strictEqual(Array.from(chunks).length, 5)
+        assert.isTrue(signal!.aborted)
       }))
   })
 


### PR DESCRIPTION
## Summary
- abort `HttpClient` request controllers whenever a response stream finalizes, so partial consumers such as `Stream.take(5)` clean up in-flight requests
- add regression coverage for early stream termination and include a patch changeset for the `effect` package