### PR TITLE
EFF-702 Move Schema type extractors to top-level exports

### DIFF
--- a/.changeset/eff-702-schema-type-extractors.md
+++ b/.changeset/eff-702-schema-type-extractors.md
@@ -1,0 +1,5 @@
+---
+"effect": major
+---
+
+Schema: move type extractors to top-level names (Schema.Type, Schema.Encoded, Schema.DecodingServices, Schema.EncodingServices, Schema.ToAsserts) and remove the previous namespace forms (Schema.Schema.Type, Schema.Codec.*).

--- a/packages/effect/SCHEMA.md
+++ b/packages/effect/SCHEMA.md
@@ -3492,7 +3492,7 @@ export type Encoded = (typeof Category)["Encoded"]
 ```ts
 import { Schema } from "effect"
 
-interface CategoryEncoded extends Schema.Codec.Encoded<typeof Category> {}
+interface CategoryEncoded extends Schema.Encoded<typeof Category> {}
 
 export class Category extends Schema.Opaque<Category>()(
   Schema.Struct({
@@ -4014,7 +4014,7 @@ import { Schema } from "effect"
 
 // Define the encoded representation for Category separately.
 // This is useful when the Encoded type differs from the Type type.
-interface CategoryEncoded extends Schema.Codec.Encoded<typeof Category> {}
+interface CategoryEncoded extends Schema.Encoded<typeof Category> {}
 
 // The runtime type is Category; the encoded form is CategoryEncoded.
 // "name" is decoded from a string to a finite number to show that

--- a/packages/effect/dtslint/VariantSchema.tst.ts
+++ b/packages/effect/dtslint/VariantSchema.tst.ts
@@ -54,7 +54,7 @@ describe("Model", () => {
     const select = Model.extract(User, "select")
     const json = Model.extract(User, "json")
 
-    expect<Schema.Codec.Encoded<typeof select>>().type.toBe<{ readonly active: 0 | 1 }>()
-    expect<Schema.Codec.Encoded<typeof json>>().type.toBe<{ readonly active: boolean }>()
+    expect<Schema.Encoded<typeof select>>().type.toBe<{ readonly active: 0 | 1 }>()
+    expect<Schema.Encoded<typeof json>>().type.toBe<{ readonly active: boolean }>()
   })
 })

--- a/packages/effect/dtslint/schema/Schema.tst.ts
+++ b/packages/effect/dtslint/schema/Schema.tst.ts
@@ -56,7 +56,7 @@ describe("Schema", () => {
     it("Schema", () => {
       function f<S extends Schema.Schema<unknown>>(_s: S) {
         // @ts-expect-error Type 'null' is not assignable to type 'Type<S>'
-        const Type: Schema.Schema.Type<S> = null
+        const Type: Schema.Type<S> = null
         return Type
       }
       f(Schema.String)
@@ -65,11 +65,11 @@ describe("Schema", () => {
     it("Codec", () => {
       function f<S extends Schema.Codec<unknown, unknown, unknown, unknown>>(_s: S) {
         // @ts-expect-error Type 'null' is not assignable to type 'Encoded<S>'
-        const Encoded: Schema.Codec.Encoded<S> = null
+        const Encoded: Schema.Encoded<S> = null
         // @ts-expect-error Type 'null' is not assignable to type 'DecodingServices<S>'
-        const DecodingServices: Schema.Codec.DecodingServices<S> = null
+        const DecodingServices: Schema.DecodingServices<S> = null
         // @ts-expect-error Type 'null' is not assignable to type 'EncodingServices<S>'
-        const EncodingServices: Schema.Codec.EncodingServices<S> = null
+        const EncodingServices: Schema.EncodingServices<S> = null
         return { Encoded, DecodingServices, EncodingServices }
       }
       f(Schema.String)

--- a/packages/effect/dtslint/schema/Union.tst.ts
+++ b/packages/effect/dtslint/schema/Union.tst.ts
@@ -141,7 +141,7 @@ describe("Union", () => {
         expect(handler).type.toBeCallableWith({ _tag: "A", a: "a" })
         expect(handler).type.toBeCallableWith({ _tag: "B", b: 1 })
         expect(handler).type.toBeAssignableTo<
-          (value: Schema.Schema.Type<typeof schema>) => Effect.Effect<"ok", "nope", never>
+          (value: Schema.Type<typeof schema>) => Effect.Effect<"ok", "nope", never>
         >()
       })
     })

--- a/packages/effect/dtslint/schema/api.tst.ts
+++ b/packages/effect/dtslint/schema/api.tst.ts
@@ -29,7 +29,7 @@ describe("decoding / encoding API", () => {
 
   it("asserts", () => {
     const schema = Schema.String
-    const asserts: Schema.Codec.ToAsserts<typeof schema> = Schema.asserts(schema)
+    const asserts: Schema.ToAsserts<typeof schema> = Schema.asserts(schema)
     const u = hole<unknown>()
     {
       asserts(u)
@@ -41,7 +41,7 @@ describe("decoding / encoding API", () => {
       expect(sn).type.toBe<string>()
     }
     const struct = Schema.Struct({ a: Schema.String })
-    const assertsStruct: Schema.Codec.ToAsserts<typeof struct> = Schema.asserts(struct)
+    const assertsStruct: Schema.ToAsserts<typeof struct> = Schema.asserts(struct)
     const s = hole<{ b: string }>()
     {
       assertsStruct(s)

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -551,28 +551,21 @@ export interface Top extends
 {}
 
 /**
- * Namespace of type-level helpers for {@link Schema}.
+ * Extracts the decoded `Type` from a schema.
+ *
+ * **Example** (Extracting the decoded type)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
+ * type Person = Schema.Type<typeof Person>
+ * // { readonly name: string; readonly age: number }
+ * ```
  *
  * @since 4.0.0
  */
