### PR TITLE
EFF-739 Fix OpenAI websocket no tool output error

### DIFF
--- a/.changeset/eff-739-openai-function-call-done.md
+++ b/.changeset/eff-739-openai-function-call-done.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Handle streamed OpenAI function calls from `response.function_call_arguments.done` so tool calls are emitted even when `response.output_item.done` is missing.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1367,6 +1367,9 @@ const makeStreamResponse = Effect.fnUntraced(
     const activeToolCalls: Record<number, {
       readonly id: string
       readonly name: string
+      readonly functionCall?: {
+        emitted: boolean
+      }
       readonly applyPatch?: {
         hasDiff: boolean
         endEmitted: boolean
@@ -1516,7 +1519,8 @@ const makeStreamResponse = Effect.fnUntraced(
               case "function_call": {
                 activeToolCalls[event.output_index] = {
                   id: event.item.call_id,
-                  name: event.item.name
+                  name: event.item.name,
+                  functionCall: { emitted: false }
                 }
                 parts.push({
                   type: "tool-params-start",
@@ -1716,6 +1720,11 @@ const makeStreamResponse = Effect.fnUntraced(
               }
 
               case "function_call": {
+                const toolCall = activeToolCalls[event.output_index]
+                if (Predicate.isNotUndefined(toolCall?.functionCall?.emitted) && toolCall.functionCall.emitted) {
+                  delete activeToolCalls[event.output_index]
+                  break
+                }
                 delete activeToolCalls[event.output_index]
 
                 hasToolCalls = true
@@ -1997,6 +2006,48 @@ const makeStreamResponse = Effect.fnUntraced(
                 id: toolCallPart.id,
                 delta: event.delta
               })
+            }
+            break
+          }
+
+          case "response.function_call_arguments.done": {
+            const toolCall = activeToolCalls[event.output_index]
+            if (
+              Predicate.isNotUndefined(toolCall?.functionCall) &&
+              !toolCall.functionCall.emitted
+            ) {
+              hasToolCalls = true
+
+              const toolParams = yield* Effect.try({
+                try: () => Tool.unsafeSecureJsonParse(event.arguments),
+                catch: (cause) =>
+                  AiError.make({
+                    module: "OpenAiLanguageModel",
+                    method: "makeStreamResponse",
+                    reason: new AiError.ToolParameterValidationError({
+                      toolName: toolCall.name,
+                      toolParams: {},
+                      description: `Failed securely JSON parse tool parameters: ${cause}`
+                    })
+                  })
+              })
+
+              const params = yield* transformToolCallParams(options.tools, toolCall.name, toolParams)
+
+              parts.push({
+                type: "tool-params-end",
+                id: toolCall.id
+              })
+
+              parts.push({
+                type: "tool-call",
+                id: toolCall.id,
+                name: toolCall.name,
+                params,
+                metadata: { openai: { ...makeItemIdMetadata(event.item_id) } }
+              })
+
+              toolCall.functionCall.emitted = true
             }
             break
           }

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -828,6 +828,82 @@ describe("OpenAiLanguageModel", () => {
           }
         })
       }))
+
+    it.effect("emits tool call from function_call_arguments.done when output_item.done is missing", () =>
+      Effect.gen(function*() {
+        const streamEvents = [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeDefaultResponse({
+              id: "resp_function_call_done",
+              status: "in_progress",
+              output: []
+            })
+          },
+          {
+            type: "response.output_item.added",
+            sequence_number: 2,
+            output_index: 0,
+            item: {
+              type: "function_call",
+              id: "fc_1",
+              call_id: "call_1",
+              name: "TestTool",
+              arguments: "",
+              status: "in_progress"
+            }
+          },
+          {
+            type: "response.function_call_arguments.delta",
+            sequence_number: 3,
+            output_index: 0,
+            item_id: "fc_1",
+            delta: "{\"input\":\"hel"
+          },
+          {
+            type: "response.function_call_arguments.done",
+            sequence_number: 4,
+            output_index: 0,
+            item_id: "fc_1",
+            name: "TestTool",
+            arguments: "{\"input\":\"hello\"}"
+          },
+          {
+            type: "response.completed",
+            sequence_number: 5,
+            response: makeDefaultResponse({
+              id: "resp_function_call_done",
+              status: "completed",
+              output: []
+            })
+          }
+        ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "Use the test tool",
+          toolkit: TestToolkit,
+          disableToolCallResolution: true
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer(streamEvents)),
+          Effect.provide(TestToolkitLayer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        const toolCalls = parts.filter((part) => part.type === "tool-call" && part.id === "call_1")
+        strictEqual(toolCalls.length, 1)
+        const toolCall = toolCalls[0]
+        assert.isDefined(toolCall)
+        if (toolCall?.type === "tool-call") {
+          strictEqual(toolCall.name, "TestTool")
+          deepStrictEqual(toolCall.params, { input: "hello" })
+        }
+
+        const toolParamsEnd = parts.find((part) => part.type === "tool-params-end" && part.id === "call_1")
+        assert.isDefined(toolParamsEnd)
+      }))
   })
 
   describe("withConfigOverride", () => {


### PR DESCRIPTION
## Summary
- handle `response.function_call_arguments.done` in OpenAI streaming response conversion
- emit the function tool-call from that event and mark it emitted to avoid duplicate emission when `response.output_item.done` also arrives
- add a regression test covering streams that include function call argument done events but omit output item done events
- add a changeset for `@effect/ai-openai`

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen