### PR TITLE
EFF-744 Fix sqlite migrator silent lock failures

### DIFF
--- a/.changeset/odd-pugs-lift.md
+++ b/.changeset/odd-pugs-lift.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix SQL migrator locking detection to avoid swallowing non-duplicate insert errors (including sqlite busy locks).

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -236,11 +236,13 @@ export const make = <RD = never>({
       if (required.length > 0) {
         yield* pipe(
           insertMigrations(required.map(([id, name]) => [id, name])),
-          Effect.mapError((_) =>
-            new MigrationError({
-              kind: "Locked",
-              message: "Migrations already running"
-            })
+          Effect.mapError((error) =>
+            isDuplicateMigrationIdError(error)
+              ? new MigrationError({
+                kind: "Locked",
+                message: "Migrations already running"
+              })
+              : error
           )
         )
       }
@@ -294,6 +296,29 @@ export const make = <RD = never>({
   })
 
 const migrationOrder = Order.make<ResolvedMigration>(([a], [b]) => Order.Number(a, b))
+
+const isDuplicateMigrationIdError = (error: SqlError): boolean => {
+  const cause = error.cause
+  if (typeof cause !== "object" || cause === null) {
+    return false
+  }
+
+  const code = (cause as { readonly code?: unknown }).code
+  if (typeof code === "string") {
+    if (code === "23505" || code === "ER_DUP_ENTRY" || code.startsWith("SQLITE_CONSTRAINT")) {
+      return true
+    }
+  }
+
+  const errno = (cause as { readonly errno?: unknown }).errno
+  if (errno === 1062 || errno === 2601 || errno === 2627) {
+    return true
+  }
+
+  const message = (cause as { readonly message?: unknown }).message
+  return typeof message === "string" &&
+    /duplicate|unique\s+constraint|UNIQUE\s+constraint\s+failed|PRIMARY\s+KEY\s+constraint/i.test(message)
+}
 
 /**
  * @since 4.0.0

--- a/packages/sql/sqlite-node/test/SqliteMigrator.test.ts
+++ b/packages/sql/sqlite-node/test/SqliteMigrator.test.ts
@@ -1,0 +1,45 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-node"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, FileSystem } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+import { SqlError } from "effect/unstable/sql/SqlError"
+
+describe("SqliteMigrator", () => {
+  it.effect("fails when sqlite is locked during migration insert", () =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const dir = yield* fs.makeTempDirectoryScoped()
+      const filename = dir + "/test.db"
+      const [sqlA, sqlB] = yield* Effect.all([
+        SqliteClient.make({ filename }),
+        SqliteClient.make({ filename })
+      ], { concurrency: 2 })
+
+      yield* SqliteMigrator.run({
+        loader: SqliteMigrator.fromRecord({})
+      }).pipe(Effect.provideService(SqlClient.SqlClient, sqlA))
+
+      yield* sqlB`PRAGMA busy_timeout = 1`
+
+      const lockConnection = yield* sqlA.reserve
+      yield* Effect.addFinalizer(() => lockConnection.executeUnprepared("ROLLBACK", [], undefined).pipe(Effect.ignore))
+      yield* lockConnection.executeUnprepared("BEGIN IMMEDIATE", [], undefined)
+
+      const error = yield* SqliteMigrator.run({
+        loader: SqliteMigrator.fromRecord({
+          "1_create_test": Effect.gen(function*() {
+            const sql = yield* SqlClient.SqlClient
+            yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+          })
+        })
+      }).pipe(
+        Effect.provideService(SqlClient.SqlClient, sqlB),
+        Effect.flip
+      )
+
+      assert.instanceOf(error, SqlError)
+      assert.include(String((error.cause as { readonly message?: string }).message), "locked")
+    }).pipe(Effect.provide([NodeFileSystem.layer, Reactivity.layer])))
+})


### PR DESCRIPTION
## Summary
- fix SQL migrator insert error handling so only duplicate-key conflicts are treated as "Migrations already running"
- preserve non-duplicate insert failures (including sqlite "database is locked") as real errors instead of returning an empty migration result
- add sqlite-node regression test that reproduces a sqlite write lock and asserts migrator now fails with SqlError
- add changeset for the effect package

## Validation
- pnpm lint-fix
- pnpm test packages/sql/sqlite-node/test/SqliteMigrator.test.ts
- pnpm check:tsgo
- pnpm docgen