### PR TITLE
EFF-745 Fix sqlite migrator constraint errors being swallowed as lock

### DIFF
--- a/.changeset/eff-745-sqlite-migrator-constraint.md
+++ b/.changeset/eff-745-sqlite-migrator-constraint.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix sql migrator lock handling so non-duplicate constraint failures are surfaced instead of being treated as a concurrent migration lock.

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -67,6 +67,65 @@ export class MigrationError extends Data.TaggedError("MigrationError")<{
   readonly message: string
 }> {}
 
+const getCauseString = (cause: unknown, key: string): string | undefined => {
+  if (typeof cause !== "object" || cause === null || !(key in cause)) {
+    return
+  }
+  const value = (cause as Record<string, unknown>)[key]
+  return typeof value === "string" ? value : undefined
+}
+
+const getCauseNumber = (cause: unknown, key: string): number | undefined => {
+  if (typeof cause !== "object" || cause === null || !(key in cause)) {
+    return
+  }
+  const value = (cause as Record<string, unknown>)[key]
+  return typeof value === "number" ? value : undefined
+}
+
+const isDuplicateMigrationInsert = (table: string, error: SqlError): boolean => {
+  if (error.reason._tag !== "ConstraintError") {
+    return false
+  }
+
+  const cause = error.reason.cause
+  const code = getCauseString(cause, "code")
+  const errno = getCauseNumber(cause, "errno")
+  const number = getCauseNumber(cause, "number")
+  const duplicateCode = code === "23505" ||
+    code === "ER_DUP_ENTRY" ||
+    code?.startsWith("SQLITE_CONSTRAINT_PRIMARYKEY") === true ||
+    code?.startsWith("SQLITE_CONSTRAINT_UNIQUE") === true ||
+    errno === 1062 ||
+    errno === 1555 ||
+    errno === 2067 ||
+    number === 2601 ||
+    number === 2627
+
+  const searchable = [
+    getCauseString(cause, "message"),
+    getCauseString(cause, "detail"),
+    getCauseString(cause, "constraint"),
+    getCauseString(cause, "column"),
+    getCauseString(cause, "sqlMessage")
+  ].filter((_) => _ !== undefined)
+    .join(" ")
+    .toLowerCase()
+
+  const mentionsDuplicate = searchable.includes("duplicate") ||
+    searchable.includes("already exists") ||
+    searchable.includes("unique constraint") ||
+    searchable.includes("primary key")
+
+  const tableLower = table.toLowerCase()
+  const targetsMigrationId = searchable.includes("migration_id") ||
+    searchable.includes(`${tableLower}_pkey`) ||
+    searchable.includes(`${tableLower}.primary`) ||
+    searchable.includes("primary key")
+
+  return targetsMigrationId && (duplicateCode || mentionsDuplicate)
+}
+
 /**
  * @category constructor
  * @since 4.0.0
@@ -237,7 +296,7 @@ export const make = <RD = never>({
         yield* pipe(
           insertMigrations(required.map(([id, name]) => [id, name])),
           Effect.mapError((error): MigrationError | SqlError =>
-            error.reason._tag === "ConstraintError"
+            isDuplicateMigrationInsert(table, error)
               ? new MigrationError({
                 kind: "Locked",
                 message: "Migrations already running"

--- a/packages/sql/sqlite-node/test/SqliteMigrator.test.ts
+++ b/packages/sql/sqlite-node/test/SqliteMigrator.test.ts
@@ -45,4 +45,27 @@ describe("SqliteMigrator", () => {
       assert(SqlError.isSqlError(error))
       assert.strictEqual(error.reason._tag, "LockTimeoutError")
     }))
+
+  it.effect("does not swallow non-lock constraint errors", () =>
+    Effect.gen(function*() {
+      const { migratorClient } = yield* makeClients
+
+      yield* migratorClient`CREATE TABLE effect_sql_migrations (
+  migration_id integer PRIMARY KEY NOT NULL,
+  created_at datetime NOT NULL DEFAULT current_timestamp,
+  name VARCHAR(255) NOT NULL CHECK(name = 'allowed')
+)`
+
+      const error = yield* Effect.flip(
+        SqliteMigrator.run({
+          loader: SqliteMigrator.fromRecord({
+            "1_test": Effect.void
+          })
+        }).pipe(Effect.provideService(SqlClient.SqlClient, migratorClient))
+      )
+
+      assert.strictEqual(error._tag, "SqlError")
+      assert(SqlError.isSqlError(error))
+      assert.strictEqual(error.reason._tag, "ConstraintError")
+    }))
 })


### PR DESCRIPTION
## Summary
- tighten migrator lock detection to only convert duplicate migration-row insert constraint failures into `MigrationError(kind: "Locked")`
- keep other constraint failures (including sqlite CHECK violations) as real SQL errors instead of silently returning `[]`
- add sqlite-node regression coverage for a migrations table with an extra CHECK constraint on `name`
- add a changeset for the `effect` package

## Validation
- pnpm lint-fix
- pnpm test packages/sql/sqlite-node/test/SqliteMigrator.test.ts
- pnpm check:tsgo
- pnpm docgen