### PR TITLE
Schema.Class plain objects rejected by HttpApi encode at runtime

### DIFF
--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -716,7 +716,7 @@ function toResponseSchema(getStatus: (ast: AST.AST) => number) {
       return cached as any
     }
     const responseSchema = $HttpServerResponse.pipe(
-      Schema.decodeTo(schema, getResponseTransformation(getStatus, schema))
+      Schema.decodeTo(HttpApiSchema.schemaForEncoding(schema), getResponseTransformation(getStatus, schema))
     )
     cache.set(responseSchema.ast, responseSchema)
     return responseSchema

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -651,7 +651,7 @@ function getEncodePayloadSchemaFromBody(
   }
   const encoding = HttpApiSchema.getPayloadEncoding(ast)
   const out = $HttpBody.pipe(Schema.decodeTo(
-    schema,
+    HttpApiSchema.schemaForEncoding(schema),
     Transformation.transformOrFail({
       decode(httpBody) {
         return Effect.fail(new Issue.Forbidden(Option.some(httpBody), { message: "Encode only schema" }))

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -27,9 +27,13 @@
  *
  * @since 4.0.0
  */
+import * as Effect from "../../Effect.ts"
 import { constVoid, type LazyArg } from "../../Function.ts"
+import * as Option from "../../Option.ts"
+import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
 import * as AST from "../../SchemaAST.ts"
+import * as Issue from "../../SchemaIssue.ts"
 import * as Transformation from "../../SchemaTransformation.ts"
 import type * as Multipart_ from "../http/Multipart.ts"
 
@@ -368,4 +372,25 @@ export function getStatusSuccess(self: AST.AST): number {
 /** @internal */
 export function getStatusError(self: AST.AST): number {
   return resolveHttpApiStatus(self) ?? 500
+}
+
+/** @internal */
+export function schemaForEncoding(schema: Schema.Top): Schema.Top {
+  const ast = schema.ast
+  if (ast._tag === "Declaration" && ast.annotations?.[AST.ClassTypeId] !== undefined) {
+    return Schema.make(
+      new AST.Declaration(
+        ast.typeParameters,
+        () => (input, declAst) =>
+          Predicate.isObject(input)
+            ? Effect.succeed(input)
+            : Effect.fail(new Issue.InvalidType(declAst, Option.some(input))),
+        ast.annotations,
+        ast.checks,
+        ast.encoding,
+        ast.context
+      )
+    )
+  }
+  return schema
 }

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -2,11 +2,14 @@ import { NodeHttpServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
 import { Effect, Layer, Schema } from "effect"
-import { HttpClient, HttpRouter } from "effect/unstable/http"
+import { HttpRouter } from "effect/unstable/http"
 import { HttpApi, HttpApiBuilder, HttpApiClient, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 
 describe("HttpApiClient", () => {
-  describe("Schema.Class payload", () => {
+  describe("Schema.Class with HttpApi", () => {
+    // Pure data classes — no extra members.
+    // TypeScript's structural typing makes plain objects indistinguishable
+    // from class instances, so `{ name: "Kit", age: 30 }` satisfies `MyBody`.
     class MyBody extends Schema.Class<MyBody>("MyBody")({
       name: Schema.String,
       age: Schema.Number
@@ -29,13 +32,12 @@ describe("HttpApiClient", () => {
           )
       )
 
-    // Server handler returns a plain object matching MyResponse shape
+    // Handler returns a plain object — not `new MyResponse(...)`.
     const GroupLive = HttpApiBuilder.group(
       Api,
       "users",
       (handlers) =>
-        handlers.handle("createUser", (ctx) =>
-          Effect.succeed({ id: 1, name: ctx.payload.name, age: ctx.payload.age }))
+        handlers.handle("createUser", (ctx) => Effect.succeed({ id: 1, name: ctx.payload.name, age: ctx.payload.age }))
     )
 
     const ApiLive = HttpRouter.serve(
@@ -43,24 +45,55 @@ describe("HttpApiClient", () => {
       { disableListenLog: true, disableLogger: true }
     ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
-    it.effect("client: accepts a plain object as payload for Schema.Class endpoint", () =>
+    it.effect("client payload: plain object typechecks and works at runtime", () =>
       Effect.gen(function*() {
         const client = yield* HttpApiClient.make(Api)
+        // This typechecks because MyBody is structurally { name: string, age: number }.
+        // Before the fix, it failed at runtime: "Expected MyBody, got {..}"
         const result = yield* client.users.createUser({
           payload: { name: "Kit", age: 30 }
         })
-        assert.deepStrictEqual(result, { id: 1, name: "Kit", age: 30 })
+        assert.deepStrictEqual({ ...result }, { id: 1, name: "Kit", age: 30 })
       }).pipe(Effect.provide(ApiLive)))
 
-    it.effect("server: encodes a plain object as Schema.Class success response", () =>
+    it.effect("client payload: class instance still works", () =>
       Effect.gen(function*() {
         const client = yield* HttpApiClient.make(Api)
-        // Handler returns plain { id, name, age } — not new MyResponse(...)
-        // Server must encode it successfully as MyResponse
         const result = yield* client.users.createUser({
           payload: new MyBody({ name: "Kit", age: 30 })
         })
-        assert.deepStrictEqual(result, { id: 1, name: "Kit", age: 30 })
+        assert.deepStrictEqual({ ...result }, { id: 1, name: "Kit", age: 30 })
+      }).pipe(Effect.provide(ApiLive)))
+
+    it.effect("server encode: handler can return plain object for Schema.Class success", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.make(Api)
+        // Handler returns `{ id, name, age }` — not `new MyResponse(...)`.
+        // Before the fix, this failed: "Expected MyResponse, got {..}"
+        const result = yield* client.users.createUser({
+          payload: new MyBody({ name: "Kit", age: 30 })
+        })
+        assert.deepStrictEqual({ ...result }, { id: 1, name: "Kit", age: 30 })
+      }).pipe(Effect.provide(ApiLive)))
+
+    it.effect("server decode: plain object payload is decoded into class instance", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.make(Api)
+        // Client sends plain object, server decodes it into a MyBody instance.
+        // Handler accesses ctx.payload.name/age — works because it's a real instance.
+        const result = yield* client.users.createUser({
+          payload: { name: "Kit", age: 30 }
+        })
+        assert.deepStrictEqual({ ...result }, { id: 1, name: "Kit", age: 30 })
+      }).pipe(Effect.provide(ApiLive)))
+
+    it.effect("client decode: response is a proper class instance", () =>
+      Effect.gen(function*() {
+        const client = yield* HttpApiClient.make(Api)
+        const result = yield* client.users.createUser({
+          payload: new MyBody({ name: "Kit", age: 30 })
+        })
+        assert.isTrue(result instanceof MyResponse)
       }).pipe(Effect.provide(ApiLive)))
   })
 


### PR DESCRIPTION
## Problem

When using `Schema.Class` as a payload or success type in HttpApi, plain objects that **typecheck** fail at **runtime**.

```ts
class MyBody extends Schema.Class<MyBody>("MyBody")({
  name: Schema.String,
  age: Schema.Number
}) {}

const Api = HttpApi.make("Api").add(
  HttpApiGroup.make("users").add(
    HttpApiEndpoint.post("createUser", "/users", {
      payload: MyBody,
      success: MyResponse
    })
  )
)

const client = yield* HttpApiClient.make(Api)

// Typechecks — MyBody is structurally { name: string, age: number }
// Runtime: SchemaError: Expected MyBody, got {"name":"Kit","age":30}
yield* client.users.createUser({ payload: { name: "Kit", age: 30 } })
```

Same issue on the server — a handler returning `Effect.succeed({ id: 1, ... })` for a `Schema.Class` success type typechecks but fails during response encoding.

The root cause: `Schema.Class` creates a Declaration AST whose guard requires `instanceof`. TypeScript's structural typing makes plain objects assignable to the class type (no nominal brand), so the types accept them while the runtime rejects them.

## Proposed fix

This PR adds `schemaForEncoding` in `HttpApiSchema` — when building encode-only schema pipelines (payload → HttpBody, success → HttpServerResponse), class Declaration guards are replaced with a lenient `isObject` check. All annotations, checks, encoding config, and context are preserved.

**This does not change `Schema.Class` behavior outside of HttpApi.** `Schema.encodeUnknownSync(MyBody)(plainObj)` still fails — only the HttpApi encode pipeline is made lenient.

Not sure if this is the right implementation — the type/runtime mismatch in `Schema.Class` is arguably a deeper issue (maybe classes should be nominally branded, or maybe `encodeUnknown` should be lenient for classes globally). This is more of a reproducer and one possible fix to consider.

## Test plan

- [ ] Client payload: plain object accepted for Schema.Class endpoint
- [ ] Client payload: class instance still works (no regression)
- [ ] Server encode: handler can return plain object for Schema.Class success
- [ ] Server decode: plain object payload decoded into proper class instance
- [ ] Client decode: response is a proper class instance (`instanceof` check)
- [ ] Existing Schema.Class tests unchanged
- [ ] Existing HttpApi tests pass (including asNoContent, error encoding, etc.)