### PR TITLE
EFF-737 Support dynamic idleTimeToLive in LayerMap

### DIFF
--- a/.changeset/layer-map-dynamic-idle-ttl.md
+++ b/.changeset/layer-map-dynamic-idle-ttl.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Support key-derived `idleTimeToLive` in `LayerMap` options (`make`, `fromRecord`, and `LayerMap.Service`) and add `LayerMap` tests for dynamic TTL behavior.

--- a/packages/effect/src/LayerMap.ts
+++ b/packages/effect/src/LayerMap.ts
@@ -12,6 +12,8 @@ import type { Mutable, NoExcessProperties } from "./Types.ts"
 
 const TypeId = "~effect/LayerMap"
 
+type IdleTimeToLiveInput<K> = Duration.Input | ((key: K) => Duration.Input)
+
 /**
  * @since 3.14.0
  * @category Models
@@ -119,7 +121,7 @@ export const make: <
 >(
   lookup: (key: K) => L,
   options?: {
-    readonly idleTimeToLive?: Duration.Input | undefined
+    readonly idleTimeToLive?: IdleTimeToLiveInput<K> | undefined
     readonly preloadKeys?: PreloadKeys
   } | undefined
 ) => Effect.Effect<
@@ -129,7 +131,7 @@ export const make: <
 > = Effect.fnUntraced(function*<I, K, EL, RL>(
   lookup: (key: K) => Layer.Layer<I, EL, RL>,
   options?: {
-    readonly idleTimeToLive?: Duration.Input | undefined
+    readonly idleTimeToLive?: IdleTimeToLiveInput<K> | undefined
   } | undefined
 ) {
   const services = yield* Effect.services<never>()
@@ -198,7 +200,7 @@ export const fromRecord = <
 >(
   layers: Layers,
   options?: {
-    readonly idleTimeToLive?: Duration.Input | undefined
+    readonly idleTimeToLive?: IdleTimeToLiveInput<keyof Layers> | undefined
     readonly preload?: Preload | undefined
   } | undefined
 ): Effect.Effect<
@@ -309,7 +311,7 @@ export const Service = <Self>() =>
     | NoExcessProperties<{
       readonly lookup: (key: any) => Layer.Layer<any, any, any>
       readonly dependencies?: ReadonlyArray<Layer.Layer<any, any, any>> | undefined
-      readonly idleTimeToLive?: Duration.Input | undefined
+      readonly idleTimeToLive?: IdleTimeToLiveInput<any> | undefined
       readonly preloadKeys?:
         | Iterable<Options extends { readonly lookup: (key: infer K) => any } ? K : never>
         | undefined
@@ -317,7 +319,7 @@ export const Service = <Self>() =>
     | NoExcessProperties<{
       readonly layers: Record<string, Layer.Layer<any, any, any>>
       readonly dependencies?: ReadonlyArray<Layer.Layer<any, any, any>> | undefined
-      readonly idleTimeToLive?: Duration.Input | undefined
+      readonly idleTimeToLive?: IdleTimeToLiveInput<any> | undefined
       readonly preload?: boolean | undefined
     }, Options>
 >(

--- a/packages/effect/test/LayerMap.test.ts
+++ b/packages/effect/test/LayerMap.test.ts
@@ -1,0 +1,98 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer, LayerMap } from "effect"
+import { TestClock } from "effect/testing"
+
+const makeLayer = (key: string, acquired: Array<string>, released: Array<string>): Layer.Layer<any> =>
+  Layer.effectDiscard(
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        acquired.push(key)
+      }),
+      () =>
+        Effect.sync(() => {
+          released.push(key)
+        })
+    )
+  ) as Layer.Layer<any>
+
+describe("LayerMap", () => {
+  it.effect("make supports dynamic idleTimeToLive", () =>
+    Effect.gen(function*() {
+      const acquired: Array<string> = []
+      const released: Array<string> = []
+      const layerMap = yield* LayerMap.make(
+        (key: string) => makeLayer(key, acquired, released),
+        { idleTimeToLive: (key: string) => key.startsWith("short:") ? 500 : 2000 }
+      )
+
+      yield* Effect.scoped(layerMap.services("short:a"))
+      yield* Effect.scoped(layerMap.services("long:b"))
+      assert.deepStrictEqual(acquired, ["short:a", "long:b"])
+      assert.deepStrictEqual(released, [])
+
+      yield* TestClock.adjust(500)
+      assert.deepStrictEqual(released, ["short:a"])
+
+      yield* TestClock.adjust(1500)
+      assert.deepStrictEqual(released, ["short:a", "long:b"])
+    }))
+
+  it.effect("fromRecord supports dynamic idleTimeToLive", () =>
+    Effect.gen(function*() {
+      const acquired: Array<string> = []
+      const released: Array<string> = []
+      const layers = {
+        short: makeLayer("short", acquired, released),
+        long: makeLayer("long", acquired, released)
+      } as const
+      const layerMap = yield* LayerMap.fromRecord(
+        layers,
+        {
+          idleTimeToLive: (key) => {
+            const key_: "short" | "long" = key
+            return key_ === "short" ? 500 : 2000
+          }
+        }
+      )
+
+      yield* Effect.scoped(layerMap.services("short"))
+      yield* Effect.scoped(layerMap.services("long"))
+      assert.deepStrictEqual(acquired, ["short", "long"])
+      assert.deepStrictEqual(released, [])
+
+      yield* TestClock.adjust(500)
+      assert.deepStrictEqual(released, ["short"])
+
+      yield* TestClock.adjust(1500)
+      assert.deepStrictEqual(released, ["short", "long"])
+    }))
+
+  it.effect("Service supports dynamic idleTimeToLive", () =>
+    Effect.gen(function*() {
+      const acquired: Array<string> = []
+      const released: Array<string> = []
+
+      class LookupMap extends LayerMap.Service<LookupMap>()("LayerMapTest/LookupMap", {
+        lookup: (key: string) => makeLayer(key, acquired, released),
+        idleTimeToLive: (key: string) => key.startsWith("short:") ? 500 : 2000
+      }) {}
+
+      class RecordMap extends LayerMap.Service<RecordMap>()("LayerMapTest/RecordMap", {
+        layers: {
+          short: makeLayer("short", acquired, released),
+          long: makeLayer("long", acquired, released)
+        },
+        idleTimeToLive: (key) => {
+          const key_: "short" | "long" = key
+          return key_ === "short" ? 500 : 2000
+        }
+      }) {}
+
+      yield* Effect.scoped(LookupMap.services("short:a").pipe(Effect.provide(LookupMap.layer)))
+      yield* Effect.scoped(RecordMap.services("short").pipe(Effect.provide(RecordMap.layer)))
+      assert.deepStrictEqual(acquired, ["short:a", "short"])
+
+      yield* TestClock.adjust(500)
+      assert.deepStrictEqual(released, ["short:a", "short"])
+    }))
+})


### PR DESCRIPTION
## Summary
- add key-derived `idleTimeToLive` input support to `LayerMap.make` and `LayerMap.fromRecord`
- update `LayerMap.Service` options to accept dynamic `idleTimeToLive` functions
- add new `LayerMap` runtime tests covering dynamic TTL behavior for make / fromRecord / Service
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/LayerMap.test.ts
- pnpm test packages/effect/test/RcMap.test.ts
- pnpm check:tsgo
- pnpm docgen