### PR TITLE
EFF-725 Fix JSDoc wording for Effect.catch

### DIFF
--- a/.changeset/eff-725-fix-catch-jsdoc.md
+++ b/.changeset/eff-725-fix-catch-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix JSDoc wording for `Effect.catch` to consistently reference the current API name.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2708,12 +2708,12 @@ export {
    *
    * **Details**
    *
-   * The `catchAll` function catches any errors that may occur during the
+   * The `catch` function catches any errors that may occur during the
    * execution of an effect and allows you to handle them by specifying a fallback
    * effect. This ensures that the program continues without failing by recovering
    * from errors using the provided fallback logic.
    *
-   * **Note**: `catchAll` only handles recoverable errors. It will not recover
+   * **Note**: `catch` only handles recoverable errors. It will not recover
    * from unrecoverable defects.
    *
    * @see {@link catchCause} for a version that can recover from both recoverable and unrecoverable errors.


### PR DESCRIPTION
## Summary
- update the JSDoc for `Effect.catch` in `packages/effect/src/Effect.ts` to consistently refer to `catch` instead of `catchAll`
- keep migration note pointing to Effect 3.x `Effect.catchAll`
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm check:tsgo
- pnpm docgen