-export declare namespace Schema {
-  /**
-   * Extracts the decoded `Type` from a schema.
-   *
-   * **Example** (Extracting the decoded type)
-   *
-   * ```ts
-   * import { Schema } from "effect"
-   *
-   * const Person = Schema.Struct({ name: Schema.String, age: Schema.Number })
-   * type Person = Schema.Schema.Type<typeof Person>
-   * // { readonly name: string; readonly age: number }
-   * ```
-   *
-   * @since 4.0.0
-   */
-  export type Type<S> = S extends Top ? S["Type"] : never
-}
+export type Type<S> = S extends Top ? S["Type"] : never
 
 /**
  * A typed view of a schema that tracks only the decoded (output) type `T`.
@@ -597,7 +590,7 @@ export declare namespace Schema {
  * ```
  *
  * @see {@link Codec} — also tracks Encoded, DecodingServices, EncodingServices
- * @see {@link Schema.Type} — extract the decoded type at the type level
+ * @see {@link Type} — extract the decoded type at the type level
  *
  * @since 4.0.0
  */
@@ -607,72 +600,68 @@ export interface Schema<out T> extends Top {
 }
 
 /**
- * Namespace of type-level helpers for {@link Codec}.
+ * Extracts the encoded (`Encoded`) type from a schema.
+ *
+ * **Example** (Extracting the encoded type)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.NumberFromString
+ * type Enc = Schema.Encoded<typeof schema>
+ * // string
+ * ```
  *
  * @since 4.0.0
  */
