### PR TITLE
EFF-731 Fix missing OpenAI tool call output serialization

### DIFF
--- a/.changeset/eff-731-openai-tool-output.md
+++ b/.changeset/eff-731-openai-tool-output.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Fix OpenAI function call output serialization when a tool returns `undefined` so the request always includes an `output` field.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -880,7 +880,7 @@ const prepareMessages = Effect.fnUntraced(
             messages.push({
               type: "function_call_output",
               call_id: part.id,
-              output: JSON.stringify(part.result),
+              output: stringifyJson(part.result),
               ...(Predicate.isNotNull(status) ? { status } : {})
             })
           }
@@ -2476,6 +2476,11 @@ const makeItemIdMetadata = (itemId: string | undefined) => Predicate.isNotUndefi
 
 const makeEncryptedContentMetadata = (encryptedContent: string | null | undefined) =>
   Predicate.isNotNullish(encryptedContent) ? { encryptedContent } : undefined
+
+const stringifyJson = (value: unknown): string =>
+  typeof value === "string"
+    ? value
+    : JSON.stringify(value) ?? "null"
 
 const unsupportedSchemaError = (error: unknown, method: string): AiError.AiError =>
   AiError.make({

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -394,6 +394,46 @@ describe("OpenAiLanguageModel", () => {
             strictEqual(toolOutput.call_id, "call_abc")
             strictEqual(toolOutput.output, JSON.stringify({ output: "result" }))
           }).pipe(Effect.provide([makeTestLayer(), TestToolkitLayer])))
+
+        it.effect("converts undefined tool results to null output", () =>
+          Effect.gen(function*() {
+            yield* LanguageModel.generateText({
+              prompt: Prompt.make([
+                { role: "user", content: "Use the tool" },
+                {
+                  role: "assistant",
+                  content: [
+                    Prompt.toolCallPart({
+                      id: "call_abc",
+                      name: "TestTool",
+                      params: { input: "test" },
+                      providerExecuted: false
+                    })
+                  ]
+                },
+                {
+                  role: "tool",
+                  content: [
+                    Prompt.toolResultPart({
+                      id: "call_abc",
+                      name: "TestTool",
+                      isFailure: false,
+                      result: undefined
+                    })
+                  ]
+                }
+              ]),
+              toolkit: TestToolkit
+            }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+            const requests = yield* MockHttpClient.requests
+            const body = yield* getRequestBody(requests[0])
+
+            const toolOutput = body.input.find((m: any) => m.type === "function_call_output")
+            assert.isDefined(toolOutput)
+            strictEqual(toolOutput.call_id, "call_abc")
+            strictEqual(toolOutput.output, "null")
+          }).pipe(Effect.provide([makeTestLayer(), TestToolkitLayer])))
       })
     })
 


### PR DESCRIPTION
## Summary
- identify the root cause of intermittent OpenAI "tool call output is missing" errors: tool results with `undefined` were serialized with `JSON.stringify`, which yields `undefined` and drops the required `output` field
- update OpenAI response message preparation to use a safe serializer that preserves strings and falls back to `"null"` when JSON serialization returns `undefined`
- add a regression test that verifies undefined tool results are sent as `function_call_output.output = "null"`
- add a changeset for `@effect/ai-openai`

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen