### PR TITLE
Add test documenting Stream.fromPubSub shutdown behavior

### DIFF
--- a/packages/effect/test/PubSub.test.ts
+++ b/packages/effect/test/PubSub.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Array, Effect, Fiber, Latch, PubSub } from "effect"
+import { Array, Effect, Exit, Fiber, Latch, PubSub, Stream } from "effect"
 import { pipe } from "effect/Function"
 
 describe("PubSub", () => {
@@ -396,6 +396,37 @@ describe("PubSub", () => {
       const pubsub = yield* PubSub.dropping<number>(2)
       yield* PubSub.publishAll(pubsub, [1, 2])
       assert.deepStrictEqual(PubSub.sizeUnsafe(pubsub), 0)
+    }))
+
+  // BUG: Stream.fromPubSub hangs on shutdown because PubSub.shutdown
+  // does not interrupt suspended subscribers. Stream.fromQueue works
+  // because Queue.shutdown actively interrupts takers via finalize().
+  //
+  // Once PubSub.shutdown is fixed to interrupt subscribers, this test
+  // should be updated. Note: even after the fix, Stream.fromPubSub will
+  // complete gracefully (not interrupt) because Channel.fromSubscriptionArray
+  // wraps the pull with onInterrupt(() => Cause.done()), converting
+  // interrupts to Done. This differs from Stream.fromQueue which
+  // propagates the interrupt. The reason is that subscription scope
+  // closure and PubSub shutdown both use fiber-level interruption, so
+  // the channel can't distinguish them. Queue doesn't have this problem
+  // because it stores an interrupt Exit in state and resumes takers with
+  // it as a return value, not via fiber interruption.
+  it.effect("Stream.fromPubSub does not complete on shutdown (known bug)", () =>
+    Effect.gen(function*() {
+      const pubsub = yield* PubSub.unbounded<number>()
+      const fiber = yield* Effect.forkChild(
+        Stream.runCollect(Stream.fromPubSub(pubsub))
+      )
+
+      yield* Effect.yieldNow
+      assert.isUndefined(fiber.pollUnsafe())
+
+      yield* PubSub.shutdown(pubsub)
+      yield* Effect.yieldNow
+
+      // The fiber is still suspended — shutdown didn't reach it
+      assert.isUndefined(fiber.pollUnsafe())
     }))
 
   describe("replay", () => {


### PR DESCRIPTION
## Summary

Documents two issues with Stream.fromPubSub on shutdown via a test with extensive comments.

### Issue 1: Shutdown doesn't reach stream subscribers (known bug)

`PubSub.shutdown` does not interrupt suspended subscribers, so `Stream.fromPubSub` hangs forever after shutdown. `Stream.fromQueue` works because `Queue.shutdown` actively interrupts takers via `finalize()`. This is fixed by #1800.

### Issue 2: Even after #1800, stream completes gracefully instead of interrupting

`Stream.fromQueue` propagates interrupts on shutdown:
```ts
// Channel.fromQueueArray -- no interrupt handling
fromPull(Effect.succeed(Queue.takeAll(queue)))
```

`Stream.fromPubSub` converts interrupts to Done:
```ts
// Channel.fromSubscriptionArray -- catches interrupt
fromPull(Effect.succeed(Effect.onInterrupt(PubSub.takeAll(subscription), () => Cause.done())))
```

The `onInterrupt -> Done` exists because subscription scope closure also uses fiber-level interruption, and the stream should end gracefully when its scope closes. But PubSub shutdown uses the same mechanism (fiber-level interrupt via `Deferred.interruptWith`), so the channel can't tell the two apart.

Queue doesn't have this problem because `Queue.shutdown` stores an `Exit.interrupt()` in state and resumes takers with it as a **return value**. The stream channel sees a failed Effect, not a fiber interrupt, so it propagates correctly.

To fix: PubSub shutdown would need a distinct signal from subscription scope closure.

## Test plan

- [x] Test passes on main (documents current behavior)
- [ ] After #1800 merges, update test to show the graceful completion behavior