### PR TITLE
EFF-698 Remove unreachable array branch in decodeJsonRpcRaw

### DIFF
--- a/.changeset/eff-698-rpcserialization-unreachable-branch.md
+++ b/.changeset/eff-698-rpcserialization-unreachable-branch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove an unreachable array branch in `decodeJsonRpcRaw` to simplify JSON-RPC decode logic without changing behavior.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -175,7 +175,7 @@ function decodeJsonRpcRaw(
     }
     return messages
   }
-  return Array.isArray(decoded) ? decoded.map(decodeJsonRpcMessage) : [decodeJsonRpcMessage(decoded)]
+  return [decodeJsonRpcMessage(decoded)]
 }
 
 function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEncoded | RpcMessage.FromServerEncoded {


### PR DESCRIPTION
## Summary
- remove unreachable `Array.isArray(decoded)` branch in `decodeJsonRpcRaw` after the existing early array return
- keep single-message decode behavior unchanged by returning a one-element array with `decodeJsonRpcMessage(decoded)`
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/rpc/RpcSerialization.test.ts
- pnpm check:tsgo
- pnpm docgen