### PR TITLE
EFF-702 Move Schema type extractors to the top level

### DIFF
--- a/.changeset/eff-702-schema-type-extractors.md
+++ b/.changeset/eff-702-schema-type-extractors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add top-level Schema type extractors (`Schema.Type`, `Schema.Encoded`, `Schema.DecodingServices`, and `Schema.EncodingServices`) while preserving the existing nested aliases.

--- a/packages/effect/dtslint/schema/Schema.tst.ts
+++ b/packages/effect/dtslint/schema/Schema.tst.ts
@@ -56,7 +56,7 @@ describe("Schema", () => {
     it("Schema", () => {
       function f<S extends Schema.Schema<unknown>>(_s: S) {
         // @ts-expect-error Type 'null' is not assignable to type 'Type<S>'
-        const Type: Schema.Schema.Type<S> = null
+        const Type: Schema.Type<S> = null
         return Type
       }
       f(Schema.String)
@@ -65,11 +65,11 @@ describe("Schema", () => {
     it("Codec", () => {
       function f<S extends Schema.Codec<unknown, unknown, unknown, unknown>>(_s: S) {
         // @ts-expect-error Type 'null' is not assignable to type 'Encoded<S>'
-        const Encoded: Schema.Codec.Encoded<S> = null
+        const Encoded: Schema.Encoded<S> = null
         // @ts-expect-error Type 'null' is not assignable to type 'DecodingServices<S>'
-        const DecodingServices: Schema.Codec.DecodingServices<S> = null
+        const DecodingServices: Schema.DecodingServices<S> = null
         // @ts-expect-error Type 'null' is not assignable to type 'EncodingServices<S>'
-        const EncodingServices: Schema.Codec.EncodingServices<S> = null
+        const EncodingServices: Schema.EncodingServices<S> = null
         return { Encoded, DecodingServices, EncodingServices }
       }
       f(Schema.String)

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -565,7 +565,7 @@ export declare namespace Schema {
    * import { Schema } from "effect"
    *
    * const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
-   * type Person = Schema.Schema.Type<typeof Person>
+   * type Person = Schema.Type<typeof Person>
    * // { readonly name: string; readonly age: number }
    * ```
    *
@@ -573,6 +573,23 @@ export declare namespace Schema {
    */
   export type Type<S> = S extends Top ? S["Type"] : never
 }
+
+/**
+ * Extracts the decoded `Type` from a schema.
+ *
+ * **Example** (Extracting the decoded type)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
+ * type Person = Schema.Type<typeof Person>
+ * // { readonly name: string; readonly age: number }
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type Type<S> = Schema.Type<S>
 
 /**
  * A typed view of a schema that tracks only the decoded (output) type `T`.
@@ -621,7 +638,7 @@ export declare namespace Codec {
    * import { Schema } from "effect"
    *
    * const schema = Schema.NumberFromString
-   * type Enc = Schema.Codec.Encoded<typeof schema>
+   * type Enc = Schema.Encoded<typeof schema>
    * // string
    * ```
    *
@@ -637,7 +654,7 @@ export declare namespace Codec {
    * import { Schema } from "effect"
    *
    * const schema = Schema.String
-   * type RD = Schema.Codec.DecodingServices<typeof schema>
+   * type RD = Schema.DecodingServices<typeof schema>
    * // never
    * ```
    *
@@ -653,7 +670,7 @@ export declare namespace Codec {
    * import { Schema } from "effect"
    *
    * const schema = Schema.String
-   * type RE = Schema.Codec.EncodingServices<typeof schema>
+   * type RE = Schema.EncodingServices<typeof schema>
    * // never
    * ```
    *
@@ -673,6 +690,57 @@ export declare namespace Codec {
     input: I
   ) => asserts input is I & S["Type"]
 }
+
+/**
+ * Extracts the encoded (`Encoded`) type from a schema.
+ *
+ * **Example** (Extracting the encoded type)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.NumberFromString
+ * type Enc = Schema.Encoded<typeof schema>
+ * // string
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type Encoded<S> = Codec.Encoded<S>
+
+/**
+ * Extracts the Effect services required during *decoding* from a schema.
+ *
+ * **Example** (Checking decoding service requirements)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.String
+ * type RD = Schema.DecodingServices<typeof schema>
+ * // never
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type DecodingServices<S> = Codec.DecodingServices<S>
+
+/**
+ * Extracts the Effect services required during *encoding* from a schema.
+ *
+ * **Example** (Checking encoding service requirements)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.String
+ * type RE = Schema.EncodingServices<typeof schema>
+ * // never
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type EncodingServices<S> = Codec.EncodingServices<S>
 
 /**
  * A schema that additionally supports optic (lens/prism) operations.


### PR DESCRIPTION
## Summary

- add top-level Schema type extractors in `packages/effect/src/Schema.ts`:
  - `Schema.Type<S>`
  - `Schema.Encoded<S>`
  - `Schema.DecodingServices<S>`
  - `Schema.EncodingServices<S>`
- keep existing nested aliases (`Schema.Schema.Type`, `Schema.Codec.*`) unchanged for compatibility
- update Schema docs/examples to prefer top-level extractor names
- update dtslint coverage in `packages/effect/dtslint/schema/Schema.tst.ts` to validate the new top-level aliases
- add changeset: `.changeset/eff-702-schema-type-extractors.md`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/schema/Schema.test.ts`
- `pnpm test-types packages/effect/dtslint/schema/Schema.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`