### PR TITLE
Fix Stream.scanEffect hanging behavior

### DIFF
--- a/.changeset/fix-stream-scan-effect.md
+++ b/.changeset/fix-stream-scan-effect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.scanEffect` hanging and repeatedly emitting the initial state.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -3580,17 +3580,19 @@ export const scanEffect: {
     Effect.map(toTransform(self)(upstream, scope), (pull) => {
       let state = initial
       let isFirst = true
-      if (isFirst) {
-        isFirst = false
-        return Effect.succeed(state)
-      }
-      return Effect.map(
-        Effect.flatMap(pull, (a) => f(state, a)),
-        (newState) => {
-          state = newState
-          return state
+      return Effect.suspend(() => {
+        if (isFirst) {
+          isFirst = false
+          return Effect.succeed(state)
         }
-      )
+        return Effect.map(
+          Effect.flatMap(pull, (a) => f(state, a)),
+          (newState) => {
+            state = newState
+            return state
+          }
+        )
+      })
     })
   ))
 

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -754,6 +754,16 @@ describe("Stream", () => {
         })
         assert.deepStrictEqual(result1, result2)
       }))
+
+    it.effect("scanEffect", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.make(1, 2, 3, 4, 5).pipe(
+          Stream.scanEffect(0, (acc, curr) => Effect.succeed(acc + curr)),
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, Array.scan([1, 2, 3, 4, 5], 0, (acc, curr) => acc + curr))
+      }))
   })
 
   describe("grouping", () => {


### PR DESCRIPTION
## Summary
- fix `Channel.scanEffect` so it emits the initial state once and then continues pulling upstream values
- add a regression test covering `Stream.scanEffect` against `Array.scan`
- add a patch changeset for the `effect` package

## Testing
- pnpm lint-fix
- pnpm test packages/effect/test/Stream.test.ts
- pnpm check:tsgo
- pnpm docgen

Closes https://github.com/Effect-TS/effect-smol/issues/1786