### PR TITLE
EFF-705 Add Layer.tap apis

### DIFF
--- a/.changeset/eff-705-layer-tap-apis.md
+++ b/.changeset/eff-705-layer-tap-apis.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Layer.tap`, `Layer.tapError`, and `Layer.tapCause` APIs for effectful observation of layer success and failure without changing layer outputs.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -1310,6 +1310,88 @@ export const flatMap: {
   ))
 
 /**
+ * Performs the specified effect if this layer succeeds.
+ *
+ * @since 4.0.0
+ * @category sequencing
+ */
+export const tap: {
+  <ROut, XR extends ROut, RIn2, E2, X>(
+    f: (context: ServiceMap.ServiceMap<XR>) => Effect<X, E2, RIn2>
+  ): <RIn, E>(self: Layer<ROut, E, RIn>) => Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+  <RIn, E, ROut, XR extends ROut, RIn2, E2, X>(
+    self: Layer<ROut, E, RIn>,
+    f: (context: ServiceMap.ServiceMap<XR>) => Effect<X, E2, RIn2>
+  ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+} = dual(2, <RIn, E, ROut, XR extends ROut, RIn2, E2, X>(
+  self: Layer<ROut, E, RIn>,
+  f: (context: ServiceMap.ServiceMap<XR>) => Effect<X, E2, RIn2>
+): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>> =>
+  fromBuild((memoMap, scope) =>
+    internalEffect.flatMap(
+      self.build(memoMap, scope),
+      (context) => Scope.provide(internalEffect.as(f(context as ServiceMap.ServiceMap<XR>), context), scope)
+    )
+  ))
+
+/**
+ * Performs the specified effect if this layer fails.
+ *
+ * @since 4.0.0
+ * @category sequencing
+ */
+export const tapError: {
+  <E, XE extends E, RIn2, E2, X>(
+    f: (e: XE) => Effect<X, E2, RIn2>
+  ): <RIn, ROut>(self: Layer<ROut, E, RIn>) => Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+  <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+    self: Layer<ROut, E, RIn>,
+    f: (e: XE) => Effect<X, E2, RIn2>
+  ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+} = dual(2, <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+  self: Layer<ROut, E, RIn>,
+  f: (e: XE) => Effect<X, E2, RIn2>
+): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>> =>
+  fromBuild((memoMap, scope) =>
+    internalEffect.catch_(
+      self.build(memoMap, scope),
+      (error) => Scope.provide(internalEffect.andThen(f(error as XE), internalEffect.fail(error)), scope)
+    )
+  ))
+
+/**
+ * Performs the specified effect if this layer fails.
+ *
+ * **Previously Known As**
+ *
+ * This API replaces the following from Effect 3.x:
+ *
+ * - `Layer.tapErrorCause`
+ *
+ * @since 4.0.0
+ * @category sequencing
+ */
+export const tapCause: {
+  <E, XE extends E, RIn2, E2, X>(
+    f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+  ): <RIn, ROut>(self: Layer<ROut, E, RIn>) => Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+  <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+    self: Layer<ROut, E, RIn>,
+    f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+  ): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>>
+} = dual(2, <RIn, E, XE extends E, ROut, RIn2, E2, X>(
+  self: Layer<ROut, E, RIn>,
+  f: (cause: Cause.Cause<XE>) => Effect<X, E2, RIn2>
+): Layer<ROut, E | E2, RIn | Exclude<RIn2, Scope.Scope>> =>
+  fromBuild((memoMap, scope) =>
+    internalEffect.catchCause(
+      self.build(memoMap, scope),
+      (cause) =>
+        Scope.provide(internalEffect.andThen(f(cause as Cause.Cause<XE>), internalEffect.failCause(cause)), scope)
+    )
+  ))
+
+/**
  * Translates effect failure into death of the fiber, making all failures
  * unchecked and not a part of the type of the layer.
  *

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Fiber, ServiceMap } from "effect"
+import * as Cause from "effect/Cause"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
@@ -88,6 +89,60 @@ describe("Layer", () => {
       )
       yield* Effect.scoped(env)
       assert.deepStrictEqual(arr, [acquire1, release1, acquire2, release2])
+    }))
+
+  it.effect("tap - executes effect with success services and preserves output", () =>
+    Effect.gen(function*() {
+      const arr: Array<string> = []
+      const env = makeLayer1(arr).pipe(
+        Layer.tap((context) =>
+          Effect.sync(() => {
+            arr.push(`tap:${ServiceMap.get(context, Service1Tag).constructor.name}`)
+          })
+        ),
+        Layer.build
+      )
+      const context = yield* Effect.scoped(env)
+      const service = ServiceMap.get(context, Service1Tag)
+      assert.strictEqual(yield* service.one(), 1)
+      assert.deepStrictEqual(arr, [acquire1, "tap:Service1", release1])
+    }))
+
+  it.effect("tapError - executes effect and preserves original error", () =>
+    Effect.gen(function*() {
+      const arr: Array<string> = []
+      const error = yield* Layer.effectDiscard(Effect.fail("failed!")).pipe(
+        Layer.tapError((e) =>
+          Effect.sync(() => {
+            arr.push(`tapError:${e}`)
+          })
+        ),
+        Layer.build,
+        Effect.scoped,
+        Effect.flip
+      )
+      assert.strictEqual(error, "failed!")
+      assert.deepStrictEqual(arr, ["tapError:failed!"])
+    }))
+
+  it.effect("tapCause - executes effect and preserves original cause", () =>
+    Effect.gen(function*() {
+      const arr: Array<string> = []
+      const exit = yield* Layer.effectDiscard(Effect.die("boom")).pipe(
+        Layer.tapCause((cause) =>
+          Effect.sync(() => {
+            arr.push(`tapCause:${Cause.hasDies(cause)}`)
+          })
+        ),
+        Layer.build,
+        Effect.scoped,
+        Effect.exit
+      )
+      assert.strictEqual(exit._tag, "Failure")
+      if (exit._tag === "Failure") {
+        assert.isTrue(Cause.hasDies(exit.cause))
+      }
+      assert.deepStrictEqual(arr, ["tapCause:true"])
     }))
 
   it.effect("fresh with merge", () =>


### PR DESCRIPTION
## Summary

Implements EFF-705 by adding Layer tap-style APIs:

- `Layer.tap`
- `Layer.tapError`
- `Layer.tapCause`

These APIs run effectful observers on layer success / error / cause and preserve the original layer output or original failure.

## Changes

- Added new public APIs in `packages/effect/src/Layer.ts`:
  - `tap`
  - `tapError`
  - `tapCause` (v4 naming aligned with `Effect.tapCause`; v3 equivalent was `tapErrorCause`)
- Added runtime tests in `packages/effect/test/Layer.test.ts` covering:
  - success path behavior for `tap`
  - failure path behavior for `tapError` with original error preserved
  - failure-cause behavior for `tapCause` with original cause preserved
- Added changeset:
  - `.changeset/eff-705-layer-tap-apis.md`

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Layer.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`
