### PR TITLE
EFF-693 RpcGroup.toLayer should include handler dependencies

### DIFF
--- a/.changeset/eff-693-rpcgroup-handler-deps.md
+++ b/.changeset/eff-693-rpcgroup-handler-deps.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `RpcGroup.toLayer` and `RpcGroup.toLayerHandler` service requirement inference so handler dependencies are preserved for non-stream RPC handlers.

--- a/packages/effect/dtslint/unstable/rpc/RpcGroup.tst.ts
+++ b/packages/effect/dtslint/unstable/rpc/RpcGroup.tst.ts
@@ -1,0 +1,52 @@
+import { Effect, Schema, ServiceMap } from "effect"
+import type * as Layer from "effect/Layer"
+import * as Rpc from "effect/unstable/rpc/Rpc"
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup"
+import { describe, expect, it } from "tstyche"
+
+class Db extends ServiceMap.Service<Db, {
+  readonly value: string
+}>()("Db") {}
+
+class Metrics extends ServiceMap.Service<Metrics, {
+  readonly value: string
+}>()("Metrics") {}
+
+const GetUser = Rpc.make("GetUser", { success: Schema.String })
+const Group = RpcGroup.make(GetUser)
+
+describe("RpcGroup", () => {
+  it("toLayer includes handler dependencies in layer services", () => {
+    const layer = Group.toLayer({
+      GetUser: () => Db.use((db) => Effect.succeed(db.value))
+    })
+
+    type HasExpectedServices = [Layer.Services<typeof layer>] extends [Db] ?
+      ([Db] extends [Layer.Services<typeof layer>] ? true : false) :
+      false
+
+    expect<HasExpectedServices>().type.toBe<true>()
+  })
+
+  it("toLayer includes handler dependencies from effect-built handlers", () => {
+    const layer = Group.toLayer(Effect.succeed({
+      GetUser: () => Db.use((db) => Effect.succeed(db.value))
+    }))
+
+    type HasExpectedServices = [Layer.Services<typeof layer>] extends [Db] ?
+      ([Db] extends [Layer.Services<typeof layer>] ? true : false) :
+      false
+
+    expect<HasExpectedServices>().type.toBe<true>()
+  })
+
+  it("toLayerHandler includes handler dependencies in layer services", () => {
+    const layer = Group.toLayerHandler("GetUser", () => Metrics.use((metrics) => Effect.succeed(metrics.value)))
+
+    type HasExpectedServices = [Layer.Services<typeof layer>] extends [Metrics] ?
+      ([Metrics] extends [Layer.Services<typeof layer>] ? true : false) :
+      false
+
+    expect<HasExpectedServices>().type.toBe<true>()
+  })
+})

--- a/packages/effect/src/unstable/rpc/RpcGroup.ts
+++ b/packages/effect/src/unstable/rpc/RpcGroup.ts
@@ -184,8 +184,8 @@ export type HandlersServices<Rpcs extends Rpc.Any, Handlers> = keyof Handlers ex
  * @since 4.0.0
  * @category groups
  */
-export type HandlerServices<Rpcs extends Rpc.Any, K extends Rpcs["_tag"], Handler> = [Rpc.IsStream<Rpcs, K>] extends
-  [true] ? Handler extends (...args: any) =>
+export type HandlerServices<Rpcs extends Rpc.Any, K extends Rpcs["_tag"], Handler> = true extends
+  Rpc.IsStream<Rpcs, K> ? Handler extends (...args: any) =>
     | Stream.Stream<infer _A, infer _E, infer _R>
     | Rpc.Wrapper<Stream.Stream<infer _A, infer _E, infer _R>>
     | Effect.Effect<
@@ -204,7 +204,7 @@ export type HandlerServices<Rpcs extends Rpc.Any, K extends Rpcs["_tag"], Handle
   Handler extends (
     ...args: any
   ) => Effect.Effect<infer _A, infer _E, infer _R> | Rpc.Wrapper<Effect.Effect<infer _A, infer _E, infer _R>> ?
-    Rpc.ExcludeProvides<_R, Rpcs, K> | Rpc.ExtractRequires<Rpcs, K>
+    Exclude<Rpc.ExcludeProvides<_R, Rpcs, K>, Scope> | Rpc.ExtractRequires<Rpcs, K>
   : never
 
 /**


### PR DESCRIPTION
## Summary

- fix `RpcGroup.HandlerServices` type-level stream detection so mixed groups no longer drop non-stream handler environments to `never`
- exclude `Scope` from non-stream handler environment requirements, aligning with `toLayer` / `toLayerHandler` return contracts
- add dtslint regression coverage in `packages/effect/dtslint/unstable/rpc/RpcGroup.tst.ts` verifying `toLayer` and `toLayerHandler` include handler dependencies in `Layer.Services`

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/rpc/Rpc.test.ts
- pnpm test-types packages/effect/dtslint/unstable/rpc/RpcGroup.tst.ts
- pnpm test-types packages/effect/dtslint/unstable/rpc/Rpc.tst.ts
- pnpm check:tsgo
- pnpm docgen
