### PR TITLE
EFF-728: Anthropic provider support for dynamic tools

### DIFF
--- a/.changeset/odd-forks-talk.md
+++ b/.changeset/odd-forks-talk.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Add dynamic tool support to the Anthropic language model provider when preparing tool definitions for requests.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -1001,9 +1001,9 @@ const prepareTools = Effect.fnUntraced(
     const providerTools: Array<AnthropicProviderDefinedTool> = []
 
     for (const tool of options.tools) {
-      if (Tool.isUserDefined(tool)) {
+      if (Tool.isUserDefined(tool) || Tool.isDynamic(tool)) {
         const description = Tool.getDescription(tool)
-        const input_schema = yield* tryJsonSchema(tool.parametersSchema, "prepareTools")
+        const input_schema = yield* tryToolJsonSchema(tool, "prepareTools")
         const toolStrict = Tool.getStrictMode(tool)
         const strict = capabilities.supportsStructuredOutput
           ? (toolStrict ?? config.strictJsonSchema ?? true)
@@ -2737,6 +2737,12 @@ const tryCodecTransform = <S extends Schema.Top>(schema: S, method: string) =>
 const tryJsonSchema = <S extends Schema.Top>(schema: S, method: string) =>
   Effect.try({
     try: () => Tool.getJsonSchemaFromSchema(schema, { transformer: toCodecAnthropic }),
+    catch: (error) => unsupportedSchemaError(error, method)
+  })
+
+const tryToolJsonSchema = <T extends Tool.Any | Tool.AnyDynamic>(tool: T, method: string) =>
+  Effect.try({
+    try: () => Tool.getJsonSchema(tool, { transformer: toCodecAnthropic }),
     catch: (error) => unsupportedSchemaError(error, method)
   })
 

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -112,6 +112,79 @@ describe("AnthropicLanguageModel", () => {
         assert.deepStrictEqual(toolCall.params, toolParams)
       }))
   })
+
+  describe("generateText", () => {
+    it.effect("encodes dynamic tools", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model: "claude-sonnet-4-20250514",
+                content: [{ type: "text", text: "Done" }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        const inputSchema = {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            limit: { type: "number" }
+          },
+          required: ["query"],
+          additionalProperties: false
+        } as const
+
+        const DynamicTool = Tool.dynamic("DynamicTool", {
+          description: "A dynamic tool",
+          parameters: inputSchema
+        })
+
+        yield* LanguageModel.generateText({
+          prompt: "Use the dynamic tool",
+          toolkit: Toolkit.make(DynamicTool),
+          disableToolCallResolution: true
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model("claude-sonnet-4-20250514")),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const body = yield* getRequestBody(capturedRequest)
+        const dynamicTool = body.tools.find((tool: any) => tool.name === "DynamicTool")
+
+        assert.isDefined(dynamicTool)
+        if (dynamicTool === undefined) {
+          return
+        }
+
+        assert.strictEqual(dynamicTool.description, "A dynamic tool")
+        assert.deepStrictEqual(dynamicTool.input_schema, inputSchema)
+      }))
+  })
 })
 
 const makeHttpClient = (
@@ -140,6 +213,29 @@ const sseResponse = (
       }
     })
   )
+
+const jsonResponse = (
+  request: HttpClientRequest.HttpClientRequest,
+  body: unknown
+): HttpClientResponse.HttpClientResponse =>
+  HttpClientResponse.fromWeb(
+    request,
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: {
+        "content-type": "application/json"
+      }
+    })
+  )
+
+const getRequestBody = (request: HttpClientRequest.HttpClientRequest) =>
+  Effect.gen(function*() {
+    const body = request.body
+    if (body._tag !== "Uint8Array") {
+      return yield* Effect.die(new Error("Expected Uint8Array body"))
+    }
+    return JSON.parse(new TextDecoder().decode(body.body))
+  })
 
 const toSseBody = (events: ReadonlyArray<unknown>): string =>
   events.map((event) => `event: message_stream\ndata: ${JSON.stringify(event)}\n\n`).join("")


### PR DESCRIPTION
## Summary
- treat dynamic tools like user-defined tools in Anthropic tool preparation
- use `Tool.getJsonSchema` when preparing tool schemas so runtime JSON Schema dynamic tools are preserved
- add Anthropic language model test coverage to assert dynamic tools are encoded into outgoing requests
- add changeset for `@effect/ai-anthropic`