### PR TITLE
EFF-691 Preserve default logger message item ordering when logging a Cause

### DIFF
--- a/.changeset/eff-691-default-logger-ordering.md
+++ b/.changeset/eff-691-default-logger-ordering.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Preserve message item ordering in the default logger when logging a `Cause` with message values.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -6195,7 +6195,7 @@ const prettyLoggerBrowser = (options: {
 export const defaultLogger = loggerMake<unknown, void>(({ cause, date, fiber, logLevel, message }) => {
   const message_ = Array.isArray(message) ? message.slice() : [message]
   if (cause.reasons.length > 0) {
-    message_.unshift(causePretty(cause))
+    message_.push(causePretty(cause))
   }
   const now = date.getTime()
   const spans = fiber.getRef(CurrentLogSpans)

--- a/packages/effect/test/Logger.test.ts
+++ b/packages/effect/test/Logger.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Exit, Scope } from "effect"
+import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Logger from "effect/Logger"
@@ -84,5 +85,20 @@ describe("Logger", () => {
         annotations,
         [{ outer: "program" }, { outer: "program", inner: "scope" }, {}]
       )
+    }))
+
+  it.effect("default logger preserves message item order when logging a cause", () =>
+    Effect.gen(function*() {
+      yield* Effect.log("first", Cause.fail("boom"), "second")
+
+      const result = yield* TestConsole.logLines
+
+      assert.match(
+        result[0] as string,
+        /\[\d{2}:\d{2}:\d{2}\.\d{3}\]\sINFO\s\(#\d+\):/
+      )
+      assert.strictEqual(result[1], "first")
+      assert.strictEqual(result[2], "second")
+      assert.match(result[3] as string, /boom/)
     }))
 })


### PR DESCRIPTION
## Summary

- changed `defaultLogger` to append rendered `Cause` output after message items instead of prepending it
- added regression coverage in `packages/effect/test/Logger.test.ts` for `Effect.log("first", Cause.fail("boom"), "second")`
- added changeset: `.changeset/eff-691-default-logger-ordering.md`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Logger.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`
