### PR TITLE
EFF-695 Layer.mock should be a dual api

### DIFF
--- a/.changeset/eff-695-layer-mock-dual-api.md
+++ b/.changeset/eff-695-layer-mock-dual-api.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Make `Layer.mock` a dual API so it supports both `Layer.mock(Service)(impl)` and `Layer.mock(Service, impl)`.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -1733,7 +1733,7 @@ export type PartialEffectful<A extends object> = Types.Simplify<
  * }>()("UserService") {}
  *
  * // Create a partial mock - only implement what you need for testing
- * const testUserLayer = Layer.mock(UserService)({
+ * const testUserLayer = Layer.mock(UserService, {
  *   config: { apiUrl: "https://test-api.com" }, // Required - non-Effect property
  *   getUser: (id: string) => Effect.succeed({ id, name: "Test User" }) // Mock implementation
  *   // deleteUser and updateUser are omitted - will throw UnimplementedError if called
@@ -1757,24 +1757,33 @@ export type PartialEffectful<A extends object> = Types.Simplify<
  * @since 4.0.0
  * @category Testing
  */
-export const mock =
-  <I, S extends object>(service: ServiceMap.Key<I, S>) => (implementation: PartialEffectful<S>): Layer<I> =>
-    succeed(service)(
-      new Proxy({ ...implementation as object } as S, {
-        get(target, prop, _receiver) {
-          if (prop in target) {
-            return target[prop as keyof S]
-          }
-          const prevLimit = (Error as ErrorWithStackTraceLimit).stackTraceLimit
-          ;(Error as ErrorWithStackTraceLimit).stackTraceLimit = 2
-          const error = new Error(`${service.key}: Unimplemented method "${prop.toString()}"`)
-          ;(Error as ErrorWithStackTraceLimit).stackTraceLimit = prevLimit
-          error.name = "UnimplementedError"
-          return makeUnimplemented(error)
-        },
-        has: constTrue
-      })
-    )
+export const mock: {
+  <I, S extends object>(service: ServiceMap.Key<I, S>): (implementation: PartialEffectful<S>) => Layer<I>
+  <I, S extends object>(service: ServiceMap.Key<I, S>, implementation: Types.NoInfer<PartialEffectful<S>>): Layer<I>
+} = function() {
+  if (arguments.length === 1) {
+    return (implementation: any) => mockImpl(arguments[0], implementation)
+  }
+  return mockImpl(arguments[0], arguments[1])
+} as any
+
+const mockImpl = <I, S extends object>(service: ServiceMap.Key<I, S>, implementation: PartialEffectful<S>): Layer<I> =>
+  succeed(service)(
+    new Proxy({ ...implementation as object } as S, {
+      get(target, prop, _receiver) {
+        if (prop in target) {
+          return target[prop as keyof S]
+        }
+        const prevLimit = (Error as ErrorWithStackTraceLimit).stackTraceLimit
+        ;(Error as ErrorWithStackTraceLimit).stackTraceLimit = 2
+        const error = new Error(`${service.key}: Unimplemented method "${prop.toString()}"`)
+        ;(Error as ErrorWithStackTraceLimit).stackTraceLimit = prevLimit
+        error.name = "UnimplementedError"
+        return makeUnimplemented(error)
+      },
+      has: constTrue
+    })
+  )
 
 const makeUnimplemented = (error: globalThis.Error) => {
   const dead = internalEffect.die(error)

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -270,6 +270,28 @@ describe("Layer", () => {
           )
         )
       }))
+
+    it.effect("allows passing partial service in dual form", () =>
+      Effect.gen(function*() {
+        class Service1 extends ServiceMap.Service<Service1, {
+          one: Effect.Effect<number>
+          two(): Effect.Effect<number>
+        }>()("Service1") {}
+        yield* Effect.gen(function*() {
+          const service = yield* Service1
+          assert.strictEqual(yield* service.one, 123)
+          yield* service.two().pipe(
+            Effect.catchDefect(Effect.fail),
+            Effect.flip
+          )
+        }).pipe(
+          Effect.provide(
+            Layer.mock(Service1, {
+              one: Effect.succeed(123)
+            })
+          )
+        )
+      }))
   })
 
   describe("MemoMap", () => {


### PR DESCRIPTION
## Summary

- make `Layer.mock` a dual API with overloads for both:
  - `Layer.mock(Service)(impl)`
  - `Layer.mock(Service, impl)`
- keep the existing mock behavior for unimplemented members (defect with `UnimplementedError`)
- add runtime test coverage for the direct two-argument form
- update the `Layer.mock` example to show the direct two-argument usage

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/Layer.test.ts
- pnpm check:tsgo
- pnpm docgen
