### PR TITLE
EFF-729: support release dependencies in Effect.acquireRelease

### DIFF
--- a/.changeset/bright-lemons-dance.md
+++ b/.changeset/bright-lemons-dance.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow `Effect.acquireRelease` release finalizers to depend on the surrounding environment.

--- a/packages/effect/dtslint/Effect.tst.ts
+++ b/packages/effect/dtslint/Effect.tst.ts
@@ -1,16 +1,5 @@
 /** @effect-diagnostics floatingEffect:skip-file */
-import {
-  type Cause,
-  Data,
-  Effect,
-  Fiber,
-  type Option,
-  pipe,
-  Result,
-  type Scope,
-  type ServiceMap,
-  type Types
-} from "effect"
+import { type Cause, Data, Effect, Fiber, type Option, pipe, Result, type Scope, ServiceMap, type Types } from "effect"
 import { describe, expect, it } from "tstyche"
 
 // Fixtures
@@ -48,6 +37,10 @@ declare const string: Effect.Effect<string, "err-1", "dep-1">
 declare const number: Effect.Effect<number, "err-2", "dep-2">
 declare const stringArray: Array<Effect.Effect<string, "err-3", "dep-3">>
 declare const numberRecord: Record<string, Effect.Effect<number, "err-4", "dep-4">>
+
+class AcquireReleaseDependency extends ServiceMap.Service<AcquireReleaseDependency, string>()(
+  "AcquireReleaseDependency"
+) {}
 
 describe("Types", () => {
   describe("ReasonOf", () => {
@@ -336,6 +329,16 @@ describe("Effect.forkScoped", () => {
       Effect.flatMap(Fiber.join)
     )
     expect(result).type.toBe<Effect.Effect<string, "err-1", "dep-1" | Scope.Scope>>()
+  })
+})
+
+describe("Effect.acquireRelease", () => {
+  it("supports dependencies in the release finalizer", () => {
+    const result = Effect.acquireRelease(
+      Effect.succeed("resource"),
+      () => Effect.service(AcquireReleaseDependency)
+    )
+    expect(result).type.toBe<Effect.Effect<string, never, AcquireReleaseDependency | Scope.Scope>>()
   })
 })
 

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6234,11 +6234,11 @@ export const scopedWith: <A, E, R>(
  * @since 2.0.0
  * @category Resource Management & Finalization
  */
-export const acquireRelease: <A, E, R>(
+export const acquireRelease: <A, E, R, R2>(
   acquire: Effect<A, E, R>,
-  release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<unknown>,
+  release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect<unknown, never, R2>,
   options?: { readonly interruptible?: boolean }
-) => Effect<A, E, Scope | R> = internal.acquireRelease
+) => Effect<A, E, R | R2 | Scope> = internal.acquireRelease
 
 /**
  * This function is used to ensure that an `Effect` value that represents the

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3792,19 +3792,21 @@ export const scopedWith = <A, E, R>(
   })
 
 /** @internal */
-export const acquireRelease = <A, E, R>(
+export const acquireRelease = <A, E, R, R2>(
   acquire: Effect.Effect<A, E, R>,
-  release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<unknown>,
+  release: (a: A, exit: Exit.Exit<unknown, unknown>) => Effect.Effect<unknown, never, R2>,
   options?: { readonly interruptible?: boolean }
-): Effect.Effect<A, E, R | Scope.Scope> =>
-  uninterruptibleMask((restore) =>
-    flatMap(
-      scope,
-      (scope) =>
-        tap(
-          options?.interruptible ? restore(acquire) : acquire,
-          (a) => scopeAddFinalizerExit(scope, (exit) => release(a, exit))
-        )
+): Effect.Effect<A, E, R | R2 | Scope.Scope> =>
+  servicesWith((services: ServiceMap.ServiceMap<R2>) =>
+    uninterruptibleMask((restore) =>
+      flatMap(
+        scope,
+        (scope) =>
+          tap(
+            options?.interruptible ? restore(acquire) : acquire,
+            (a) => scopeAddFinalizerExit(scope, (exit) => provideServices(release(a, exit), services))
+          )
+      )
     )
   )
 

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -557,6 +557,28 @@ describe("Effect", () => {
         yield* Fiber.await(fiber)
         assert.strictEqual(release, true)
       }).pipe(Effect.runPromise))
+
+    it.effect("supports release dependencies", () =>
+      Effect.gen(function*() {
+        let release = false
+        const scope = yield* Scope.make()
+        yield* Scope.provide(scope)(
+          Effect.provideService(
+            Effect.acquireRelease(
+              Effect.succeed("foo"),
+              () =>
+                Effect.flatMap(Effect.service(ATag), () =>
+                  Effect.sync(() => {
+                    release = true
+                  }))
+            ),
+            ATag,
+            "A"
+          )
+        )
+        yield* Scope.close(scope, Exit.void)
+        assert.strictEqual(release, true)
+      }))
   })
 
   it.effect("raceAll", () =>


### PR DESCRIPTION
## Summary
- extend `Effect.acquireRelease` typings so release finalizers can require environment dependencies
- capture and re-provide current services when registering acquireRelease finalizers, matching addFinalizer behavior
- add runtime and dtslint regression tests for release dependency support
- add a patch changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test-types packages/effect/dtslint/Effect.tst.ts
- pnpm check:tsgo
- pnpm docgen