### PR TITLE
EFF-727 Align CLI help description columns for long flags

### DIFF
--- a/.changeset/eff-727-cli-help-alignment.md
+++ b/.changeset/eff-727-cli-help-alignment.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Align CLI help flag and global flag descriptions to a single column even when some flag names are very long.

--- a/packages/effect/src/unstable/cli/CliOutput.ts
+++ b/packages/effect/src/unstable/cli/CliOutput.ts
@@ -406,8 +406,9 @@ interface Row {
  * Renders a table with aligned columns.
  * @internal
  */
-const renderTable = (rows: ReadonlyArray<Row>, widthCap: number) => {
-  const col = Math.min(Math.max(...rows.map((r) => visualLength(r.left))) + 4, widthCap)
+const renderTable = (rows: ReadonlyArray<Row>, widthCap?: number) => {
+  const maxColumn = Math.max(...rows.map((r) => visualLength(r.left))) + 4
+  const col = widthCap === undefined ? maxColumn : Math.min(maxColumn, widthCap)
   return rows.map(({ left, right }) => `  ${pad(left, col)}${right}`).join("\n")
 }
 
@@ -497,7 +498,7 @@ const formatHelpDocImpl = (doc: HelpDoc, colors: ColorFunctions): string => {
       }
     })
 
-    sections.push(renderTable(flagRows, 30))
+    sections.push(renderTable(flagRows))
     sections.push("")
   }
 
@@ -525,7 +526,7 @@ const formatHelpDocImpl = (doc: HelpDoc, colors: ColorFunctions): string => {
       }
     })
 
-    sections.push(renderTable(globalFlagRows, 30))
+    sections.push(renderTable(globalFlagRows))
     sections.push("")
   }
 

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -74,6 +74,28 @@ describe("Command help output", () => {
       `)
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("aligns flag descriptions when flag names are long", () =>
+    Effect.gen(function*() {
+      const command = Command.make("tool", {
+        short: Flag.string("short").pipe(Flag.withDescription("Short flag description")),
+        veryLong: Flag.string("this-is-a-very-very-long-flag-name").pipe(
+          Flag.withDescription("Long flag description")
+        )
+      })
+      const run = Command.runWith(command, { version: "1.0.0" })
+
+      yield* run(["--help"])
+
+      const helpText = (yield* TestConsole.logLines).join("\n")
+      const lines = helpText.split("\n")
+      const shortLine = lines.find((line) => line.includes("--short"))
+      const longLine = lines.find((line) => line.includes("--this-is-a-very-very-long-flag-name"))
+
+      expect(shortLine).toBeDefined()
+      expect(longLine).toBeDefined()
+      expect(shortLine!.indexOf("Short flag description")).toBe(longLine!.indexOf("Long flag description"))
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("command help renders examples", () =>
     Effect.gen(function*() {
       const command = Command.make("login").pipe(


### PR DESCRIPTION
## Summary
- remove the width cap for flag and global flag table columns in CLI help output
- keep existing width caps for arguments and subcommands
- add a regression test that verifies long and short flag descriptions start at the same column
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Help.test.ts
- pnpm check:tsgo
- pnpm docgen