### PR TITLE
EFF-683 Fix fragmented streaming tool calls in openai-compat

### DIFF
--- a/.changeset/blue-onions-smile.md
+++ b/.changeset/blue-onions-smile.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Preserve streamed OpenAI compat tool call ids and names across fragmented chat completion chunks.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -896,11 +896,23 @@ const ChatCompletionToolFunction = Schema.Struct({
   arguments: Schema.optionalKey(Schema.String)
 })
 
+const ChatCompletionToolFunctionDelta = Schema.Struct({
+  name: Schema.optionalKey(Schema.String),
+  arguments: Schema.optionalKey(Schema.String)
+})
+
 const ChatCompletionToolCall = Schema.Struct({
   id: Schema.optionalKey(Schema.String),
   index: Schema.optionalKey(Schema.Number),
   type: Schema.optionalKey(Schema.String),
   function: Schema.optionalKey(ChatCompletionToolFunction)
+})
+
+const ChatCompletionToolCallDelta = Schema.Struct({
+  id: Schema.optionalKey(Schema.String),
+  index: Schema.optionalKey(Schema.Number),
+  type: Schema.optionalKey(Schema.String),
+  function: Schema.optionalKey(ChatCompletionToolFunctionDelta)
 })
 
 const ChatCompletionMessage = Schema.Struct({
@@ -912,7 +924,7 @@ const ChatCompletionMessage = Schema.Struct({
 const ChatCompletionDelta = Schema.Struct({
   role: Schema.optionalKey(Schema.String),
   content: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
+  tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCallDelta))
 })
 
 const ChatCompletionChoice = Schema.Struct({

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -979,11 +979,13 @@ const makeStreamResponse = Effect.fnUntraced(
           hasToolCalls = hasToolCalls || choice.delta.tool_calls.length > 0
           choice.delta.tool_calls.forEach((deltaTool, indexInChunk) => {
             const toolIndex = deltaTool.index ?? indexInChunk
-            const toolId = deltaTool.id ?? `${event.id}_tool_${toolIndex}`
-            const providerToolName = deltaTool.function?.name
-            const toolName = toolNameMapper.getCustomName(providerToolName ?? "unknown_tool")
-            const argumentsDelta = deltaTool.function?.arguments ?? ""
             const activeToolCall = activeToolCalls[toolIndex]
+            const toolId = activeToolCall?.id ?? deltaTool.id ?? `${event.id}_tool_${toolIndex}`
+            const providerToolName = deltaTool.function?.name
+            const toolName = providerToolName !== undefined
+              ? toolNameMapper.getCustomName(providerToolName)
+              : activeToolCall?.name ?? toolNameMapper.getCustomName("unknown_tool")
+            const argumentsDelta = deltaTool.function?.arguments ?? ""
 
             if (Predicate.isUndefined(activeToolCall)) {
               activeToolCalls[toolIndex] = {

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -750,6 +750,127 @@ describe("OpenAiLanguageModel", () => {
         })
       }))
 
+    it.effect("preserves fragmented stream tool call ids and names", () =>
+      Effect.gen(function*() {
+        const expectedParams = {
+          call_id: "patch_call_2",
+          operation: {
+            type: "delete_file",
+            path: "src/fragmented.ts"
+          }
+        }
+        const toolArguments = JSON.stringify(expectedParams)
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  id: "chatcmpl_apply_patch_fragmented_1",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        id: "patch_call_2",
+                        type: "function",
+                        function: {
+                          name: "apply_patch",
+                          arguments: toolArguments.slice(0, 24)
+                        }
+                      }]
+                    },
+                    finish_reason: null
+                  }]
+                },
+                {
+                  id: "chatcmpl_apply_patch_fragmented_1",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        function: {
+                          arguments: toolArguments.slice(24, 48)
+                        }
+                      }]
+                    },
+                    finish_reason: null
+                  }]
+                },
+                {
+                  id: "chatcmpl_apply_patch_fragmented_1",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{
+                    index: 0,
+                    delta: {
+                      tool_calls: [{
+                        index: 0,
+                        function: {
+                          arguments: toolArguments.slice(48)
+                        }
+                      }]
+                    },
+                    finish_reason: "tool_calls"
+                  }]
+                },
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const toolkit = Toolkit.make(CompatApplyPatchTool({}))
+        const toolkitLayer = toolkit.toLayer({
+          CompatApplyPatch: () =>
+            Effect.succeed({
+              status: "completed",
+              output: "deleted"
+            })
+        })
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "Delete src/fragmented.ts",
+          toolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(toolkitLayer),
+          Effect.provide(layer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+
+        const start = parts.find((part) => part.type === "tool-params-start" && part.id === "patch_call_2")
+        assert.isDefined(start)
+        if (start?.type !== "tool-params-start") {
+          return
+        }
+        assert.strictEqual(start.name, "CompatApplyPatch")
+
+        assert.deepStrictEqual(decodeToolParamsFromStream(parts, "patch_call_2"), expectedParams)
+
+        const toolCall = parts.find((part) => part.type === "tool-call")
+        assert.isDefined(toolCall)
+        if (toolCall?.type !== "tool-call") {
+          return
+        }
+
+        assert.strictEqual(toolCall.id, "patch_call_2")
+        assert.strictEqual(toolCall.name, "CompatApplyPatch")
+        assert.deepStrictEqual(toolCall.params, expectedParams)
+      }))
+
     it.effect("streams known events and ignores unknown ones", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
@@ -976,6 +1097,23 @@ const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
     }
     return yield* Effect.die(new Error("Expected Uint8Array body"))
   })
+
+const decodeToolParamsFromStream = (
+  parts: ReadonlyArray<any>,
+  toolCallId: string
+): Record<string, unknown> => {
+  const start = parts.find((part) => part.type === "tool-params-start" && part.id === toolCallId)
+  const end = parts.find((part) => part.type === "tool-params-end" && part.id === toolCallId)
+  assert.isDefined(start)
+  assert.isDefined(end)
+
+  const deltas = parts
+    .filter((part) => part.type === "tool-params-delta" && part.id === toolCallId)
+    .map((part) => part.delta)
+    .join("")
+
+  return JSON.parse(deltas) as Record<string, unknown>
+}
 
 const toSseBody = (events: ReadonlyArray<unknown>): string =>
   events.map((event) => {


### PR DESCRIPTION
## Summary
- relax the OpenAI compat chat-completions stream schema so fragmented `tool_calls` deltas with arguments-only payloads still decode
- preserve the first streamed tool-call id and name while later chunks append arguments, avoiding fallback ids and `unknown_tool` names
- add a regression test covering fragmented `apply_patch` stream chunks and include a changeset for `@effect/ai-openai-compat`

## Testing
- pnpm lint-fix
- pnpm test packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
- pnpm test packages/ai/openai-compat/test/OpenAiClient.test.ts
- pnpm check:tsgo
- pnpm docgen