### PR TITLE
EFF-742 Add HttpClientRequest.toWeb and fromWeb

### DIFF
--- a/.changeset/eff-742-http-client-request-web.md
+++ b/.changeset/eff-742-http-client-request-web.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+unstable/http HttpClientRequest: add toWeb and fromWeb conversions for web Request objects

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -15,10 +15,11 @@ import type * as Redacted from "../../Redacted.ts"
 import * as Result from "../../Result.ts"
 import type * as Schema from "../../Schema.ts"
 import type { ParseOptions } from "../../SchemaAST.ts"
-import type * as Stream from "../../Stream.ts"
+import * as ServiceMap from "../../ServiceMap.ts"
+import * as Stream from "../../Stream.ts"
 import * as Headers from "./Headers.ts"
 import * as HttpBody from "./HttpBody.ts"
-import type { HttpMethod } from "./HttpMethod.ts"
+import { hasBody, type HttpMethod } from "./HttpMethod.ts"
 import * as UrlParams from "./UrlParams.ts"
 
 const TypeId = "~effect/http/HttpClientRequest"
@@ -749,3 +750,104 @@ export function toUrl(self: HttpClientRequest): Option.Option<URL> {
   }
   return Option.none()
 }
+
+/**
+ * @since 4.0.0
+ * @category conversions
+ */
+export const fromWeb = (request: globalThis.Request): HttpClientRequest => {
+  const method = request.method.toUpperCase() as HttpMethod
+  return modify(empty, {
+    method,
+    url: new URL(request.url),
+    headers: request.headers,
+    body: fromWebBody(request, method)
+  })
+}
+
+const fromWebBody = (request: globalThis.Request, method: HttpMethod): HttpBody.HttpBody => {
+  if (!hasBody(method) || request.body === null) {
+    return HttpBody.empty
+  }
+  return HttpBody.raw(request.body, {
+    contentType: request.headers.get("content-type") ?? undefined,
+    contentLength: parseContentLength(request.headers.get("content-length"))
+  })
+}
+
+const parseContentLength = (contentLength: string | null): number | undefined => {
+  if (contentLength === null) {
+    return undefined
+  }
+  const parsed = Number.parseInt(contentLength, 10)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+/**
+ * @since 4.0.0
+ * @category conversions
+ */
+export const toWebResult = (self: HttpClientRequest, options?: {
+  readonly signal?: AbortSignal | undefined
+  readonly services?: ServiceMap.ServiceMap<never> | undefined
+}): Result.Result<Request, UrlParams.UrlParamsError> => {
+  const url = UrlParams.makeUrl(self.url, self.urlParams, Option.getOrUndefined(self.hash))
+  if (Result.isFailure(url)) {
+    return Result.fail(url.failure)
+  }
+  const requestInit: RequestInit = {
+    method: self.method,
+    headers: self.headers
+  }
+  if (options?.signal) {
+    requestInit.signal = options.signal
+  }
+  if (hasBody(self.method)) {
+    switch (self.body._tag) {
+      case "Empty": {
+        break
+      }
+      case "Raw": {
+        requestInit.body = self.body.body as any
+        if (isReadableStream(self.body.body)) {
+          ;(requestInit as any).duplex = "half"
+        }
+        break
+      }
+      case "Uint8Array": {
+        requestInit.body = self.body.body as any
+        break
+      }
+      case "FormData": {
+        requestInit.body = self.body.formData
+        break
+      }
+      case "Stream": {
+        requestInit.body = Stream.toReadableStreamWith(self.body.stream, options?.services ?? ServiceMap.empty())
+        ;(requestInit as any).duplex = "half"
+        break
+      }
+    }
+  }
+  return Result.try({
+    try: () => new Request(url.success, requestInit),
+    catch: (cause) => new UrlParams.UrlParamsError({ cause })
+  })
+}
+
+const isReadableStream = (u: unknown): u is ReadableStream<Uint8Array> =>
+  typeof ReadableStream !== "undefined" && u instanceof ReadableStream
+
+/**
+ * @since 4.0.0
+ * @category conversions
+ */
+export const toWeb = (self: HttpClientRequest, options?: {
+  readonly signal?: AbortSignal | undefined
+}): Effect.Effect<Request, UrlParams.UrlParamsError> =>
+  Effect.servicesWith((services) =>
+    toWebResult(self, {
+      services,
+      signal: options?.signal
+    }).asEffect()
+  )

--- a/packages/effect/test/unstable/http/HttpClientRequest.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientRequest.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "@effect/vitest"
-import { assertNone, assertSome, strictEqual } from "@effect/vitest/utils"
+import { assertNone, assertSome, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Effect, Stream } from "effect"
 import * as Option from "effect/Option"
 import { HttpClientRequest } from "effect/unstable/http"
 
@@ -105,6 +106,59 @@ describe("HttpClientRequest", () => {
         HttpClientRequest.setUrl("http://[::1")
       )
       assertNone(HttpClientRequest.toUrl(request))
+    })
+  })
+
+  describe("web conversions", () => {
+    it.effect("fromWeb", () =>
+      Effect.gen(function*() {
+        const webRequest = new Request("http://localhost:3000/todos/1?a=1&a=2#top", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "content-length": "13",
+            "x-test": "ok"
+          },
+          body: "{\"foo\":\"bar\"}"
+        })
+        const request = HttpClientRequest.fromWeb(webRequest)
+
+        strictEqual(request.method, "POST")
+        strictEqual(request.url, "http://localhost:3000/todos/1")
+        assertSome(request.hash, "top")
+        strictEqual(request.headers["content-type"], "application/json")
+        strictEqual(request.headers["content-length"], "13")
+        strictEqual(request.headers["x-test"], "ok")
+        deepStrictEqual([...request.urlParams], [["a", "1"], ["a", "2"]])
+        strictEqual(request.body._tag, "Raw")
+
+        const webRequest2 = yield* HttpClientRequest.toWeb(request)
+        strictEqual(yield* Effect.promise(() => webRequest2.text()), "{\"foo\":\"bar\"}")
+      }))
+
+    it.effect("toWeb stream body", () =>
+      Effect.gen(function*() {
+        const body = new Uint8Array([104, 101, 108, 108, 111])
+        const request = HttpClientRequest.post("http://localhost:3000/stream").pipe(
+          HttpClientRequest.bodyStream(Stream.succeed(body), {
+            contentType: "text/plain",
+            contentLength: body.length
+          })
+        )
+        const webRequest = yield* HttpClientRequest.toWeb(request)
+
+        strictEqual(webRequest.method, "POST")
+        strictEqual(webRequest.url, "http://localhost:3000/stream")
+        strictEqual(yield* Effect.promise(() => webRequest.text()), "hello")
+      }))
+
+    it("toWebResult returns failure for invalid url", () => {
+      const request = HttpClientRequest.get("http://localhost").pipe(
+        HttpClientRequest.setUrl("http://[::1")
+      )
+      const result = HttpClientRequest.toWebResult(request)
+
+      strictEqual(result._tag, "Failure")
     })
   })
 })


### PR DESCRIPTION
## Summary
- add `HttpClientRequest.fromWeb`, `HttpClientRequest.toWebResult`, and `HttpClientRequest.toWeb` for web `Request` conversion
- preserve method, URL params, hash, headers, and body metadata when converting from web requests
- convert stream bodies to web readable streams with `duplex: "half"` when required during conversion to web requests
- add request conversion tests in `HttpClientRequest.test.ts`
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/http/HttpClientRequest.test.ts
- pnpm check:tsgo
- pnpm docgen