### PR TITLE
Backport Fix HttpServerResponse.fromWeb losing Content-Type header

### DIFF
--- a/.changeset/good-tools-work.md
+++ b/.changeset/good-tools-work.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+HttpServerResponse: fix `fromWeb` to preserve Content-Type header when response has a body
+
+Previously, when converting a web `Response` to an `HttpServerResponse` via `fromWeb`, the `Content-Type` header was not passed to `Body.stream()`, causing it to default to `application/octet-stream`. This affected any code using `HttpApp.fromWebHandler` to wrap web handlers, as JSON responses would incorrectly have their Content-Type set to `application/octet-stream` instead of `application/json`.

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -1131,12 +1131,16 @@ export const fromWeb = (response: Response): HttpServerResponse => {
     cookies: Cookies.fromSetCookie(setCookieHeaders)
   })
   if (response.body) {
+    const contentType = response.headers.get("content-type")
     self = setBody(
       self,
-      Body.stream(Stream.fromReadableStream({
-        evaluate: () => response.body!,
-        onError: (e) => e
-      }))
+      Body.stream(
+        Stream.fromReadableStream({
+          evaluate: () => response.body!,
+          onError: (e) => e
+        }),
+        contentType ?? undefined
+      )
     )
   }
   return self

--- a/packages/effect/test/unstable/http/HttpEffect.test.ts
+++ b/packages/effect/test/unstable/http/HttpEffect.test.ts
@@ -221,5 +221,34 @@ describe("Http/App", () => {
       const response = await finalHandler(new Request("http://localhost:3000/"))
       deepStrictEqual(await response.json(), { source: "effect" })
     })
+
+    test("json preserves content-type", async () => {
+      const handler = HttpEffect.toWebHandler(HttpServerResponse.json({ foo: "bar" }))
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "application/json")
+    })
+
+    test("preserves response content-type header", async () => {
+      const webHandler = async (_request: Request) => {
+        return Response.json({ message: "hello" })
+      }
+      const app = HttpEffect.fromWebHandler(webHandler)
+      const handler = HttpEffect.toWebHandler(app)
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "application/json")
+      deepStrictEqual(await response.json(), { message: "hello" })
+    })
+
+    test("preserves custom content-type header", async () => {
+      const webHandler = async (_request: Request) => {
+        return new Response("<html></html>", {
+          headers: { "Content-Type": "text/html; charset=utf-8" }
+        })
+      }
+      const app = HttpEffect.fromWebHandler(webHandler)
+      const handler = HttpEffect.toWebHandler(app)
+      const response = await handler(new Request("http://localhost:3000/"))
+      strictEqual(response.headers.get("Content-Type"), "text/html; charset=utf-8")
+    })
   })
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Back-porting the fix https://github.com/Effect-TS/effect/pull/5940/commits

## Related

- Related Issue #
- Closes #
