### PR TITLE
EFF-708 Add SubscriptionRef.makeScoped

### DIFF
--- a/.changeset/eff-708-subscriptionref-makescoped.md
+++ b/.changeset/eff-708-subscriptionref-makescoped.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+SubscriptionRef: add `makeScoped` constructor that shuts down the underlying `PubSub` when its scope is released.

--- a/packages/effect/src/SubscriptionRef.ts
+++ b/packages/effect/src/SubscriptionRef.ts
@@ -8,6 +8,7 @@ import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import * as PubSub from "./PubSub.ts"
 import * as Ref from "./Ref.ts"
+import type * as Scope from "./Scope.ts"
 import * as Semaphore from "./Semaphore.ts"
 import * as Stream from "./Stream.ts"
 import type { Invariant } from "./Types.ts"
@@ -77,6 +78,16 @@ export const make = <A>(value: A): Effect.Effect<SubscriptionRef<A>> =>
     PubSub.publishUnsafe(self.pubsub, value)
     return self
   })
+
+/**
+ * Constructs a new `SubscriptionRef` from an initial value and shuts down the
+ * underlying `PubSub` when the scope is closed.
+ *
+ * @since 4.0.0
+ * @category constructors
+ */
+export const makeScoped = <A>(value: A): Effect.Effect<SubscriptionRef<A>, never, Scope.Scope> =>
+  Effect.acquireRelease(make(value), (self) => PubSub.shutdown(self.pubsub))
 
 /**
  * Creates a stream that emits the current value and all subsequent changes to

--- a/packages/effect/test/SubscriptionRef.test.ts
+++ b/packages/effect/test/SubscriptionRef.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Effect, Exit, Fiber, Latch, Number, Pull, Random, Stream, SubscriptionRef } from "effect"
+import { Array, Effect, Exit, Fiber, Latch, Number, PubSub, Pull, Random, Stream, SubscriptionRef } from "effect"
 
 describe("SubscriptionRef", () => {
   it.effect("multiple subscribers can receive changes", () =>
@@ -71,6 +71,12 @@ describe("SubscriptionRef", () => {
       yield* Fiber.interrupt(producer)
       assert.deepStrictEqual(result1, Array.sort(Number.Order)(result1))
       assert.deepStrictEqual(result2, Array.sort(Number.Order)(result2))
+    }))
+
+  it.effect("makeScoped shuts down the underlying PubSub on scope release", () =>
+    Effect.gen(function*() {
+      const pubsub = yield* Effect.scoped(Effect.map(SubscriptionRef.makeScoped(0), (ref) => ref.pubsub))
+      assert.isTrue(yield* PubSub.isShutdown(pubsub))
     }))
 })
 


### PR DESCRIPTION
## Summary
- add `SubscriptionRef.makeScoped` in `packages/effect/src/SubscriptionRef.ts`
- implement it as a scoped constructor using `Effect.acquireRelease(make(value), ...)`
- release action calls `PubSub.shutdown(self.pubsub)`
- add regression test in `packages/effect/test/SubscriptionRef.test.ts` asserting the underlying `PubSub` is shutdown after scope release
- add changeset: `.changeset/eff-708-subscriptionref-makescoped.md`

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/SubscriptionRef.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`