### PR TITLE
Add message option to Effect.ignore and Effect.ignoreCause

### DIFF
--- a/.changeset/lucky-buttons-jump.md
+++ b/.changeset/lucky-buttons-jump.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add an optional `message` field to `Effect.ignore` and `Effect.ignoreCause` for custom log output.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4155,7 +4155,8 @@ export const sandbox: <A, E, R>(
  * it succeeds or fails. This is useful when you only care about the side
  * effects of the effect and do not need to handle or process its outcome.
  *
- * Use the `log` option to emit the full {@link Cause} when the effect fails.
+ * Use the `log` option to emit the full {@link Cause} when the effect fails,
+ * and `message` to prepend a custom log message.
  *
  * @example
  * ```ts
@@ -4179,7 +4180,7 @@ export const sandbox: <A, E, R>(
  * const task = Effect.fail("Uh oh!")
  *
  * const program = task.pipe(Effect.ignore({ log: true }))
- * const programWarn = task.pipe(Effect.ignore({ log: "Warn" }))
+ * const programWarn = task.pipe(Effect.ignore({ log: "Warn", message: "Ignoring task failure" }))
  * ```
  *
  * **Previously Known As**
@@ -4194,13 +4195,16 @@ export const sandbox: <A, E, R>(
 export const ignore: <
   Arg extends Effect<any, any, any> | {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   } | undefined = {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   }
 >(
   effectOrOptions?: Arg,
   options?: {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   } | undefined
 ) => [Arg] extends [Effect<infer _A, infer _E, infer _R>] ? Effect<void, never, _R>
   : <A, E, R>(self: Effect<A, E, R>) => Effect<void, never, R> = internal.ignore
@@ -4208,7 +4212,8 @@ export const ignore: <
 /**
  * Ignores the effect's failure cause, including defects and interruptions.
  *
- * Use the `log` option to emit the full {@link Cause} when the effect fails.
+ * Use the `log` option to emit the full {@link Cause} when the effect fails,
+ * and `message` to prepend a custom log message.
  *
  * @example
  * ```ts
@@ -4217,7 +4222,7 @@ export const ignore: <
  * const task = Effect.fail("boom")
  *
  * const program = task.pipe(Effect.ignoreCause)
- * const programLog = task.pipe(Effect.ignoreCause({ log: true }))
+ * const programLog = task.pipe(Effect.ignoreCause({ log: true, message: "Ignoring failure cause" }))
  * ```
  *
  * @since 4.0.0
@@ -4226,13 +4231,16 @@ export const ignore: <
 export const ignoreCause: <
   Arg extends Effect<any, any, any> | {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   } | undefined = {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   }
 >(
   effectOrOptions?: Arg,
   options?: {
     readonly log?: boolean | Severity | undefined
+    readonly message?: string | undefined
   } | undefined
 ) => [Arg] extends [Effect<infer _A, infer _E, infer _R>] ? Effect<void, never, _R>
   : <A, E, R>(self: Effect<A, E, R>) => Effect<void, never, R> = internal.ignoreCause

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3182,13 +3182,16 @@ export const eventually = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect
 export const ignore: <
   Arg extends Effect.Effect<any, any, any> | {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   } | undefined = {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   }
 >(
   effectOrOptions: Arg,
   options?: {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   } | undefined
 ) => [Arg] extends [Effect.Effect<infer _A, infer _E, infer _R>] ? Effect.Effect<void, never, _R>
   : <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<void, never, R> = dual(
@@ -3197,6 +3200,7 @@ export const ignore: <
       self: Effect.Effect<A, E, R>,
       options?: {
         readonly log?: boolean | LogLevel.Severity | undefined
+        readonly message?: string | undefined
       } | undefined
     ): Effect.Effect<void, never, R> => {
       if (!options?.log) {
@@ -3206,7 +3210,11 @@ export const ignore: <
       return matchCauseEffect(self, {
         onFailure(cause) {
           const failure = findFail(cause)
-          return Result.isFailure(failure) ? failCause(failure.failure) : logEffect(cause)
+          return Result.isFailure(failure)
+            ? failCause(failure.failure)
+            : options.message === undefined
+            ? logEffect(cause)
+            : logEffect(options.message, cause)
         },
         onSuccess: (_) => void_
       })
@@ -3217,13 +3225,16 @@ export const ignore: <
 export const ignoreCause: <
   Arg extends Effect.Effect<any, any, any> | {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   } | undefined = {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   }
 >(
   effectOrOptions: Arg,
   options?: {
     readonly log?: boolean | LogLevel.Severity | undefined
+    readonly message?: string | undefined
   } | undefined
 ) => [Arg] extends [Effect.Effect<infer _A, infer _E, infer _R>] ? Effect.Effect<void, never, _R>
   : <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<void, never, R> = dual(
@@ -3232,13 +3243,17 @@ export const ignoreCause: <
       self: Effect.Effect<A, E, R>,
       options?: {
         readonly log?: boolean | LogLevel.Severity | undefined
+        readonly message?: string | undefined
       } | undefined
     ): Effect.Effect<void, never, R> => {
       if (!options?.log) {
         return matchCauseEffect(self, { onFailure: (_) => void_, onSuccess: (_) => void_ })
       }
       const logEffect = logWithLevel(options.log === true ? undefined : options.log)
-      return matchCauseEffect(self, { onFailure: logEffect, onSuccess: (_) => void_ })
+      return matchCauseEffect(self, {
+        onFailure: (cause) => options.message === undefined ? logEffect(cause) : logEffect(options.message, cause),
+        onSuccess: (_) => void_
+      })
     }
   )
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1487,15 +1487,16 @@ describe("Effect", () => {
   })
 
   describe("Effect.ignore", () => {
-    type IgnoreOptions = { readonly log?: boolean | LogLevel.Severity }
+    type IgnoreOptions = { readonly log?: boolean | LogLevel.Severity; readonly message?: string }
 
     const makeTestLogger = () => {
       const capturedLogs: Array<{
         readonly logLevel: LogLevel.LogLevel
         readonly cause: Cause.Cause<unknown>
+        readonly message: unknown
       }> = []
       const testLogger = Logger.make<unknown, void>((options) => {
-        capturedLogs.push({ logLevel: options.logLevel, cause: options.cause })
+        capturedLogs.push({ logLevel: options.logLevel, cause: options.cause, message: options.message })
       })
       return { capturedLogs, testLogger }
     }
@@ -1541,18 +1542,27 @@ describe("Effect", () => {
         assert.strictEqual(logs[0].logLevel, "Error")
         assertCauseFail(logs[0].cause, "boom")
       }))
+
+    it.effect("prepends the provided message when logging", () =>
+      Effect.gen(function*() {
+        const logs = yield* runIgnore({ log: true, message: "Ignoring failure" })
+        assert.strictEqual(logs.length, 1)
+        assert.deepStrictEqual(logs[0].message, ["Ignoring failure"])
+        assertCauseFail(logs[0].cause, "boom")
+      }))
   })
 
   describe("Effect.ignoreCause", () => {
-    type IgnoreCauseOptions = { readonly log?: boolean | LogLevel.Severity }
+    type IgnoreCauseOptions = { readonly log?: boolean | LogLevel.Severity; readonly message?: string }
 
     const makeTestLogger = () => {
       const capturedLogs: Array<{
         readonly logLevel: LogLevel.LogLevel
         readonly cause: Cause.Cause<unknown>
+        readonly message: unknown
       }> = []
       const testLogger = Logger.make<unknown, void>((options) => {
-        capturedLogs.push({ logLevel: options.logLevel, cause: options.cause })
+        capturedLogs.push({ logLevel: options.logLevel, cause: options.cause, message: options.message })
       })
       return { capturedLogs, testLogger }
     }
@@ -1608,6 +1618,14 @@ describe("Effect", () => {
         const logs = yield* runIgnoreCause({ log: "Error" }, "Warn")
         assert.strictEqual(logs.length, 1)
         assert.strictEqual(logs[0].logLevel, "Error")
+        assertCauseFail(logs[0].cause, "boom")
+      }))
+
+    it.effect("prepends the provided message when logging", () =>
+      Effect.gen(function*() {
+        const logs = yield* runIgnoreCause({ log: true, message: "Ignoring cause" })
+        assert.strictEqual(logs.length, 1)
+        assert.deepStrictEqual(logs[0].message, ["Ignoring cause"])
         assertCauseFail(logs[0].cause, "boom")
       }))
   })


### PR DESCRIPTION
## Summary
- add an optional `message` field to `Effect.ignore` and `Effect.ignoreCause`
- prepend the custom message when logging ignored failures while preserving existing cause logging behavior
- add tests and a patch changeset for the new option