### PR TITLE
EFF-738 Backport Cron.prev api

### DIFF
--- a/.changeset/eff-738-cron-prev.md
+++ b/.changeset/eff-738-cron-prev.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Backport `Cron.prev` with reverse lookup tables and cron stepping logic, including DST-aware reverse traversal.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -100,7 +100,25 @@ export interface Cron extends Pipeable, Equal.Equal, Inspectable {
     readonly weekday: number
   }
   /** @internal */
+  readonly last: {
+    readonly second: number
+    readonly minute: number
+    readonly hour: number
+    readonly day: number
+    readonly month: number
+    readonly weekday: number
+  }
+  /** @internal */
   readonly next: {
+    readonly second: ReadonlyArray<number | undefined>
+    readonly minute: ReadonlyArray<number | undefined>
+    readonly hour: ReadonlyArray<number | undefined>
+    readonly day: ReadonlyArray<number | undefined>
+    readonly month: ReadonlyArray<number | undefined>
+    readonly weekday: ReadonlyArray<number | undefined>
+  }
+  /** @internal */
+  readonly prev: {
     readonly second: ReadonlyArray<number | undefined>
     readonly minute: ReadonlyArray<number | undefined>
     readonly hour: ReadonlyArray<number | undefined>
@@ -325,31 +343,64 @@ export const make = (values: {
     weekday: weekdays[0] ?? 0
   }
 
+  o.last = {
+    second: seconds[seconds.length - 1] ?? 59,
+    minute: minutes[minutes.length - 1] ?? 59,
+    hour: hours[hours.length - 1] ?? 23,
+    day: days[days.length - 1] ?? 31,
+    month: (months[months.length - 1] ?? 12) - 1,
+    weekday: weekdays[weekdays.length - 1] ?? 6
+  }
+
   o.next = {
-    second: nextLookupTable(seconds, 60),
-    minute: nextLookupTable(minutes, 60),
-    hour: nextLookupTable(hours, 24),
-    day: nextLookupTable(days, 32),
-    month: nextLookupTable(months, 13),
-    weekday: nextLookupTable(weekdays, 7)
+    second: lookupTable(seconds, 60, "next"),
+    minute: lookupTable(minutes, 60, "next"),
+    hour: lookupTable(hours, 24, "next"),
+    day: lookupTable(days, 32, "next"),
+    month: lookupTable(months, 13, "next"),
+    weekday: lookupTable(weekdays, 7, "next")
+  }
+
+  o.prev = {
+    second: lookupTable(seconds, 60, "prev"),
+    minute: lookupTable(minutes, 60, "prev"),
+    hour: lookupTable(hours, 24, "prev"),
+    day: lookupTable(days, 32, "prev"),
+    month: lookupTable(months, 13, "prev"),
+    weekday: lookupTable(weekdays, 7, "prev")
   }
 
   return o
 }
 
-const nextLookupTable = (values: ReadonlyArray<number>, size: number): Array<number | undefined> => {
+const lookupTable = (
+  values: ReadonlyArray<number>,
+  size: number,
+  dir: "next" | "prev"
+): Array<number | undefined> => {
   const result = new Array(size).fill(undefined)
   if (values.length === 0) {
     return result
   }
 
   let current: number | undefined = undefined
-  let index = values.length - 1
-  for (let i = size - 1; i >= 0; i--) {
-    while (index >= 0 && values[index] >= i) {
-      current = values[index--]
+
+  if (dir === "next") {
+    let index = values.length - 1
+    for (let i = size - 1; i >= 0; i--) {
+      while (index >= 0 && values[index] >= i) {
+        current = values[index--]
+      }
+      result[i] = current
     }
-    result[i] = current
+  } else {
+    let index = 0
+    for (let i = 0; i < size; i++) {
+      while (index < values.length && values[index] <= i) {
+        current = values[index++]
+      }
+      result[i] = current
+    }
   }
 
   return result
@@ -587,38 +638,61 @@ const daysInMonth = (date: Date): number =>
  * @category utils
  */
 export const next = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
+  return stepCron(cron, now, "next")
+}
+
+/**
+ * Returns the previous scheduled date/time for the given Cron instance.
+ *
+ * @since 4.0.0
+ * @category utils
+ */
+export const prev = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
+  return stepCron(cron, now, "prev")
+}
+
+const stepCron = (cron: Cron, now: DateTime.DateTime.Input | undefined, direction: "next" | "prev"): Date => {
   const tz = Option.getOrUndefined(cron.tz)
   const zoned = dateTime.makeZonedUnsafe(now ?? new Date(), {
     timeZone: tz
   })
 
+  const reverse = direction === "prev"
+  const tick = reverse ? -1 : 1
+  const table = cron[direction]
+  const boundary = reverse ? cron.last : cron.first
+
+  const needsStep = reverse ?
+    (next: number, current: number) => next < current :
+    (next: number, current: number) => next > current
+
   const utc = tz !== undefined && dateTime.isTimeZoneNamed(tz) && tz.id === "UTC"
   const adjustDst = utc ? constVoid : (current: Date) => {
     const adjusted = dateTime.makeZonedUnsafe(current, {
       timeZone: zoned.zone,
-      adjustForTimeZone: true
+      adjustForTimeZone: true,
+      disambiguation: reverse ? "later" : undefined
     }).pipe(dateTime.toDate)
 
-    // TODO: This implementation currently only skips forward when transitioning into daylight savings time.
     const drift = current.getTime() - adjusted.getTime()
-    if (drift > 0) {
-      current.setTime(current.getTime() + drift)
+    if (reverse ? drift !== 0 : drift > 0) {
+      current.setTime(reverse ? adjusted.getTime() : current.getTime() + drift)
     }
   }
 
   const result = dateTime.mutate(zoned, (current) => {
-    current.setUTCSeconds(current.getUTCSeconds() + 1, 0)
+    current.setUTCSeconds(current.getUTCSeconds() + tick, 0)
 
     for (let i = 0; i < 10_000; i++) {
       if (cron.seconds.size !== 0) {
         const currentSecond = current.getUTCSeconds()
-        const nextSecond = cron.next.second[currentSecond]
+        const nextSecond = table.second[currentSecond]
         if (nextSecond === undefined) {
-          current.setUTCMinutes(current.getUTCMinutes() + 1, cron.first.second)
+          current.setUTCMinutes(current.getUTCMinutes() + tick, boundary.second)
           adjustDst(current)
           continue
         }
-        if (nextSecond > currentSecond) {
+        if (needsStep(nextSecond, currentSecond)) {
           current.setUTCSeconds(nextSecond)
           adjustDst(current)
           continue
@@ -627,14 +701,14 @@ export const next = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
 
       if (cron.minutes.size !== 0) {
         const currentMinute = current.getUTCMinutes()
-        const nextMinute = cron.next.minute[currentMinute]
+        const nextMinute = table.minute[currentMinute]
         if (nextMinute === undefined) {
-          current.setUTCHours(current.getUTCHours() + 1, cron.first.minute, cron.first.second)
+          current.setUTCHours(current.getUTCHours() + tick, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
-        if (nextMinute > currentMinute) {
-          current.setUTCMinutes(nextMinute, cron.first.second)
+        if (needsStep(nextMinute, currentMinute)) {
+          current.setUTCMinutes(nextMinute, boundary.second)
           adjustDst(current)
           continue
         }
@@ -642,40 +716,55 @@ export const next = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
 
       if (cron.hours.size !== 0) {
         const currentHour = current.getUTCHours()
-        const nextHour = cron.next.hour[currentHour]
+        const nextHour = table.hour[currentHour]
         if (nextHour === undefined) {
-          current.setUTCDate(current.getUTCDate() + 1)
-          current.setUTCHours(cron.first.hour, cron.first.minute, cron.first.second)
+          current.setUTCDate(current.getUTCDate() + tick)
+          current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
-        if (nextHour > currentHour) {
-          current.setUTCHours(nextHour, cron.first.minute, cron.first.second)
+        if (needsStep(nextHour, currentHour)) {
+          current.setUTCHours(nextHour, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
       }
 
       if (cron.weekdays.size !== 0 || cron.days.size !== 0) {
-        let a: number = Infinity
-        let b: number = Infinity
+        let a: number = reverse ? -Infinity : Infinity
+        let b: number = reverse ? -Infinity : Infinity
 
         if (cron.weekdays.size !== 0) {
           const currentWeekday = current.getUTCDay()
-          const nextWeekday = cron.next.weekday[currentWeekday]
-          a = nextWeekday === undefined ? 7 - currentWeekday + cron.first.weekday : nextWeekday - currentWeekday
+          const nextWeekday = table.weekday[currentWeekday]
+          if (nextWeekday === undefined) {
+            a = reverse ?
+              currentWeekday - 7 + boundary.weekday :
+              7 - currentWeekday + boundary.weekday
+          } else {
+            a = nextWeekday - currentWeekday
+          }
         }
 
         if (cron.days.size !== 0 && a !== 0) {
           const currentDay = current.getUTCDate()
-          const nextDay = cron.next.day[currentDay]
-          b = nextDay === undefined ? daysInMonth(current) - currentDay + cron.first.day : nextDay - currentDay
+          const nextDay = table.day[currentDay]
+          if (nextDay === undefined) {
+            if (reverse) {
+              const prevMonthDays = daysInMonth(new Date(Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 0)))
+              b = -(currentDay + (prevMonthDays - boundary.day))
+            } else {
+              b = daysInMonth(current) - currentDay + boundary.day
+            }
+          } else {
+            b = nextDay - currentDay
+          }
         }
 
-        const addDays = Math.min(a, b)
+        const addDays = reverse ? Math.max(a, b) : Math.min(a, b)
         if (addDays !== 0) {
           current.setUTCDate(current.getUTCDate() + addDays)
-          current.setUTCHours(cron.first.hour, cron.first.minute, cron.first.second)
+          current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
@@ -683,17 +772,25 @@ export const next = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
 
       if (cron.months.size !== 0) {
         const currentMonth = current.getUTCMonth() + 1
-        const nextMonth = cron.next.month[currentMonth]
+        const nextMonth = table.month[currentMonth]
+        const clampBoundaryDay = (targetMonthIndex: number): number => {
+          if (cron.days.size !== 0) {
+            return boundary.day
+          }
+          const maxDayInMonth = daysInMonth(new Date(Date.UTC(current.getUTCFullYear(), targetMonthIndex + 1, 0)))
+          return Math.min(boundary.day, maxDayInMonth)
+        }
         if (nextMonth === undefined) {
-          current.setUTCFullYear(current.getUTCFullYear() + 1)
-          current.setUTCMonth(cron.first.month, cron.first.day)
-          current.setUTCHours(cron.first.hour, cron.first.minute, cron.first.second)
+          current.setUTCFullYear(current.getUTCFullYear() + tick)
+          current.setUTCMonth(boundary.month, clampBoundaryDay(boundary.month))
+          current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
-        if (nextMonth > currentMonth) {
-          current.setUTCMonth(nextMonth - 1, cron.first.day)
-          current.setUTCHours(cron.first.hour, cron.first.minute, cron.first.second)
+        if (needsStep(nextMonth, currentMonth)) {
+          const targetMonthIndex = nextMonth - 1
+          current.setUTCMonth(targetMonthIndex, clampBoundaryDay(targetMonthIndex))
+          current.setUTCHours(boundary.hour, boundary.minute, boundary.second)
           adjustDst(current)
           continue
         }
@@ -702,7 +799,7 @@ export const next = (cron: Cron, now?: DateTime.DateTime.Input): Date => {
       return
     }
 
-    throw new Error("Unable to find next cron date")
+    throw new Error("Unable to find " + direction + " cron date")
   })
 
   return dateTime.toDateUtc(result)

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -8,6 +8,9 @@ const match = (input: Cron.Cron | string, date: DateTime.DateTime.Input) =>
 const next = (input: Cron.Cron | string, after?: DateTime.DateTime.Input) =>
   Cron.next(Cron.isCron(input) ? input : Cron.parseUnsafe(input), after)
 
+const prev = (input: Cron.Cron | string, after?: DateTime.DateTime.Input) =>
+  Cron.prev(Cron.isCron(input) ? input : Cron.parseUnsafe(input), after)
+
 describe("Cron", () => {
   it("isCronParseError", () => {
     const result = Cron.parse("")
@@ -164,6 +167,139 @@ describe("Cron", () => {
 
     deepStrictEqual(next(Cron.parseUnsafe("5 0 8 2 *", london), after), DateTime.toDateUtc(londonTime))
     deepStrictEqual(next(Cron.parseUnsafe("5 0 8 2 *", london), after), DateTime.toDateUtc(amsterdamTime))
+  })
+
+  it("prev", () => {
+    const utc = DateTime.zoneMakeNamedUnsafe("UTC")
+    const before = new Date("2024-01-04T16:21:00Z")
+    deepStrictEqual(prev(Cron.parseUnsafe("5 0 8 2 *", utc), before), new Date("2023-02-08T00:05:00.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("15 14 1 * *", utc), before), new Date("2024-01-01T14:15:00.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("23 0-20/2 * * * 0", utc), before), new Date("2023-12-31T23:20:23.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("5 4 * * SUN", utc), before), new Date("2023-12-31T04:05:00.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("5 4 * DEC SUN", utc), before), new Date("2023-12-31T04:05:00.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("30 5 0 8 2 *", utc), before), new Date("2023-02-08T00:05:30.000Z"))
+
+    const wednesday = new Date("2025-10-22T01:00:00.000Z")
+    deepStrictEqual(prev(Cron.parseUnsafe("0 1 * * MON", utc), wednesday), new Date("2025-10-20T01:00:00.000Z"))
+    deepStrictEqual(next(Cron.parseUnsafe("0 1 * * MON", utc), wednesday), new Date("2025-10-27T01:00:00.000Z"))
+    deepStrictEqual(prev(Cron.parseUnsafe("0 1 * * TUE", utc), wednesday), new Date("2025-10-21T01:00:00.000Z"))
+    deepStrictEqual(next(Cron.parseUnsafe("0 1 * * TUE", utc), wednesday), new Date("2025-10-28T01:00:00.000Z"))
+  })
+
+  it("returns the latest second when rolling back a minute", () => {
+    const utc = DateTime.zoneMakeNamedUnsafe("UTC")
+    const expr = Cron.parseUnsafe("10,30 * * * * *", utc)
+    const before = new Date("2024-01-01T00:00:05.000Z")
+    deepStrictEqual(prev(expr, before), new Date("2023-12-31T23:59:30.000Z"))
+  })
+
+  it("forward and reverse sequences stay aligned", () => {
+    const cases = [
+      ["5 2 * * 1", "2020-01-01T00:00:01Z", "2021-01-01T00:00:01Z"],
+      ["0 12 1 * *", "2020-01-01T00:00:01Z", "2021-01-01T00:00:01Z"],
+      ["10,30 * * * * *", "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"]
+    ] as const
+
+    const gatherForward = (cron: Cron.Cron, lower: Date, upper: Date) => {
+      const dates: Array<Date> = []
+      let current = lower
+      while (true) {
+        current = Cron.next(cron, current)
+        if (current >= upper) {
+          return dates
+        }
+        dates.push(current)
+      }
+    }
+
+    const gatherReverse = (cron: Cron.Cron, lower: Date, upper: Date) => {
+      const dates: Array<Date> = []
+      let current = upper
+      while (true) {
+        current = Cron.prev(cron, current)
+        if (current <= lower) {
+          return dates.reverse()
+        }
+        dates.push(current)
+      }
+    }
+
+    for (const [expr, lowerStr, upperStr] of cases) {
+      const lower = new Date(lowerStr)
+      const upper = new Date(upperStr)
+      const cron = Cron.parseUnsafe(expr, DateTime.zoneMakeNamedUnsafe("UTC"))
+
+      deepStrictEqual(gatherForward(cron, lower, upper), gatherReverse(cron, lower, upper))
+    }
+  })
+
+  it("prev prefers the latest matching day within the previous month", () => {
+    const cron = Cron.parseUnsafe("0 0 8 5,20 * *", DateTime.zoneMakeNamedUnsafe("UTC"))
+    const before = new Date("2024-06-03T00:00:00.000Z")
+    deepStrictEqual(prev(cron, before), new Date("2024-05-20T08:00:00.000Z"))
+  })
+
+  it("prev wraps weekday using the last allowed value", () => {
+    const cron = Cron.parseUnsafe("0 1 * * MON,FRI", DateTime.zoneMakeNamedUnsafe("UTC"))
+    const sunday = new Date("2025-10-19T12:00:00.000Z")
+    deepStrictEqual(prev(cron, sunday), new Date("2025-10-17T01:00:00.000Z"))
+  })
+
+  it("prev chooses the preferred occurrence in DST fall-back", () => {
+    const make = (s: string): DateTime.Zoned => Option.getOrThrow(DateTime.makeZonedFromString(s))
+    const cron = Cron.parseUnsafe("0 30 2 * * *", "Europe/Berlin")
+    const before = make("2024-10-27T03:30:00.000+01:00[Europe/Berlin]")
+    const result = DateTime.makeZonedUnsafe(prev(cron, before), { timeZone: "Europe/Berlin" })
+    deepStrictEqual(result.pipe(DateTime.formatIsoZoned), "2024-10-27T02:30:00.000+02:00[Europe/Berlin]")
+  })
+
+  it("prev respects combined day-of-month and weekday constraints", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 9 1,15 * MON", tz)
+    const before = new Date("2024-04-02T12:00:00.000Z")
+    deepStrictEqual(prev(cron, before), new Date("2024-04-01T09:00:00.000Z"))
+  })
+
+  it("prev handles step expressions across day boundary", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 */7 8-10 * * *", tz)
+    const before = new Date("2024-01-01T08:01:00.000Z")
+    deepStrictEqual(prev(cron, before), new Date("2024-01-01T08:00:00.000Z"))
+  })
+
+  it("prev works with fixed offset time zones", () => {
+    const offset = DateTime.zoneMakeOffset(2 * 60 * 60 * 1000)
+    const cron = Cron.parseUnsafe("0 0 10 * * *", offset)
+    const before = new Date("2024-05-01T07:00:00.000Z")
+    deepStrictEqual(prev(cron, before), new Date("2024-04-30T08:00:00.000Z"))
+  })
+
+  it("prev wraps across year boundary", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 1 1 *", tz)
+    const from = new Date("2024-01-01T00:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2023-01-01T00:00:00.000Z"))
+  })
+
+  it("prev handles day 31 skipping months without it", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 31 * *", tz)
+    const from = new Date("2024-03-01T00:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2024-01-31T00:00:00.000Z"))
+  })
+
+  it("prev clamps to the last valid day when rolling back a month with only month constraints", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 0 * FEB *", tz)
+    const from = new Date("2024-03-31T12:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2024-02-29T00:00:00.000Z"))
+  })
+
+  it("prev with multiple months specified", () => {
+    const tz = DateTime.zoneMakeNamedUnsafe("UTC")
+    const cron = Cron.parseUnsafe("0 0 15 1,4,7,10 *", tz)
+    const from = new Date("2024-05-01T00:00:00.000Z")
+    deepStrictEqual(prev(cron, from), new Date("2024-04-15T00:00:00.000Z"))
   })
 
   it("sequence", () => {


### PR DESCRIPTION
## Summary
- backport Cron.prev to the current Cron module using reverse lookup tables and shared directional stepping
- extend internal cron metadata with reverse boundaries (last) and reverse lookup tables (prev)
- add prev regression coverage (including DST and forward/reverse alignment checks) and include a changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Cron.test.ts
- pnpm check:tsgo
- pnpm docgen