### PR TITLE
EFF-704 Use arguments predicate for Stream.merge

### DIFF
--- a/.changeset/eff-704-stream-merge-predicate.md
+++ b/.changeset/eff-704-stream-merge-predicate.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use predicate-based `dual` dispatch for `Stream.merge` so data-last calls with optional `options` are handled correctly.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -2863,7 +2863,7 @@ export const merge: {
     } | undefined
   ): Stream<A | A2, E | E2, R | R2>
 } = dual(
-  2,
+  (args) => isStream(args[0]) && isStream(args[1]),
   <A, E, R, A2, E2, R2>(
     self: Stream<A, E, R>,
     that: Stream<A2, E2, R2>,

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -3345,6 +3345,26 @@ describe("Stream", () => {
       }))
   })
 
+  describe("merge", () => {
+    it.effect("data-first with options", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.runCollect(
+          Stream.merge(Stream.make(1), Stream.never, { haltStrategy: "left" })
+        )
+        deepStrictEqual(result, [1])
+      }))
+
+    it.effect("data-last with options", () =>
+      Effect.gen(function*() {
+        const result = yield* pipe(
+          Stream.make(1),
+          Stream.merge(Stream.never, { haltStrategy: "left" }),
+          Stream.runCollect
+        )
+        deepStrictEqual(result, [1])
+      }))
+  })
+
   describe("partition", () => {
     it.effect("values", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary

- switch `Stream.merge` to predicate-based `dual` dispatch using stream argument checks
- keep API signatures unchanged while correctly handling variable argument forms with optional `options`
- add regression tests for both data-first and data-last calls with `haltStrategy` options
- add a patch changeset for `effect`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Stream.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`
