### PR TITLE
EFF-748 Create dedicated PG connection for LISTEN

### DIFF
--- a/.changeset/odd-socks-boil.md
+++ b/.changeset/odd-socks-boil.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Use a dedicated PostgreSQL client for LISTEN / UNLISTEN subscriptions instead of checking out a pooled connection for the listener lifecycle.

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -455,8 +455,31 @@ export const fromPool = Effect.fnUntraced(function*(
   })
   const reserve = Effect.map(reserveRaw, (client) => new ConnectionImpl(client))
 
+  const onListenClientError = (_: Error) => {
+  }
+
   const listenClient = yield* RcRef.make({
-    acquire: reserveRaw
+    acquire: Effect.acquireRelease(
+      Effect.tryPromise({
+        try: async () => {
+          const client = new Pg.Client(pool.options)
+          await client.connect()
+          client.on("error", onListenClientError)
+          return client
+        },
+        catch: (cause) =>
+          new SqlError({
+            reason: classifyError(cause, "Failed to acquire connection for listen", "acquireConnection")
+          })
+      }),
+      (client) =>
+        Effect.promise(() => {
+          client.off("error", onListenClientError)
+          return client.end()
+        }).pipe(
+          Effect.timeoutOption(1000)
+        )
+    )
   })
 
   let config: PgClientConfig = {

--- a/packages/sql/pg/test/Client.test.ts
+++ b/packages/sql/pg/test/Client.test.ts
@@ -1,6 +1,6 @@
 import { PgClient } from "@effect/sql-pg"
 import { assert, expect, it } from "@effect/vitest"
-import { Effect, Redacted, Stream, String } from "effect"
+import { Effect, Fiber, Redacted, Stream, String } from "effect"
 import { TestClock } from "effect/testing"
 import { SqlClient } from "effect/unstable/sql"
 import * as Statement from "effect/unstable/sql/Statement"
@@ -314,4 +314,37 @@ it.layer(PgContainer.layerClientWithTransforms, { timeout: "30 seconds" })("PgCl
       expect(Redacted.value(sql.config.password)).toEqual(parsedConfig.password)
       expect(sql.config.database).toEqual(parsedConfig.database)
     }))
+})
+
+it.layer(PgContainer.layerClientSingleConnection, { timeout: "30 seconds" })("PgClient listen", (it) => {
+  it.effect("listen does not reserve a pool connection", () =>
+    Effect.gen(function*() {
+      const sql = yield* PgClient.PgClient
+      const channel = "pool_connection_listen"
+
+      const listenFiber = yield* sql.listen(channel).pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped
+      )
+
+      yield* Effect.sleep("250 millis")
+
+      const rows = yield* sql<{ value: number }>`SELECT 1 as value`.pipe(
+        Effect.timeoutOrElse({
+          duration: "3 seconds",
+          onTimeout: () => Effect.fail(new Error("query timed out while listener was active"))
+        })
+      )
+      expect(rows).toEqual([{ value: 1 }])
+
+      yield* sql`SELECT pg_notify(${channel}, ${"payload"})`
+      const payloads = yield* Fiber.join(listenFiber).pipe(
+        Effect.timeoutOrElse({
+          duration: "3 seconds",
+          onTimeout: () => Effect.fail(new Error("listener did not receive notification in time"))
+        })
+      )
+      expect(Array.from(payloads)).toEqual(["payload"])
+    }).pipe(TestClock.withLive), 20_000)
 })

--- a/packages/sql/pg/test/utils.ts
+++ b/packages/sql/pg/test/utils.ts
@@ -36,4 +36,14 @@ export class PgContainer extends ServiceMap.Service<PgContainer>()("test/PgConta
       })
     })
   ).pipe(Layer.provide(this.layer))
+
+  static layerClientSingleConnection = Layer.unwrap(
+    Effect.gen(function*() {
+      const container = yield* PgContainer
+      return PgClient.layer({
+        url: Redacted.make(container.getConnectionUri()),
+        maxConnections: 1
+      })
+    })
+  ).pipe(Layer.provide(this.layer))
 }


### PR DESCRIPTION
## Summary
- changed PgClient LISTEN acquisition to use a dedicated `pg.Client` built from pool options, instead of reserving a `PoolClient` via `pool.connect`
- kept listener resource lifecycle managed by `RcRef`, including detach/end cleanup on release
- added a regression test with `maxConnections: 1` proving normal queries still run while a LISTEN stream is active
- added a changeset for `@effect/sql-pg`

## Validation
- pnpm lint-fix
- pnpm test packages/sql/pg/test/Client.test.ts
- pnpm check:tsgo
- pnpm docgen
