### PR TITLE
fix: json RpcSerialization decode double-wraps array responses

### DIFF
--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -37,7 +37,10 @@ export const json: RpcSerialization["Service"] = RpcSerialization.of({
   makeUnsafe: () => {
     const decoder = new TextDecoder()
     return {
-      decode: (bytes) => [JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))],
+      decode: (bytes) => {
+        const parsed = JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))
+        return Array.isArray(parsed) ? parsed : [parsed]
+      },
       encode: (response) => JSON.stringify(response)
     }
   }

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -11,6 +11,47 @@ const responseExitSuccess = (requestId: string, value: unknown) => ({
 })
 
 describe("RpcSerialization", () => {
+  it("json decode returns flat array when server sends array of messages", () => {
+    const parser = RpcSerialization.json.makeUnsafe()
+
+    const msg1 = responseExitSuccess("0", { name: "Alice" })
+    const msg2 = responseExitSuccess("1", { name: "Bob" })
+    const serverResponse = JSON.stringify([msg1, msg2])
+
+    const decoded = parser.decode(serverResponse)
+
+    // decoded should be [msg1, msg2], NOT [[msg1, msg2]]
+    assert.strictEqual(decoded.length, 2)
+    assert.deepStrictEqual(decoded[0], msg1)
+    assert.deepStrictEqual(decoded[1], msg2)
+  })
+
+  it("json decode wraps single non-array value in array", () => {
+    const parser = RpcSerialization.json.makeUnsafe()
+
+    const msg = responseExitSuccess("0", { name: "Alice" })
+    const serverResponse = JSON.stringify(msg)
+
+    const decoded = parser.decode(serverResponse)
+
+    assert.strictEqual(decoded.length, 1)
+    assert.deepStrictEqual(decoded[0], msg)
+  })
+
+  it("json encode/decode roundtrip preserves messages", () => {
+    const parser = RpcSerialization.json.makeUnsafe()
+
+    const messages = [
+      responseExitSuccess("0", { name: "Alice" }),
+      responseExitSuccess("1", { name: "Bob" })
+    ]
+
+    const encoded = parser.encode(messages)
+    const decoded = parser.decode(encoded as string)
+
+    assert.deepStrictEqual(decoded, messages)
+  })
+
   it("jsonRpc encodes a non-batched single response array as an object", () => {
     const parser = RpcSerialization.jsonRpc().makeUnsafe()
     const decoded = parser.decode("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"users.get\"}")


### PR DESCRIPTION
## Summary

Fixes #1719

- `RpcSerialization.json.decode` unconditionally wraps `JSON.parse()` output in `[...]`, causing double-nesting when the server sends a JSON array of RPC response messages via the HTTP protocol
- The `makeProtocolHttp` non-framed path iterates the decoded result expecting message objects, but receives arrays — `message._tag` is `undefined`, responses are silently discarded, and the RPC call hangs until timeout
- Fix: return the parsed value directly when it is already an array, only wrapping non-array values

## What changed

**`packages/effect/src/unstable/rpc/RpcSerialization.ts`**

```typescript
// Before:
decode: (bytes) => [JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))]

// After:
decode: (bytes) => {
  const parsed = JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))
  return Array.isArray(parsed) ? parsed : [parsed]
}
```

## Test plan

- [x] Added test: `json decode returns flat array when server sends array of messages` — verifies decode returns `[msg1, msg2]` not `[[msg1, msg2]]`
- [x] Added test: `json decode wraps single non-array value in array` — verifies single objects are still wrapped
- [x] Added test: `json encode/decode roundtrip preserves messages` — verifies `decode(encode(messages))` equals `messages`
- [x] Existing `Rpc.test.ts` passes (3/3)
- [x] Existing `AtomRpc.test.ts` passes (1/1)
- [x] Existing `RpcSerialization.test.ts` jsonRpc tests pass (2/2)
- [x] Validated end-to-end in a real app (React + Cloudflare Worker) — RPC responses now flow through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)