### PR TITLE
EFF-743 Fix Ctrl-L rendering artifacts in CLI Prompt

### DIFF
--- a/.changeset/forty-hounds-cheer.md
+++ b/.changeset/forty-hounds-cheer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ignore unsupported Ctrl key combinations in interactive CLI prompts to avoid rendering control characters such as Ctrl+L form feed into prompt input.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2187,11 +2187,14 @@ const processSelection = Effect.fnUntraced(function*(state: FileState, options: 
 
 const handleFileProcess = (options: FileOptionsReq) => {
   return Effect.fnUntraced(function*(input: Terminal.UserInput, state: FileState) {
-    if (input.key.ctrl && input.key.name === "u") {
-      if (showConfirmation(state.confirm)) {
-        return Action.Beep()
+    if (input.key.ctrl) {
+      if (input.key.name === "u") {
+        if (showConfirmation(state.confirm)) {
+          return Action.Beep()
+        }
+        return yield* processFileClear(state)
       }
-      return yield* processFileClear(state)
+      return Action.Beep()
     }
     switch (input.key.name) {
       case "k":
@@ -3154,8 +3157,11 @@ const handleSelectProcess = <A>(options: SelectOptionsReq<A>) => {
 
 const handleAutoCompleteProcess = <A>(options: AutoCompleteOptionsReq<A>) => {
   return (input: Terminal.UserInput, state: AutoCompleteState) => {
-    if (input.key.ctrl && input.key.name === "u") {
-      return processAutoCompleteClear(state, options)
+    if (input.key.ctrl) {
+      if (input.key.name === "u") {
+        return processAutoCompleteClear(state, options)
+      }
+      return Effect.succeed(Action.Beep())
     }
     switch (input.key.name) {
       case "k":
@@ -3416,6 +3422,9 @@ const handleTextProcess = (options: TextOptionsReq) => {
         }
         case "e": {
           return processTextCursorEnd(state)
+        }
+        default: {
+          return Effect.succeed(Action.Beep())
         }
       }
     }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -143,6 +143,21 @@ describe("Prompt.text", () => {
       assert.strictEqual(result, "Jane Doe")
     }).pipe(Effect.provide(TestLayer)))
 
+  it.effect("does not insert characters for unsupported ctrl key combinations", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.text({
+        message: "Name"
+      })
+
+      yield* MockTerminal.inputText("Ja")
+      yield* MockTerminal.inputKey("l", { ctrl: true })
+      yield* MockTerminal.inputText("ne")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "Jane")
+    }).pipe(Effect.provide(TestLayer)))
+
   it.effect("does not render or submit the cleared default value", () =>
     Effect.gen(function*() {
       const prompt = Prompt.text({


### PR DESCRIPTION
## Summary
- ignore unsupported Ctrl key combinations in text, file, and autocomplete prompt processors
- keep existing Ctrl+U behavior intact for clear actions
- add a regression test ensuring unsupported Ctrl combinations (Ctrl+L) are not inserted into Prompt.text input
- add a changeset for the effect package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Prompt.test.ts
- pnpm check:tsgo
- pnpm docgen