### PR TITLE
EFF-733 Fix missing finish parts in LanguageModel streaming

### DIFF
--- a/.changeset/tall-wombats-wave.md
+++ b/.changeset/tall-wombats-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix ai LanguageModel streaming finish parts so finish events are always emitted when a toolkit is provided.

--- a/packages/effect/src/unstable/ai/LanguageModel.ts
+++ b/packages/effect/src/unstable/ai/LanguageModel.ts
@@ -1497,9 +1497,7 @@ export const make: (params: {
         )
       ),
       Effect.andThen(
-        deferredFinishParts.length > 0
-          ? Queue.offerAll(queue, deferredFinishParts)
-          : Effect.void
+        Queue.offerAll(queue, deferredFinishParts)
       ),
       // And then end the queue
       Effect.andThen(Queue.end(queue)),

--- a/packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts
@@ -220,6 +220,27 @@ describe("LanguageModel tracker lifecycle integration", () => {
       assert.deepStrictEqual(providerOptions[1]!.incrementalPrompt, Prompt.fromMessages([user2]))
     }))
 
+  it.effect("emits finish parts in streamText when toolkit is provided and no tool calls are returned", () =>
+    Effect.gen(function*() {
+      const languageModel = yield* LanguageModel.make({
+        generateText: () => Effect.succeed([]),
+        streamText: () => Stream.fromIterable([finishPart])
+      })
+
+      const parts = yield* LanguageModel.streamText({
+        prompt: [userMessage("hello")],
+        toolkit: ApprovalToolkit
+      }).pipe(
+        Stream.runCollect,
+        Effect.map((parts) => Array.from(parts)),
+        Effect.provideService(LanguageModel.LanguageModel, languageModel),
+        Effect.provide(ApprovalToolkitLayer)
+      )
+
+      assert.strictEqual(parts.length, 1)
+      assert.strictEqual(parts[0]?.type, "finish")
+    }))
+
   it.effect("keeps incremental provider fields undefined when tracker is omitted", () =>
     Effect.gen(function*() {
       const generateTextOptions: Array<LanguageModel.ProviderOptions> = []


### PR DESCRIPTION
## Summary
- fix LanguageModel.streamText to always enqueue deferred `finish` parts after tool handlers complete
- add a regression test for streaming with a toolkit and no tool calls to verify `finish` is emitted
- add a changeset for the effect package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/LanguageModelTrackerLifecycle.test.ts
- pnpm check:tsgo
- pnpm docgen