### PR TITLE
EFF-687 Fix toolkit tool requirements inference

### DIFF
--- a/.changeset/strong-balloons-tickle.md
+++ b/.changeset/strong-balloons-tickle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Include toolkit tool handler requirements in AI generation API environment inference.

--- a/packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts
+++ b/packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts
@@ -1,5 +1,4 @@
-import type { Effect } from "effect"
-import { Schema } from "effect"
+import { Effect, Schema, ServiceMap } from "effect"
 import { type AiError, LanguageModel, Tool, Toolkit } from "effect/unstable/ai"
 import { describe, expect, it } from "tstyche"
 
@@ -15,6 +14,24 @@ const FailureModeErrorTool = Tool.make("FailureModeErrorTool", {
   })
 })
 
+class RequestContext extends ServiceMap.Service<RequestContext, {
+  readonly requestId: string
+}>()("RequestContext") {}
+
+class ToolkitContext extends ServiceMap.Service<ToolkitContext, {
+  readonly tenantId: string
+}>()("ToolkitContext") {}
+
+const ToolWithRequestContext = Tool.make("ToolWithRequestContext", {
+  parameters: Schema.Struct({
+    input: Schema.String
+  }),
+  success: Schema.Struct({
+    output: Schema.String
+  }),
+  dependencies: [RequestContext]
+})
+
 describe("LanguageModel", () => {
   describe("generateText", () => {
     it("tool handlers do not leak AiErrorReason into the error channel", () => {
@@ -28,6 +45,56 @@ describe("LanguageModel", () => {
 
       expect<ProgramError>().type.toBe<AiError.AiError | { readonly message: string }>()
       expect<Extract<ProgramError, AiError.AiErrorReason>>().type.toBe<never>()
+    })
+
+    it("includes tool request dependencies when a toolkit is provided", () => {
+      const toolkit = Toolkit.make(ToolWithRequestContext)
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type ProgramRequirements = typeof program extends Effect.Effect<any, any, infer R> ? R : never
+
+      expect<ProgramRequirements>().type.toBe<
+        LanguageModel.LanguageModel | RequestContext | Tool.HandlersFor<Toolkit.Tools<typeof toolkit>>
+      >()
+    })
+
+    it("includes tool request dependencies for resolved toolkits with handlers", () => {
+      const toolkit: Toolkit.WithHandler<{
+        readonly ToolWithRequestContext: typeof ToolWithRequestContext
+      }> = {
+        tools: {
+          ToolWithRequestContext
+        },
+        handle: () => Effect.die("not implemented")
+      }
+      const program = LanguageModel.generateText({
+        prompt: "hello",
+        toolkit
+      })
+
+      type ProgramRequirements = typeof program extends Effect.Effect<any, any, infer R> ? R : never
+
+      expect<ProgramRequirements>().type.toBe<LanguageModel.LanguageModel | RequestContext>()
+    })
+
+    it("includes yieldable toolkit requirements and tool request dependencies", () => {
+      type ToolWithRequestContextTools = {
+        readonly ToolWithRequestContext: typeof ToolWithRequestContext
+      }
+
+      type YieldableToolkit = Effect.Yieldable<
+        Toolkit.Toolkit<ToolWithRequestContextTools>,
+        Toolkit.WithHandler<ToolWithRequestContextTools>,
+        never,
+        ToolkitContext
+      >
+
+      expect<LanguageModel.ExtractServices<{ readonly toolkit: YieldableToolkit }>>().type.toBe<
+        RequestContext | ToolkitContext
+      >()
     })
   })
 })

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -518,7 +518,7 @@ export type ExtractServices<Options> = Options extends {
   }
   // Required for tool call execution
     ?
-      | Tool.ResultEncodingServices<_Tools[keyof _Tools]>
+      | Tool.HandlerServices<_Tools[keyof _Tools]>
       // Required for decoding large language model responses
       | Tool.ResultDecodingServices<_Tools[keyof _Tools]>
   : Options extends {
@@ -531,7 +531,7 @@ export type ExtractServices<Options> = Options extends {
   }
   // Required for tool call execution
     ?
-      | Tool.ResultEncodingServices<_Tools[keyof _Tools]>
+      | Tool.HandlerServices<_Tools[keyof _Tools]>
       // Required for decoding large language model responses
       | Tool.ResultDecodingServices<_Tools[keyof _Tools]>
       | _R


### PR DESCRIPTION
## Summary

- include tool handler requirements in `LanguageModel.ExtractServices` for toolkit-backed generation APIs
- add dtslint regressions covering toolkit request dependencies, resolved `WithHandler` toolkits, and yieldable toolkit requirement inference
- add a changeset for the `effect` package

## Validation

- `pnpm lint-fix`
- `pnpm test-types packages/effect/dtslint/unstable/ai/LanguageModel.tst.ts`
- `pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`