### PR TITLE
EFF-697 Fix JSON RpcSerialization decode array double-wrap

### DIFF
--- a/.changeset/eff-697-rpcserialization-json-array-decode.md
+++ b/.changeset/eff-697-rpcserialization-json-array-decode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `RpcSerialization.json` decode so JSON array payloads are not wrapped in an extra outer array.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -37,7 +37,10 @@ export const json: RpcSerialization["Service"] = RpcSerialization.of({
   makeUnsafe: () => {
     const decoder = new TextDecoder()
     return {
-      decode: (bytes) => [JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))],
+      decode: (bytes) => {
+        const decoded = JSON.parse(typeof bytes === "string" ? bytes : decoder.decode(bytes))
+        return Array.isArray(decoded) ? decoded : [decoded]
+      },
       encode: (response) => JSON.stringify(response)
     }
   }

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -11,6 +11,20 @@ const responseExitSuccess = (requestId: string, value: unknown) => ({
 })
 
 describe("RpcSerialization", () => {
+  it("json decode keeps array payloads flat", () => {
+    const parser = RpcSerialization.json.makeUnsafe()
+    const decoded = parser.decode("[1,2,3]")
+    assert.strictEqual(decoded.length, 3)
+    assert.deepStrictEqual(decoded, [1, 2, 3])
+  })
+
+  it("json decode wraps non-array payloads", () => {
+    const parser = RpcSerialization.json.makeUnsafe()
+    const decoded = parser.decode("{\"a\":1}")
+    assert.strictEqual(decoded.length, 1)
+    assert.deepStrictEqual(decoded, [{ a: 1 }])
+  })
+
   it("jsonRpc encodes a non-batched single response array as an object", () => {
     const parser = RpcSerialization.jsonRpc().makeUnsafe()
     const decoded = parser.decode("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"users.get\"}")


### PR DESCRIPTION
## Summary

- fix `RpcSerialization.json` decode to preserve top-level JSON arrays instead of always wrapping parse output
- keep non-array behavior unchanged by wrapping object/scalar payloads in a single-element array
- add regression tests in `RpcSerialization.test.ts` for both array and non-array JSON decode behavior
- add changeset for `effect` patch release

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/rpc/RpcSerialization.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`
