### PR TITLE
EFF-716: ResponseIdTracker use Map and clear on reset

### DIFF
--- a/.changeset/eff-716-response-id-tracker-map.md
+++ b/.changeset/eff-716-response-id-tracker-map.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Use a normal Map in ResponseIdTracker and clear it on divergence / reset instead of reallocating a WeakMap.

--- a/packages/effect/src/unstable/ai/ResponseIdTracker.ts
+++ b/packages/effect/src/unstable/ai/ResponseIdTracker.ts
@@ -38,16 +38,16 @@ export class ResponseIdTracker
  * @category constructors
  */
 export const make: Effect.Effect<Service> = Effect.sync(() => {
-  let sentParts = new WeakMap<object, string>()
+  const sentParts = new Map<object, string>()
 
   const none = () => {
-    sentParts = new WeakMap<object, string>()
+    sentParts.clear()
     return Option.none<PrepareResult>()
   }
 
   return {
     clearUnsafe() {
-      sentParts = new WeakMap<object, string>()
+      sentParts.clear()
     },
     markParts(parts, responseId) {
       for (let i = 0; i < parts.length; i++) {


### PR DESCRIPTION
## Summary\n- switch ResponseIdTracker sentParts storage from WeakMap to Map\n- replace map re-allocation on divergence/reset paths with Map.clear()\n- add changeset for effect patch release\n\n## Validation\n- pnpm lint-fix\n- pnpm test packages/effect/test/unstable/ai/ResponseIdTracker.test.ts\n- pnpm test packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts\n- pnpm check:tsgo\n- pnpm docgen