### PR TITLE
PubSub.publish returns false on shutdown instead of interrupting

### DIFF
--- a/.changeset/pubsub-publish-false.md
+++ b/.changeset/pubsub-publish-false.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+PubSub.publish and PubSub.publishAll now return false on shutdown instead of interrupting, matching Queue.offer semantics.

--- a/packages/effect/src/PubSub.ts
+++ b/packages/effect/src/PubSub.ts
@@ -810,7 +810,7 @@ export const publish: {
 } = dual(2, <A>(self: PubSub<A>, value: A): Effect.Effect<boolean> =>
   Effect.suspend(() => {
     if (self.shutdownFlag.current) {
-      return Effect.interrupt
+      return Effect.succeed(false)
     }
 
     if (self.pubsub.publish(value)) {
@@ -909,7 +909,7 @@ export const publishAll: {
 } = dual(2, <A>(self: PubSub<A>, elements: Iterable<A>): Effect.Effect<boolean> =>
   Effect.suspend(() => {
     if (self.shutdownFlag.current) {
-      return Effect.interrupt
+      return Effect.succeed(false)
     }
     const surplus = self.pubsub.publishAll(elements)
     self.strategy.completeSubscribersUnsafe(self.pubsub, self.subscribers)

--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -515,4 +515,24 @@ describe("PubSub", () => {
       const result = yield* Fiber.join(fiber)
       assert.deepStrictEqual(result, [])
     }))
+
+  it.effect("publish returns false after shutdown", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.unbounded<number>()
+        yield* PubSub.shutdown(pubsub)
+
+        assert.strictEqual(yield* PubSub.publish(pubsub, 1), false)
+      })
+    ))
+
+  it.effect("publishAll returns false after shutdown", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const pubsub = yield* PubSub.unbounded<number>()
+        yield* PubSub.shutdown(pubsub)
+
+        assert.strictEqual(yield* PubSub.publishAll(pubsub, [1, 2, 3]), false)
+      })
+    ))
 })


### PR DESCRIPTION
I decided to audit the shutdown semantics in general after working on #1800. Once again, this is just a proposal. I'm not sure if any of these semantic differences are intended, but I think consistent shutdown semantics would be nice to have.

I don't have strong opinions about interrupting versus succeeding with false. But as offer and publish are typed as `Effect<Boolean>`, perhaps succeeding with false makes a little more sense?


---

# Human Approved Robot Summary 🤖🤝👴

## Summary

`PubSub.publish` and `PubSub.publishAll` are typed as `Effect<boolean>` but returned `Effect.interrupt` when the PubSub was shut down. `Queue.offer` returns `false` in the same situation. `PubSub.publishUnsafe` already returned `false` correctly.

## Before

```ts
// PubSub.publish after shutdown
if (self.shutdownFlag.current) {
  return Effect.interrupt  // unexpected interrupt for an Effect<boolean>
}

// Queue.offer after shutdown
if (self.state._tag !== "Open") {
  return exitFalse  // returns false
}
```

## After

```ts
// PubSub.publish after shutdown
if (self.shutdownFlag.current) {
  return Effect.succeed(false)  // matches Queue.offer
}
```

## Test plan

- [x] Added tests for `publish` and `publishAll` returning false after shutdown
- [x] All PubSub tests pass