### PR TITLE
EFF-740 Fix ai missing summaryParts error

### DIFF
--- a/.changeset/eff-740-missing-summary-parts.md
+++ b/.changeset/eff-740-missing-summary-parts.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-openai": patch
+---
+
+Fix OpenAI reasoning stream state handling so out-of-order reasoning summary events do not crash when prior reasoning item state is missing.

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -1357,11 +1357,34 @@ const makeStreamResponse = Effect.fnUntraced(
     // Track annotations for current message to include in text-end metadata
     const activeAnnotations: Array<typeof Generated.Annotation.Encoded> = []
 
+    type ReasoningSummaryPartStatus = "active" | "can-conclude" | "concluded"
+    type ReasoningPart = {
+      encryptedContent: string | undefined
+      summaryParts: Record<number, ReasoningSummaryPartStatus>
+    }
+
     // Track active reasoning items with state machine for proper concluding logic
-    const activeReasoning: Record<string, {
-      readonly encryptedContent: string | undefined
-      readonly summaryParts: Record<number, "active" | "can-conclude" | "concluded">
-    }> = {}
+    const activeReasoning: Record<string, ReasoningPart> = {}
+
+    const getOrCreateReasoningPart = (
+      itemId: string,
+      encryptedContent?: string | null
+    ): ReasoningPart => {
+      const activePart = activeReasoning[itemId]
+      if (Predicate.isNotUndefined(activePart)) {
+        if (Predicate.isNotNullish(encryptedContent)) {
+          activePart.encryptedContent = encryptedContent
+        }
+        return activePart
+      }
+
+      const reasoningPart: ReasoningPart = {
+        encryptedContent: Predicate.isNotNullish(encryptedContent) ? encryptedContent : undefined,
+        summaryParts: {}
+      }
+      activeReasoning[itemId] = reasoningPart
+      return reasoningPart
+    }
 
     // Track active tool calls with optional provider-specific state
     const activeToolCalls: Record<number, {
@@ -1563,21 +1586,20 @@ const makeStreamResponse = Effect.fnUntraced(
               }
 
               case "reasoning": {
-                const encryptedContent = event.item.encrypted_content ?? undefined
-                activeReasoning[event.item.id] = {
-                  encryptedContent,
-                  summaryParts: { 0: "active" }
-                }
-                parts.push({
-                  type: "reasoning-start",
-                  id: `${event.item.id}:0`,
-                  metadata: {
-                    openai: {
-                      ...makeItemIdMetadata(event.item.id),
-                      ...makeEncryptedContentMetadata(event.item.encrypted_content)
+                const reasoningPart = getOrCreateReasoningPart(event.item.id, event.item.encrypted_content)
+                if (Predicate.isUndefined(reasoningPart.summaryParts[0])) {
+                  reasoningPart.summaryParts[0] = "active"
+                  parts.push({
+                    type: "reasoning-start",
+                    id: `${event.item.id}:0`,
+                    metadata: {
+                      openai: {
+                        ...makeItemIdMetadata(event.item.id),
+                        ...makeEncryptedContentMetadata(reasoningPart.encryptedContent)
+                      }
                     }
-                  }
-                })
+                  })
+                }
                 break
               }
 
@@ -1866,7 +1888,7 @@ const makeStreamResponse = Effect.fnUntraced(
               }
 
               case "reasoning": {
-                const reasoningPart = activeReasoning[event.item.id]
+                const reasoningPart = getOrCreateReasoningPart(event.item.id, event.item.encrypted_content)
                 for (const [summaryIndex, status] of Object.entries(reasoningPart.summaryParts)) {
                   if (status === "active" || status === "can-conclude") {
                     parts.push({
@@ -1875,7 +1897,7 @@ const makeStreamResponse = Effect.fnUntraced(
                       metadata: {
                         openai: {
                           ...makeItemIdMetadata(event.item.id),
-                          ...makeEncryptedContentMetadata(event.item.encrypted_content)
+                          ...makeEncryptedContentMetadata(reasoningPart.encryptedContent)
                         }
                       }
                     })
@@ -2141,28 +2163,28 @@ const makeStreamResponse = Effect.fnUntraced(
           }
 
           case "response.reasoning_summary_part.added": {
-            // The first reasoning start is pushed in the `response.output_item.added` block
+            const reasoningPart = getOrCreateReasoningPart(event.item_id)
             if (event.summary_index > 0) {
-              const reasoningPart = activeReasoning[event.item_id]
-              if (Predicate.isNotUndefined(reasoningPart)) {
-                // Conclude all can-conclude parts before starting new one
-                for (const [summaryIndex, status] of Object.entries(reasoningPart.summaryParts)) {
-                  if (status === "can-conclude") {
-                    parts.push({
-                      type: "reasoning-end",
-                      id: `${event.item_id}:${summaryIndex}`,
-                      metadata: {
-                        openai: {
-                          ...makeItemIdMetadata(event.item_id),
-                          ...makeEncryptedContentMetadata(reasoningPart.encryptedContent)
-                        }
+              // Conclude all can-conclude parts before starting new one
+              for (const [summaryIndex, status] of Object.entries(reasoningPart.summaryParts)) {
+                if (status === "can-conclude") {
+                  parts.push({
+                    type: "reasoning-end",
+                    id: `${event.item_id}:${summaryIndex}`,
+                    metadata: {
+                      openai: {
+                        ...makeItemIdMetadata(event.item_id),
+                        ...makeEncryptedContentMetadata(reasoningPart.encryptedContent)
                       }
-                    })
-                    reasoningPart.summaryParts[Number(summaryIndex)] = "concluded"
-                  }
+                    }
+                  })
+                  reasoningPart.summaryParts[Number(summaryIndex)] = "concluded"
                 }
-                reasoningPart.summaryParts[event.summary_index] = "active"
               }
+            }
+
+            if (Predicate.isUndefined(reasoningPart.summaryParts[event.summary_index])) {
+              reasoningPart.summaryParts[event.summary_index] = "active"
               parts.push({
                 type: "reasoning-start",
                 id: `${event.item_id}:${event.summary_index}`,
@@ -2188,6 +2210,7 @@ const makeStreamResponse = Effect.fnUntraced(
           }
 
           case "response.reasoning_summary_part.done": {
+            const reasoningPart = getOrCreateReasoningPart(event.item_id)
             // When OpenAI stores message data, we can immediately conclude the
             // reasoning part given that we do not need the encrypted content
             if (config.store === true) {
@@ -2197,11 +2220,11 @@ const makeStreamResponse = Effect.fnUntraced(
                 metadata: { openai: { ...makeItemIdMetadata(event.item_id) } }
               })
               // Mark the summary part concluded
-              activeReasoning[event.item_id].summaryParts[event.summary_index] = "concluded"
+              reasoningPart.summaryParts[event.summary_index] = "concluded"
             } else {
               // Mark the summary part as can-conclude given we still need a
               // final summary part with the encrypted content
-              activeReasoning[event.item_id].summaryParts[event.summary_index] = "can-conclude"
+              reasoningPart.summaryParts[event.summary_index] = "can-conclude"
             }
             break
           }

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -904,6 +904,77 @@ describe("OpenAiLanguageModel", () => {
         const toolParamsEnd = parts.find((part) => part.type === "tool-params-end" && part.id === "call_1")
         assert.isDefined(toolParamsEnd)
       }))
+
+    it.effect("handles reasoning summary events when reasoning state is missing", () =>
+      Effect.gen(function*() {
+        const streamEvents = [
+          {
+            type: "response.created",
+            sequence_number: 1,
+            response: makeDefaultResponse({
+              id: "resp_reasoning_missing_state",
+              status: "in_progress",
+              output: []
+            })
+          },
+          {
+            type: "response.reasoning_summary_part.added",
+            sequence_number: 2,
+            output_index: 0,
+            item_id: "rs_missing",
+            summary_index: 1
+          },
+          {
+            type: "response.reasoning_summary_text.delta",
+            sequence_number: 3,
+            output_index: 0,
+            item_id: "rs_missing",
+            summary_index: 1,
+            delta: "thinking"
+          },
+          {
+            type: "response.reasoning_summary_part.done",
+            sequence_number: 4,
+            output_index: 0,
+            item_id: "rs_missing",
+            summary_index: 1
+          },
+          {
+            type: "response.output_item.done",
+            sequence_number: 5,
+            output_index: 0,
+            item: makeReasoningOutput(["thinking"], { id: "rs_missing" })
+          },
+          {
+            type: "response.output_item.done",
+            sequence_number: 6,
+            output_index: 1,
+            item: makeReasoningOutput([], { id: "rs_done_only" })
+          },
+          {
+            type: "response.completed",
+            sequence_number: 7,
+            response: makeDefaultResponse({
+              id: "resp_reasoning_missing_state",
+              status: "completed",
+              output: []
+            })
+          }
+        ] as unknown as ReadonlyArray<typeof Generated.ResponseStreamEvent.Type>
+
+        const partsChunk = yield* LanguageModel.streamText({
+          prompt: "reason"
+        }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(makeStreamTestLayer(streamEvents))
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        assert.isDefined(parts.find((part) => part.type === "reasoning-start" && part.id === "rs_missing:1"))
+        assert.isDefined(parts.find((part) => part.type === "reasoning-end" && part.id === "rs_missing:1"))
+        assert.isDefined(parts.find((part) => part.type === "finish"))
+      }))
   })
 
   describe("withConfigOverride", () => {


### PR DESCRIPTION
## Summary
- add a resilient reasoning stream state helper in OpenAI streaming so reasoning events can recover when `response.output_item.added` is missing
- guard reasoning summary added/done and reasoning output completion paths from missing `activeReasoning` state, including metadata handling
- add a stream regression test covering missing reasoning state across summary and output completion events
- add a changeset for `@effect/ai-openai`

## Validation
- pnpm lint-fix
- pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts
- pnpm check:tsgo
- pnpm docgen