-export declare namespace Codec {
-  /**
-   * Extracts the encoded (`Encoded`) type from a schema.
-   *
-   * **Example** (Extracting the encoded type)
-   *
-   * ```ts
-   * import { Schema } from "effect"
-   *
-   * const schema = Schema.NumberFromString
-   * type Enc = Schema.Codec.Encoded<typeof schema>
-   * // string
-   * ```
-   *
-   * @since 4.0.0
-   */
-  export type Encoded<S> = S extends Top ? S["Encoded"] : never
-  /**
-   * Extracts the Effect services required during *decoding* from a schema.
-   *
-   * **Example** (Checking decoding service requirements)
-   *
-   * ```ts
-   * import { Schema } from "effect"
-   *
-   * const schema = Schema.String
-   * type RD = Schema.Codec.DecodingServices<typeof schema>
-   * // never
-   * ```
-   *
-   * @since 4.0.0
-   */
-  export type DecodingServices<S> = S extends Top ? S["DecodingServices"] : never
-  /**
-   * Extracts the Effect services required during *encoding* from a schema.
-   *
-   * **Example** (Checking encoding service requirements)
-   *
-   * ```ts
-   * import { Schema } from "effect"
-   *
-   * const schema = Schema.String
-   * type RE = Schema.Codec.EncodingServices<typeof schema>
-   * // never
-   * ```
-   *
-   * @since 4.0.0
-   */
-  export type EncodingServices<S> = S extends Top ? S["EncodingServices"] : never
-  /**
-   * Converts a schema type into an assertion function signature. The resulting
-   * function narrows its argument to `I & S["Type"]`. Only schemas with
-   * `DecodingServices: never` (i.e. no required services) can be used here.
-   *
-   * Produced by {@link asserts}.
-   *
-   * @since 4.0.0
-   */
-  export type ToAsserts<S extends Top & { readonly DecodingServices: never }> = <I>(
-    input: I
-  ) => asserts input is I & S["Type"]
-}
+export type Encoded<S> = S extends Top ? S["Encoded"] : never
+
+/**
+ * Extracts the Effect services required during *decoding* from a schema.
+ *
+ * **Example** (Checking decoding service requirements)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.String
+ * type RD = Schema.DecodingServices<typeof schema>
+ * // never
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type DecodingServices<S> = S extends Top ? S["DecodingServices"] : never
+
+/**
+ * Extracts the Effect services required during *encoding* from a schema.
+ *
+ * **Example** (Checking encoding service requirements)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.String
+ * type RE = Schema.EncodingServices<typeof schema>
+ * // never
+ * ```
+ *
+ * @since 4.0.0
+ */
+export type EncodingServices<S> = S extends Top ? S["EncodingServices"] : never
+
+/**
+ * Converts a schema type into an assertion function signature. The resulting
+ * function narrows its argument to `I & S["Type"]`. Only schemas with
+ * `DecodingServices: never` (i.e. no required services) can be used here.
+ *
+ * Produced by {@link asserts}.
+ *
+ * @since 4.0.0
+ */
+export type ToAsserts<S extends Top & { readonly DecodingServices: never }> = <I>(
+  input: I
+) => asserts input is I & S["Type"]
 
 /**
  * A schema that additionally supports optic (lens/prism) operations.
@@ -719,9 +708,9 @@ export interface Optic<out T, out Iso> extends Schema<T> {
  * serialize(Schema.NumberFromString) // ok — decodes number, encoded as string
  * ```
  *
- * @see {@link Codec.Encoded} — extract the encoded type
- * @see {@link Codec.DecodingServices} — extract required decoding services
- * @see {@link Codec.EncodingServices} — extract required encoding services
+ * @see {@link Encoded} — extract the encoded type
+ * @see {@link DecodingServices} — extract required decoding services
+ * @see {@link EncodingServices} — extract required encoding services
  * @see {@link revealCodec} — helper to make TypeScript infer the full Codec type
  *
  * @since 4.0.0

--- a/packages/effect/src/unstable/devtools/DevToolsSchema.ts
+++ b/packages/effect/src/unstable/devtools/DevToolsSchema.ts
@@ -17,7 +17,7 @@ export const SpanStatusStarted = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type SpanStatusStarted = Schema.Schema.Type<typeof SpanStatusStarted>
+export type SpanStatusStarted = Schema.Type<typeof SpanStatusStarted>
 
 /**
  * @since 4.0.0
@@ -33,7 +33,7 @@ export const SpanStatusEnded = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type SpanStatusEnded = Schema.Schema.Type<typeof SpanStatusEnded>
+export type SpanStatusEnded = Schema.Type<typeof SpanStatusEnded>
 
 /**
  * @since 4.0.0
@@ -45,7 +45,7 @@ export const SpanStatus = Schema.Union([SpanStatusStarted, SpanStatusEnded])
  * @since 4.0.0
  * @category schemas
  */
-export type SpanStatus = Schema.Schema.Type<typeof SpanStatus>
+export type SpanStatus = Schema.Type<typeof SpanStatus>
 
 /**
  * @since 4.0.0
@@ -116,7 +116,7 @@ export const SpanEvent = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type SpanEvent = Schema.Schema.Type<typeof SpanEvent>
+export type SpanEvent = Schema.Type<typeof SpanEvent>
 
 /**
  * @since 4.0.0
@@ -142,7 +142,7 @@ export const Ping = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type Ping = Schema.Schema.Type<typeof Ping>
+export type Ping = Schema.Type<typeof Ping>
 
 /**
  * @since 4.0.0
@@ -156,7 +156,7 @@ export const Pong = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type Pong = Schema.Schema.Type<typeof Pong>
+export type Pong = Schema.Type<typeof Pong>
 
 /**
  * @since 4.0.0
@@ -170,7 +170,7 @@ export const MetricsRequest = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type MetricsRequest = Schema.Schema.Type<typeof MetricsRequest>
+export type MetricsRequest = Schema.Type<typeof MetricsRequest>
 
 /**
  * @since 4.0.0
@@ -185,7 +185,7 @@ export const MetricLabel = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type MetricLabel = Schema.Schema.Type<typeof MetricLabel>
+export type MetricLabel = Schema.Type<typeof MetricLabel>
 
 const metric = <Type extends string, State extends Schema.Top>(type: Type, state: State) =>
   Schema.Struct({
@@ -212,7 +212,7 @@ export const Counter = metric(
  * @since 4.0.0
  * @category schemas
  */
-export type Counter = Schema.Schema.Type<typeof Counter>
+export type Counter = Schema.Type<typeof Counter>
 
 /**
  * @since 4.0.0
@@ -229,7 +229,7 @@ export const Frequency = metric(
  * @since 4.0.0
  * @category schemas
  */
-export type Frequency = Schema.Schema.Type<typeof Frequency>
+export type Frequency = Schema.Type<typeof Frequency>
 
 /**
  * @since 4.0.0
@@ -246,7 +246,7 @@ export const Gauge = metric(
  * @since 4.0.0
  * @category schemas
  */
-export type Gauge = Schema.Schema.Type<typeof Gauge>
+export type Gauge = Schema.Type<typeof Gauge>
 
 /**
  * @since 4.0.0
@@ -267,7 +267,7 @@ export const Histogram = metric(
  * @since 4.0.0
  * @category schemas
  */
-export type Histogram = Schema.Schema.Type<typeof Histogram>
+export type Histogram = Schema.Type<typeof Histogram>
 
 /**
  * @since 4.0.0
@@ -288,7 +288,7 @@ export const Summary = metric(
  * @since 4.0.0
  * @category schemas
  */
-export type Summary = Schema.Schema.Type<typeof Summary>
+export type Summary = Schema.Type<typeof Summary>
 
 /**
  * @since 4.0.0
@@ -300,7 +300,7 @@ export const Metric = Schema.Union([Counter, Frequency, Gauge, Histogram, Summar
  * @since 4.0.0
  * @category schemas
  */
-export type Metric = Schema.Schema.Type<typeof Metric>
+export type Metric = Schema.Type<typeof Metric>
 
 /**
  * @since 4.0.0
@@ -315,7 +315,7 @@ export const MetricsSnapshot = Schema.Struct({
  * @since 4.0.0
  * @category schemas
  */
-export type MetricsSnapshot = Schema.Schema.Type<typeof MetricsSnapshot>
+export type MetricsSnapshot = Schema.Type<typeof MetricsSnapshot>
 
 /**
  * @since 4.0.0
@@ -327,7 +327,7 @@ export const Request = Schema.Union([Ping, Span, SpanEvent, MetricsSnapshot])
  * @since 4.0.0
  * @category schemas
  */
-export type Request = Schema.Schema.Type<typeof Request>
+export type Request = Schema.Type<typeof Request>
 
 /**
  * @since 4.0.0
@@ -351,7 +351,7 @@ export const Response = Schema.Union([Pong, MetricsRequest])
  * @since 4.0.0
  * @category schemas
  */
-export type Response = Schema.Schema.Type<typeof Response>
+export type Response = Schema.Type<typeof Response>
 
 /**
  * @since 4.0.0

--- a/packages/effect/src/unstable/eventlog/Event.ts
+++ b/packages/effect/src/unstable/eventlog/Event.ts
@@ -39,7 +39,7 @@ export interface Event<
   readonly [TypeId]: TypeId
   readonly tag: Tag
   readonly key: string
-  readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+  readonly primaryKey: (payload: Schema.Type<Payload>) => string
   readonly payload: Payload
   readonly payloadMsgPack: Msgpack.schema<Payload>
   readonly success: Success
@@ -116,7 +116,7 @@ export type ErrorSchema<A extends Any> = A extends Event<
  * @since 4.0.0
  * @category models
  */
-export type Error<A extends Any> = Schema.Schema.Type<ErrorSchema<A>>
+export type Error<A extends Any> = Schema.Type<ErrorSchema<A>>
 
 /**
  * @since 4.0.0
@@ -158,7 +158,7 @@ export type PayloadSchemaWithTag<A extends Any, Tag extends string> = A extends 
  * @since 4.0.0
  * @category models
  */
-export type Payload<A extends Any> = Schema.Schema.Type<PayloadSchema<A>>
+export type Payload<A extends Any> = Schema.Type<PayloadSchema<A>>
 
 /**
  * @since 4.0.0
@@ -171,7 +171,7 @@ export type TaggedPayload<A extends Any> = A extends Event<
   infer _Error
 > ? {
     readonly _tag: _Tag
-    readonly payload: Schema.Schema.Type<_Payload>
+    readonly payload: Schema.Type<_Payload>
   }
   : never
 
@@ -191,7 +191,7 @@ export type SuccessSchema<A extends Any> = A extends Event<
  * @since 4.0.0
  * @category models
  */
-export type Success<A extends Any> = Schema.Schema.Type<SuccessSchema<A>>
+export type Success<A extends Any> = Schema.Type<SuccessSchema<A>>
 
 /**
  * @since 4.0.0
@@ -295,14 +295,14 @@ export function make<
   Error extends Schema.Top = typeof Schema.Never
 >(options: {
   readonly tag: Tag
-  readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+  readonly primaryKey: (payload: Schema.Type<Payload>) => string
   readonly payload?: Payload | undefined
   readonly success?: Success | undefined
   readonly error?: Error | undefined
 }): Event<Tag, Payload, Success, Error>
 export function make(options: {
   readonly tag: string
-  readonly primaryKey: (payload: Schema.Schema.Type<Schema.Top>) => string
+  readonly primaryKey: (payload: Schema.Type<Schema.Top>) => string
   readonly payload?: Schema.Top | undefined
   readonly success?: Schema.Top | undefined
   readonly error?: Schema.Top | undefined

--- a/packages/effect/src/unstable/eventlog/EventGroup.ts
+++ b/packages/effect/src/unstable/eventlog/EventGroup.ts
@@ -52,7 +52,7 @@ export interface EventGroup<
     Error extends Schema.Top = typeof Schema.Never
   >(options: {
     readonly tag: Tag
-    readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+    readonly primaryKey: (payload: Schema.Type<Payload>) => string
     readonly payload?: Payload
     readonly success?: Success
     readonly error?: Error
@@ -124,7 +124,7 @@ const makeProto = <
       this: EventGroup<Events>,
       addOptions: {
         readonly tag: Tag
-        readonly primaryKey: (payload: Schema.Schema.Type<Payload>) => string
+        readonly primaryKey: (payload: Schema.Type<Payload>) => string
         readonly payload?: Payload
         readonly success?: Success
         readonly error?: Error

--- a/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogEncryption.ts
@@ -22,7 +22,7 @@ export const EncryptedEntry = Schema.Struct({
  * @since 4.0.0
  * @category models
  */
-export interface EncryptedRemoteEntry extends Schema.Schema.Type<typeof EncryptedRemoteEntry> {}
+export interface EncryptedRemoteEntry extends Schema.Type<typeof EncryptedRemoteEntry> {}
 
 /**
  * @since 4.0.0

--- a/packages/effect/src/unstable/eventlog/EventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/EventLogServer.ts
@@ -59,7 +59,7 @@ export const makeHandler: Effect.Effect<
       >()
       let latestSequence = -1
 
-      const write = Effect.fnUntraced(function*(response: Schema.Schema.Type<typeof ProtocolResponse>) {
+      const write = Effect.fnUntraced(function*(response: Schema.Type<typeof ProtocolResponse>) {
         const data = yield* encodeResponse(response)
         if (response._tag !== "Changes" || data.byteLength <= constChunkSize) {
           return yield* writeRaw(data)
@@ -72,7 +72,7 @@ export const makeHandler: Effect.Effect<
 
       yield* Effect.forkChild(Effect.orDie(write(new Hello({ remoteId }))))
 
-      const handleRequest = (request: Schema.Schema.Type<typeof ProtocolRequest>): Effect.Effect<void> => {
+      const handleRequest = (request: Schema.Type<typeof ProtocolRequest>): Effect.Effect<void> => {
         switch (request._tag) {
           case "Ping": {
             return Effect.orDie(write(new Pong({ id: request.id })))

--- a/packages/effect/src/unstable/eventlog/SqlEventLogJournal.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogJournal.ts
@@ -272,7 +272,7 @@ const EntryRow = Schema.Struct({
 
 const EntryRowArray = Schema.Array(EntryRow)
 
-type EntryRow = Schema.Schema.Type<typeof EntryRow>
+type EntryRow = Schema.Type<typeof EntryRow>
 
 const toEntry = (row: EntryRow): EventJournal.Entry =>
   new EventJournal.Entry({

--- a/packages/effect/src/unstable/eventlog/SqlEventLogServer.ts
+++ b/packages/effect/src/unstable/eventlog/SqlEventLogServer.ts
@@ -210,7 +210,7 @@ const EncryptedRemoteEntrySql = Schema.Struct({
   encrypted_entry: Schema.Uint8Array
 })
 
-type EncryptedRemoteEntrySql = Schema.Schema.Type<typeof EncryptedRemoteEntrySql>
+type EncryptedRemoteEntrySql = Schema.Type<typeof EncryptedRemoteEntrySql>
 
 const decodeEntryRows = Schema.decodeUnknownEffect(Schema.Array(EncryptedRemoteEntrySql))
 

--- a/packages/effect/src/unstable/rpc/Rpc.ts
+++ b/packages/effect/src/unstable/rpc/Rpc.ts
@@ -275,7 +275,7 @@ export type ErrorSchema<R> = R extends Rpc<
  * @since 4.0.0
  * @category models
  */
-export type Error<R> = Schema.Schema.Type<ErrorSchema<R>>
+export type Error<R> = Schema.Type<ErrorSchema<R>>
 
 /**
  * @since 4.0.0
@@ -565,7 +565,7 @@ export type ResultFrom<R extends Any, Services> = R extends Rpc<
       >
       | Effect<
         Queue.Dequeue<_SA["Type"], _SE["Type"] | _Error["Type"] | Cause.Done>,
-        _SE["Type"] | Schema.Schema.Type<_Error>,
+        _SE["Type"] | Schema.Type<_Error>,
         Services
       > :
   Effect<

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -6494,7 +6494,7 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
   describe("asserts", () => {
     it("FiniteFromString", () => {
       const schema = Schema.FiniteFromString
-      const asserts: Schema.Codec.ToAsserts<typeof schema> = Schema.asserts(schema)
+      const asserts: Schema.ToAsserts<typeof schema> = Schema.asserts(schema)
       try {
         asserts(1)
       } catch {


### PR DESCRIPTION
## Summary
- move Schema type extractors to top-level aliases: `Schema.Type`, `Schema.Encoded`, `Schema.DecodingServices`, `Schema.EncodingServices`, and `Schema.ToAsserts`
- remove previous namespace extractor types (`Schema.Schema.Type` and `Schema.Codec.*`)
- update internal usages, dtslint type tests, runtime tests, and generated Schema docs to the new extractor names
- add changeset for the API change

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/schema/Schema.test.ts
- pnpm test-types packages/effect/dtslint/schema/Schema.tst.ts
- pnpm test-types packages/effect/dtslint/schema/api.tst.ts
- pnpm test-types packages/effect/dtslint/schema/Union.tst.ts
- pnpm test-types packages/effect/dtslint/VariantSchema.tst.ts
- pnpm check:tsgo
- pnpm docgen