### PR TITLE
EFF-732 Fix missing tool output persistence in streamed chat history

### DIFF
--- a/.changeset/blue-ravens-type.md
+++ b/.changeset/blue-ravens-type.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure streamed tool results are emitted before the finish part so chat history includes tool outputs before stream termination.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1407,6 +1407,7 @@ export const make: (params: {
       | Cause.Done
       | Schema.SchemaError
     >()
+    const deferredFinishParts: Array<Response.StreamPart<Tools>> = []
 
     // Emit pre-resolved tool results so Chat.streamText persists them to
     // history. This ensures collectToolApprovals({ excludeResolved }) can
@@ -1465,8 +1466,19 @@ export const make: (params: {
               }
             }
           }
-          // Add decoded response parts to the output queue
-          yield* Queue.offerAll(queue, parts)
+          // Defer finish parts until all tool handlers complete. This guarantees
+          // tool results are emitted before finish in streaming mode.
+          const immediateParts: Array<Response.StreamPart<Tools>> = []
+          for (const part of parts) {
+            if (part.type === "finish") {
+              deferredFinishParts.push(part)
+            } else {
+              immediateParts.push(part)
+            }
+          }
+          if (immediateParts.length > 0) {
+            yield* Queue.offerAll(queue, immediateParts)
+          }
           // Fork tool call handlers - use the raw chunk for encoded params
           for (const part of chunk) {
             if (part.type === "tool-call" && part.providerExecuted !== true) {
@@ -1483,6 +1495,11 @@ export const make: (params: {
           FiberSet.join(toolCallFibers),
           FiberSet.awaitEmpty(toolCallFibers)
         )
+      ),
+      Effect.andThen(
+        deferredFinishParts.length > 0
+          ? Queue.offerAll(queue, deferredFinishParts)
+          : Effect.void
       ),
       // And then end the queue
       Effect.andThen(Queue.end(queue)),

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -110,6 +110,51 @@ describe("LanguageModel", () => {
 
         deepStrictEqual(parts, [toolCallPart, toolResultPart])
       }))
+
+    it("emits finish after resolved tool results", () =>
+      Effect.gen(function*() {
+        const parts: Array<Response.StreamPart<Toolkit.Tools<typeof MyToolkit>>> = []
+        const latch = yield* Latch.make()
+
+        yield* LanguageModel.streamText({
+          prompt: [],
+          toolkit: MyToolkit
+        }).pipe(
+          Stream.runForEach((part) =>
+            Effect.andThen(
+              latch.open,
+              Effect.sync(() => {
+                parts.push(part)
+              })
+            )
+          ),
+          TestUtils.withLanguageModel({
+            streamText: [
+              {
+                type: "tool-call",
+                id: "tool-finish-order",
+                name: "MyTool",
+                params: { testParam: "test-param" }
+              },
+              finishPart
+            ]
+          }),
+          Effect.provide(MyToolkitLayer),
+          Effect.forkScoped
+        )
+
+        yield* latch.await
+
+        strictEqual(parts[0]?.type, "tool-call")
+        strictEqual(parts.some((part) => part.type === "finish"), false)
+
+        yield* TestClock.adjust("10 seconds")
+
+        strictEqual(parts.length, 3)
+        strictEqual(parts[0]?.type, "tool-call")
+        strictEqual(parts[1]?.type, "tool-result")
+        strictEqual(parts[2]?.type, "finish")
+      }))
   })
 
   describe("generateObject", () => {


### PR DESCRIPTION
## Summary
- fix streaming `LanguageModel.streamText` ordering so `finish` is emitted only after any user-space tool handlers complete
- defer finish parts while streaming and flush them after tool-fiber completion, preventing streams from terminating before tool results are emitted
- add a regression test that reproduces the race (tool-call + finish + delayed handler) and asserts the emitted order is tool-call -> tool-result -> finish
- add a changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen