### PR TITLE
docs: README mismatch between 'pg' library deps and 'postgres.js'

### DIFF
--- a/packages/sql/pg/README.md
+++ b/packages/sql/pg/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-pg`
 
-An `@effect/sql` implementation using the `postgres.js` library.
+An `@effect/sql` implementation using the `pg` library.
 
 ## Documentation
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

fix mismatch between package.json deps and README.md description
