### PR TITLE
EFF-688 Fix Ndjson Uint8Array typing regression

### DIFF
--- a/.changeset/tiny-rabbits-smile.md
+++ b/.changeset/tiny-rabbits-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Relax `Ndjson` byte-stream channel signatures to accept plain `Uint8Array`.

--- a/packages/effect/dtslint/unstable/encoding/Ndjson.tst.ts
+++ b/packages/effect/dtslint/unstable/encoding/Ndjson.tst.ts
@@ -1,0 +1,24 @@
+import { Schema, Stream } from "effect"
+import * as Ndjson from "effect/unstable/encoding/Ndjson"
+import { describe, expect, it } from "tstyche"
+
+describe("Ndjson", () => {
+  it("decodeSchema accepts plain Uint8Array streams", () => {
+    const stream = Stream.fail("FooBar") as Stream.Stream<Uint8Array, string>
+
+    const decoded = stream.pipe(
+      Stream.pipeThroughChannel(
+        Ndjson.decodeSchema(Schema.Struct({ foo: Schema.String }))({
+          ignoreEmptyLines: true
+        })
+      )
+    )
+
+    expect(decoded).type.toBe<
+      Stream.Stream<
+        { readonly foo: string },
+        string | Schema.SchemaError | Ndjson.NdjsonError
+      >
+    >()
+  })
+})

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -5978,7 +5978,7 @@ export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOp
   Arr.NonEmptyReadonlyArray<string>,
   Err,
   Done,
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   Err,
   Done
 > =>
@@ -5994,7 +5994,7 @@ export const decodeText = <Err, Done>(encoding?: string, options?: TextDecoderOp
  * @category String manipulation
  */
 export const encodeText = <Err, Done>(): Channel<
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   Err,
   Done,
   Arr.NonEmptyReadonlyArray<string>,
@@ -6004,7 +6004,7 @@ export const encodeText = <Err, Done>(): Channel<
   fromTransform((upstream, _scope) =>
     Effect.sync(() => {
       const encoder = new TextEncoder()
-      return Effect.map(upstream, Arr.map((line) => encoder.encode(line) as Uint8Array<ArrayBuffer>))
+      return Effect.map(upstream, Arr.map((line) => encoder.encode(line)))
     })
   )
 

--- a/packages/effect/src/unstable/encoding/Ndjson.ts
+++ b/packages/effect/src/unstable/encoding/Ndjson.ts
@@ -61,13 +61,13 @@ export const encodeString = <IE = never, Done = unknown>(): Channel.Channel<
  * @category constructors
  */
 export const encode = <IE = never, Done = unknown>(): Channel.Channel<
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   IE | NdjsonError,
   Done,
   Arr.NonEmptyReadonlyArray<unknown>,
   IE,
   Done
-> => Channel.map(encodeString(), Arr.map((_) => encoder.encode(_) as Uint8Array<ArrayBuffer>))
+> => Channel.map(encodeString(), Arr.map((_) => encoder.encode(_)))
 
 /**
  * @since 4.0.0
@@ -77,7 +77,7 @@ export const encodeSchema = <S extends Schema.Top>(
   schema: S
 ) =>
 <IE = never, Done = unknown>(): Channel.Channel<
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   NdjsonError | Schema.SchemaError | IE,
   Done,
   Arr.NonEmptyReadonlyArray<S["Type"]>,
@@ -141,7 +141,7 @@ export const decode = <IE = never, Done = unknown>(options?: {
   Arr.NonEmptyReadonlyArray<unknown>,
   IE | NdjsonError,
   Done,
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   IE,
   Done
 > => {
@@ -161,7 +161,7 @@ export const decodeSchema = <S extends Schema.Top>(
   Arr.NonEmptyReadonlyArray<S["Type"]>,
   Schema.SchemaError | NdjsonError | IE,
   Done,
-  Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+  Arr.NonEmptyReadonlyArray<Uint8Array>,
   IE,
   Done,
   S["DecodingServices"]
@@ -195,10 +195,10 @@ export const duplex: {
     readonly ignoreEmptyLines?: boolean | undefined
   }): <R, IE, OE, OutDone, InDone>(
     self: Channel.Channel<
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       OE,
       OutDone,
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       IE | NdjsonError,
       InDone,
       R
@@ -214,10 +214,10 @@ export const duplex: {
   >
   <R, IE, OE, OutDone, InDone>(
     self: Channel.Channel<
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       OE,
       OutDone,
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       IE | NdjsonError,
       InDone,
       R
@@ -236,10 +236,10 @@ export const duplex: {
   >
 } = dual((args) => Channel.isChannel(args[0]), <R, IE, OE, OutDone, InDone>(
   self: Channel.Channel<
-    Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+    Arr.NonEmptyReadonlyArray<Uint8Array>,
     OE,
     OutDone,
-    Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+    Arr.NonEmptyReadonlyArray<Uint8Array>,
     IE | NdjsonError,
     InDone,
     R
@@ -349,10 +349,10 @@ export const duplexSchema: {
     }
   ): <OutErr, OutDone, InErr, InDone, R>(
     self: Channel.Channel<
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       OutErr,
       OutDone,
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       NdjsonError | Schema.SchemaError | InErr,
       InDone,
       R
@@ -368,10 +368,10 @@ export const duplexSchema: {
   >
   <Out extends Schema.Top, In extends Schema.Top, OutErr, OutDone, InErr, InDone, R>(
     self: Channel.Channel<
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       OutErr,
       OutDone,
-      Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+      Arr.NonEmptyReadonlyArray<Uint8Array>,
       NdjsonError | Schema.SchemaError | InErr,
       InDone,
       R
@@ -392,10 +392,10 @@ export const duplexSchema: {
   >
 } = dual(2, <Out extends Schema.Top, In extends Schema.Top, OutErr, OutDone, InErr, InDone, R>(
   self: Channel.Channel<
-    Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+    Arr.NonEmptyReadonlyArray<Uint8Array>,
     OutErr,
     OutDone,
-    Arr.NonEmptyReadonlyArray<Uint8Array<ArrayBuffer>>,
+    Arr.NonEmptyReadonlyArray<Uint8Array>,
     NdjsonError | Schema.SchemaError | InErr,
     InDone,
     R

--- a/packages/effect/test/unstable/encoding/Ndjson.test.ts
+++ b/packages/effect/test/unstable/encoding/Ndjson.test.ts
@@ -1,0 +1,18 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Stream } from "effect"
+import * as Schema from "effect/Schema"
+import * as Ndjson from "effect/unstable/encoding/Ndjson"
+
+describe("Ndjson", () => {
+  it.effect("decodeSchema decodes Uint8Array streams", () =>
+    Effect.gen(function*() {
+      const messages = yield* Stream.make(
+        new TextEncoder().encode("{\"foo\":\"bar\"}\n")
+      ).pipe(
+        Stream.pipeThroughChannel(Ndjson.decodeSchema(Schema.Struct({ foo: Schema.String }))()),
+        Stream.runCollect
+      )
+
+      assert.deepStrictEqual([...messages], [{ foo: "bar" }])
+    }))
+})


### PR DESCRIPTION
## Summary

- relax `Ndjson` byte-channel signatures to accept plain `Uint8Array`
- align `Channel.decodeText` / `Channel.encodeText` with plain `Uint8Array` so NDJSON composition type-checks
- add runtime and dtslint regression coverage for `Ndjson.decodeSchema`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/encoding/Ndjson.test.ts`
- `pnpm test-types packages/effect/dtslint/unstable/encoding/Ndjson.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`
