### PR TITLE
EFF-730 Fix ai LanguageModel incremental prompt fallback

### DIFF
--- a/.changeset/eff-730-language-model-incremental-fallback.md
+++ b/.changeset/eff-730-language-model-incremental-fallback.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `LanguageModel` incremental prompt fallback to reliably retry with the full prompt when an incremental request fails with `InvalidRequestError`.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -937,19 +937,23 @@ export const make: (params: {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
 
-    const withNonIncrementalFallback = <R>(
-      effect: Effect.Effect<Array<Response.PartEncoded>, AiError.AiError, R>
-    ): Effect.Effect<Array<Response.PartEncoded>, AiError.AiError, R | IdGenerator> =>
-      providerOptions.incrementalPrompt ?
-        effect.pipe(
-          Effect.catchReason("AiError", "InvalidRequestError", (_) =>
-            params.generateText({
-              ...providerOptions,
-              incrementalPrompt: undefined,
-              previousResponseId: undefined
-            }))
-        ) :
-        effect
+    const generateWithNonIncrementalFallback = () => {
+      const requestOptions: ProviderOptions = {
+        ...providerOptions
+      }
+      const fallbackPrompt = requestOptions.prompt
+      const fallbackOptions: ProviderOptions = {
+        ...requestOptions,
+        prompt: fallbackPrompt,
+        incrementalPrompt: undefined,
+        previousResponseId: undefined
+      }
+      return requestOptions.incrementalPrompt
+        ? params.generateText(requestOptions).pipe(
+          Effect.catchReason("AiError", "InvalidRequestError", (_) => params.generateText(fallbackOptions))
+        )
+        : params.generateText(requestOptions)
+    }
 
     // Check for pending approvals that need resolution
     const { approved, denied } = collectToolApprovals(
@@ -982,7 +986,7 @@ export const make: (params: {
       const ResponseSchema = Schema.mutable(
         Schema.Array(Response.Part(Toolkit.empty))
       )
-      const rawContent = yield* withNonIncrementalFallback(params.generateText(providerOptions))
+      const rawContent = yield* generateWithNonIncrementalFallback()
       const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
@@ -1020,7 +1024,7 @@ export const make: (params: {
       const ResponseSchema = Schema.mutable(
         Schema.Array(Response.Part(Toolkit.empty))
       )
-      const rawContent = yield* withNonIncrementalFallback(params.generateText(providerOptions))
+      const rawContent = yield* generateWithNonIncrementalFallback()
       const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
@@ -1099,7 +1103,7 @@ export const make: (params: {
     // If tool call resolution is disabled, return the response without
     // resolving the tool calls that were generated
     if (options.disableToolCallResolution === true) {
-      const rawContent = yield* withNonIncrementalFallback(params.generateText(providerOptions))
+      const rawContent = yield* generateWithNonIncrementalFallback()
       const content = yield* Schema.decodeEffect(ResponseSchema)(rawContent)
       if (tracker) {
         const responseMetadata = content.find((part) => part.type === "response-metadata")
@@ -1110,7 +1114,7 @@ export const make: (params: {
       return content as Array<Response.Part<Tools>>
     }
 
-    const rawContent = yield* withNonIncrementalFallback(params.generateText(providerOptions))
+    const rawContent = yield* generateWithNonIncrementalFallback()
 
     // Resolve the generated tool calls
     const toolResults = yield* resolveToolCalls(
@@ -1168,19 +1172,23 @@ export const make: (params: {
     const tracker = Option.getOrUndefined(yield* Effect.serviceOption(ResponseIdTracker.ResponseIdTracker))
     const toolChoice = options.toolChoice ?? "auto"
 
-    const withNonIncrementalFallback = <R>(
-      stream: Stream.Stream<Response.StreamPartEncoded, AiError.AiError, R>
-    ): Stream.Stream<Response.StreamPartEncoded, AiError.AiError, R | IdGenerator> =>
-      providerOptions.incrementalPrompt ?
-        stream.pipe(
-          Stream.catchReason("AiError", "InvalidRequestError", (_) =>
-            params.streamText({
-              ...providerOptions,
-              incrementalPrompt: undefined,
-              previousResponseId: undefined
-            }))
-        ) :
-        stream
+    const streamWithNonIncrementalFallback = () => {
+      const requestOptions: ProviderOptions = {
+        ...providerOptions
+      }
+      const fallbackPrompt = requestOptions.prompt
+      const fallbackOptions: ProviderOptions = {
+        ...requestOptions,
+        prompt: fallbackPrompt,
+        incrementalPrompt: undefined,
+        previousResponseId: undefined
+      }
+      return requestOptions.incrementalPrompt
+        ? params.streamText(requestOptions).pipe(
+          Stream.catchReason("AiError", "InvalidRequestError", (_) => params.streamText(fallbackOptions))
+        )
+        : params.streamText(requestOptions)
+    }
 
     // Check for pending approvals that need resolution
     const { approved: pendingApproved, denied: pendingDenied } = collectToolApprovals(providerOptions.prompt.content, {
@@ -1212,8 +1220,7 @@ export const make: (params: {
       const schema = Schema.NonEmptyArray(Response.StreamPart(Toolkit.empty))
       const decodeParts = Schema.decodeEffect(schema)
       return pipe(
-        params.streamText(providerOptions),
-        withNonIncrementalFallback,
+        streamWithNonIncrementalFallback(),
         Stream.mapArrayEffect((parts) =>
           decodeParts(parts).pipe(
             tracker ?
@@ -1262,8 +1269,7 @@ export const make: (params: {
       const schema = Schema.NonEmptyArray(Response.StreamPart(Toolkit.empty))
       const decodeParts = Schema.decodeEffect(schema)
       return pipe(
-        params.streamText(providerOptions),
-        withNonIncrementalFallback,
+        streamWithNonIncrementalFallback(),
         Stream.mapArrayEffect((parts) =>
           decodeParts(parts).pipe(
             tracker ?
@@ -1369,8 +1375,7 @@ export const make: (params: {
     if (options.disableToolCallResolution === true) {
       const schema = Schema.NonEmptyArray(Response.StreamPart(toolkit))
       const decodeParts = Schema.decodeEffect(schema)
-      return params.streamText(providerOptions).pipe(
-        withNonIncrementalFallback,
+      return streamWithNonIncrementalFallback().pipe(
         Stream.mapArrayEffect((parts) =>
           decodeParts(parts).pipe(
             tracker ?
@@ -1449,8 +1454,7 @@ export const make: (params: {
       )
     })
 
-    yield* params.streamText(providerOptions).pipe(
-      withNonIncrementalFallback,
+    yield* streamWithNonIncrementalFallback().pipe(
       Stream.runForEachArray(
         Effect.fnUntraced(function*(chunk) {
           const parts = yield* decodeParts(chunk)

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@effect/vitest"
 import { assertDefined, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
 import { Effect, Latch, Option, Schema, Stream } from "effect"
 import { TestClock } from "effect/testing"
-import { LanguageModel, Prompt, Response, ResponseIdTracker, Tool, Toolkit } from "effect/unstable/ai"
+import { AiError, LanguageModel, Prompt, Response, ResponseIdTracker, Tool, Toolkit } from "effect/unstable/ai"
 import * as TestUtils from "./utils.ts"
 
 const MyTool = Tool.make("MyTool", {
@@ -202,6 +202,121 @@ describe("LanguageModel", () => {
         assertDefined(capturedOptions)
         strictEqual(capturedOptions.previousResponseId, undefined)
         strictEqual(capturedOptions.incrementalPrompt, undefined)
+      }))
+
+    it("falls back to full prompt in generateText when incremental request fails", () =>
+      Effect.gen(function*() {
+        const fullPrompt = Prompt.make([
+          Prompt.systemMessage({ content: "system" }),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "user" })] }),
+          Prompt.assistantMessage({ content: [Prompt.textPart({ text: "assistant" })] }),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "next" })] })
+        ])
+
+        const incrementalPrompt = Prompt.make([
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "next" })] })
+        ])
+
+        const calls: Array<LanguageModel.ProviderOptions> = []
+
+        yield* LanguageModel.generateText({
+          prompt: fullPrompt
+        }).pipe(
+          Effect.provideServiceEffect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: (options) => {
+                calls.push(options)
+                if (calls.length === 1) {
+                  ;(options as any).prompt = options.incrementalPrompt ?? options.prompt
+                  return Effect.fail(AiError.make({
+                    module: "LanguageModelTest",
+                    method: "generateText",
+                    reason: new AiError.InvalidRequestError({
+                      description: "invalid previous response id"
+                    })
+                  }))
+                }
+                return Effect.succeed([finishPart])
+              },
+              streamText: () => Stream.empty
+            })
+          ),
+          Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            clearUnsafe() {},
+            markParts() {},
+            prepareUnsafe: () =>
+              Option.some({
+                previousResponseId: "resp_prev",
+                prompt: incrementalPrompt
+              })
+          })
+        )
+
+        strictEqual(calls.length, 2)
+        strictEqual(calls[0]!.previousResponseId, "resp_prev")
+        strictEqual(calls[0]!.incrementalPrompt, incrementalPrompt)
+        strictEqual(calls[1]!.previousResponseId, undefined)
+        strictEqual(calls[1]!.incrementalPrompt, undefined)
+        deepStrictEqual(calls[1]!.prompt, fullPrompt)
+      }))
+
+    it("falls back to full prompt in streamText when incremental request fails", () =>
+      Effect.gen(function*() {
+        const fullPrompt = Prompt.make([
+          Prompt.systemMessage({ content: "system" }),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "user" })] }),
+          Prompt.assistantMessage({ content: [Prompt.textPart({ text: "assistant" })] }),
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "next" })] })
+        ])
+
+        const incrementalPrompt = Prompt.make([
+          Prompt.userMessage({ content: [Prompt.textPart({ text: "next" })] })
+        ])
+
+        const calls: Array<LanguageModel.ProviderOptions> = []
+
+        yield* LanguageModel.streamText({
+          prompt: fullPrompt
+        }).pipe(
+          Stream.runDrain,
+          Effect.provideServiceEffect(
+            LanguageModel.LanguageModel,
+            LanguageModel.make({
+              generateText: () => Effect.succeed([finishPart]),
+              streamText: (options) => {
+                calls.push(options)
+                if (calls.length === 1) {
+                  ;(options as any).prompt = options.incrementalPrompt ?? options.prompt
+                  return Stream.fail(AiError.make({
+                    module: "LanguageModelTest",
+                    method: "streamText",
+                    reason: new AiError.InvalidRequestError({
+                      description: "invalid previous response id"
+                    })
+                  }))
+                }
+                return Stream.fromIterable([finishPart])
+              }
+            })
+          ),
+          Effect.provideService(ResponseIdTracker.ResponseIdTracker, {
+            clearUnsafe() {},
+            markParts() {},
+            prepareUnsafe: () =>
+              Option.some({
+                previousResponseId: "resp_prev",
+                prompt: incrementalPrompt
+              })
+          })
+        )
+
+        strictEqual(calls.length, 2)
+        strictEqual(calls[0]!.previousResponseId, "resp_prev")
+        strictEqual(calls[0]!.incrementalPrompt, incrementalPrompt)
+        strictEqual(calls[1]!.previousResponseId, undefined)
+        strictEqual(calls[1]!.incrementalPrompt, undefined)
+        deepStrictEqual(calls[1]!.prompt, fullPrompt)
       }))
 
     it("uses tracker prepareUnsafe and markParts in generateText without toolkit", () =>


### PR DESCRIPTION
## Summary
- harden LanguageModel incremental fallback in both generate and stream paths by cloning request options before provider calls
- on InvalidRequestError retry with incremental fields cleared while preserving the original full prompt snapshot
- add regression tests that simulate provider-side mutation of request options and verify fallback retries send full prompt
- add changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen