### PR TITLE
EFF-715 Add Stream.catchIf

### DIFF
--- a/.changeset/odd-bulldogs-sleep.md
+++ b/.changeset/odd-bulldogs-sleep.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add dtslint coverage for `Stream.catchIf` to lock in predicate and refinement inference behavior in both data-first and data-last forms.

--- a/packages/effect/dtslint/Stream.tst.ts
+++ b/packages/effect/dtslint/Stream.tst.ts
@@ -1,0 +1,56 @@
+import { Data, pipe, Stream } from "effect"
+import { describe, expect, it } from "tstyche"
+
+class ErrorA extends Data.TaggedError("ErrorA")<{
+  readonly message: string
+}> {}
+
+class ErrorB extends Data.TaggedError("ErrorB")<{
+  readonly code: number
+}> {}
+
+declare const stream: Stream.Stream<string, ErrorA | ErrorB, "dep-1">
+declare const predicate: (error: ErrorA | ErrorB) => boolean
+
+describe("Stream.catchIf", () => {
+  it("supports refinement in data-last usage", () => {
+    const result = pipe(
+      stream,
+      Stream.catchIf(
+        (error): error is ErrorA => error._tag === "ErrorA",
+        (error) => {
+          expect(error).type.toBe<ErrorA>()
+          return Stream.succeed("recovered")
+        }
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
+  })
+
+  it("supports refinement with orElse", () => {
+    const result = pipe(
+      stream,
+      Stream.catchIf(
+        (error): error is ErrorA => error._tag === "ErrorA",
+        () => Stream.succeed(1),
+        (error) => {
+          expect(error).type.toBe<ErrorB>()
+          return Stream.succeed(2)
+        }
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string | number, never, "dep-1">>()
+  })
+
+  it("supports predicate in data-first usage", () => {
+    const result = Stream.catchIf(
+      stream,
+      predicate,
+      (error) => {
+        expect(error).type.toBe<ErrorA | ErrorB>()
+        return Stream.succeed(0)
+      }
+    )
+    expect(result).type.toBe<Stream.Stream<string | number, ErrorA | ErrorB, "dep-1">>()
+  })
+})


### PR DESCRIPTION
## Summary

- add a new dtslint file at `packages/effect/dtslint/Stream.tst.ts`
- add type-level coverage for `Stream.catchIf` across:
  - refinement-based usage (data-last)
  - refinement + `orElse` usage (data-last)
  - predicate-based usage (data-first)
- add a changeset for the `effect` package documenting the added `Stream.catchIf` type-level coverage

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/Stream.test.ts
- pnpm test-types packages/effect/dtslint/Stream.tst.ts
- pnpm check:tsgo
- pnpm docgen
