### PR TITLE
feat: add force stale functionality to swr combinator

### DIFF
--- a/.changeset/silent-badgers-refuse.md
+++ b/.changeset/silent-badgers-refuse.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Exposes a markStale() function on swr combinator that forcibly marks cached data as stale. The next mount or focus will trigger a refresh. Unlike the registry's invalidate, this doesn't refresh immediately. So some kind of lazy invalidation.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1580,6 +1580,38 @@ export const withRefresh: {
   }
 )
 
+// -----------------------------------------------------------------------------
+// SWR
+// -----------------------------------------------------------------------------
+
+/**
+ * @since 4.0.0
+ * @category SWR
+ */
+export const SWRTypeId: SWRTypeId = "~effect/reactivity/Atom/SWR"
+
+/**
+ * @since 4.0.0
+ * @category SWR
+ */
+export type SWRTypeId = "~effect/reactivity/Atom/SWR"
+
+/**
+ * @since 4.0.0
+ * @category SWR
+ */
+export interface SWR {
+  readonly [SWRTypeId]: {
+    readonly markStale: () => void
+  }
+}
+
+/**
+ * @since 4.0.0
+ * @category SWR
+ */
+export const isSWR = (self: Atom<any>): self is Atom<any> & SWR => SWRTypeId in self
+
 /**
  * Adds stale-while-revalidate refresh behavior to an async result atom.
  *
@@ -1624,9 +1656,12 @@ export const swr: {
     }
   ): Atom<AsyncResult.AsyncResult<A, E>> => {
     const staleTime = Duration.toMillis(Duration.fromInputUnsafe(options.staleTime))
-    return transform(self, (get) => {
+    let forceStale = false
+
+    const atom = transform(self, (get) => {
       const current = get.once(self)
       get.subscribe(self, (value) => {
+        if (!value.waiting) forceStale = false
         get.setSelf(value)
       })
       if (options.revalidateOnFocus && options.focusSignal) {
@@ -1635,7 +1670,8 @@ export const swr: {
           options.focusSignal,
           options.revalidateOnFocus === "always" ? () => get.refresh(self) : () => {
             const current = get.once(self)
-            if (shouldRevalidateSWR(current, staleTime)) {
+            if (forceStale || shouldRevalidateSWR(current, staleTime)) {
+              forceStale = false
               get.refresh(self)
             }
           }
@@ -1645,11 +1681,21 @@ export const swr: {
       if (firstRead && options.revalidateOnMount === false) {
         return current
       }
-      if (shouldRevalidateSWR(current, staleTime)) {
+      if (forceStale || shouldRevalidateSWR(current, staleTime)) {
+        forceStale = false
         get.refresh(self)
       }
       return current
     }, { initialValueTarget: self })
+
+    return Object.assign(Object.create(Object.getPrototypeOf(atom)), {
+      ...atom,
+      [SWRTypeId]: {
+        markStale: () => {
+          forceStale = true
+        }
+      }
+    })
   }
 ) as any
 

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -1634,7 +1634,7 @@ export const swr: {
       readonly revalidateOnFocus?: boolean | "always" | undefined
       readonly focusSignal?: Atom<any> | undefined
     }
-  ): <R extends Atom<AsyncResult.AsyncResult<any, any>>>(self: R) => WithoutSerializable<R>
+  ): <R extends Atom<AsyncResult.AsyncResult<any, any>>>(self: R) => WithoutSerializable<R> & SWR
   <R extends Atom<AsyncResult.AsyncResult<any, any>>>(
     self: R,
     options: {
@@ -1643,7 +1643,7 @@ export const swr: {
       readonly revalidateOnFocus?: boolean | "always" | undefined
       readonly focusSignal?: Atom<any> | undefined
     }
-  ): WithoutSerializable<R>
+  ): WithoutSerializable<R> & SWR
 } = dual(
   2,
   <A, E>(

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -1885,6 +1885,61 @@ describe.sequential("Atom", () => {
     assert.strictEqual(runs, 2)
   })
 
+  test(`swr markStale triggers refresh on next remount`, () => {
+    const r = AtomRegistry.make()
+    let runs = 0
+    const base = Atom.make(Effect.sync(() => ++runs)).pipe(Atom.keepAlive)
+    const atom = base.pipe(Atom.swr({ staleTime: 10_000, revalidateOnMount: true }))
+
+    const unmount1 = r.mount(atom)
+    let result = r.get(atom)
+    assert(AsyncResult.isSuccess(result))
+    assert.strictEqual(result.value, 1)
+    assert.strictEqual(runs, 1)
+    unmount1()
+
+    assert(Atom.isSWR(atom))
+    atom[Atom.SWRTypeId].markStale()
+
+    const unmount2 = r.mount(atom)
+    result = r.get(atom)
+    assert(AsyncResult.isSuccess(result))
+    assert.strictEqual(result.value, 2)
+    assert.strictEqual(runs, 2)
+    unmount2()
+  })
+
+  test(`swr markStale triggers refresh on focus signal`, () => {
+    const r = AtomRegistry.make()
+    const focusSignal = Atom.make(0)
+    let focus = 0
+    const emitFocus = () => r.set(focusSignal, ++focus)
+    let runs = 0
+    const atom = Atom.make(Effect.sync(() => ++runs)).pipe(
+      Atom.swr({ staleTime: 10_000, revalidateOnFocus: true, focusSignal })
+    )
+    const unmount = r.mount(atom)
+
+    let result = r.get(atom)
+    assert(AsyncResult.isSuccess(result))
+    assert.strictEqual(result.value, 1)
+    assert.strictEqual(runs, 1)
+
+    emitFocus()
+    result = r.get(atom)
+    assert.strictEqual(runs, 1)
+
+    assert(Atom.isSWR(atom))
+    atom[Atom.SWRTypeId].markStale()
+    emitFocus()
+    result = r.get(atom)
+    assert(AsyncResult.isSuccess(result))
+    assert.strictEqual(result.value, 2)
+    assert.strictEqual(runs, 2)
+
+    unmount()
+  })
+
   // it("dehydrate", async () => {
   //   const r = AtomRegistry.make()
   //   const notSerializable = Atom.make(0)

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -1885,7 +1885,7 @@ describe.sequential("Atom", () => {
     assert.strictEqual(runs, 2)
   })
 
-  test(`swr markStale triggers refresh on next remount`, () => {
+  test(`swr markStale triggers refresh on next remount`, async () => {
     const r = AtomRegistry.make()
     let runs = 0
     const base = Atom.make(Effect.sync(() => ++runs)).pipe(Atom.keepAlive)
@@ -1897,6 +1897,8 @@ describe.sequential("Atom", () => {
     assert.strictEqual(result.value, 1)
     assert.strictEqual(runs, 1)
     unmount1()
+
+    await Effect.runPromise(Effect.yieldNow)
 
     assert(Atom.isSWR(atom))
     atom[Atom.SWRTypeId].markStale()


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Exposes a `markStale()` function on swr combinator that forcibly marks cached data as stale. The next mount or focus will trigger a refresh. Unlike the registry's `invalidate`, this doesn't refresh immediately. So some kind of lazy invalidation.

Adds `SWRTypeId`, `SWR` interface, and `isSWR` guard.