### PR TITLE
EFF-751 HttpApiClient.urlBuilder should use schemas and client-shaped API

### DIFF
--- a/.changeset/sixty-socks-yell.md
+++ b/.changeset/sixty-socks-yell.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update `HttpApiClient.urlBuilder` to mirror client shape, and encode params/query via endpoint schemas before building URLs.

--- a/packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts
+++ b/packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts
@@ -59,7 +59,7 @@ describe("HttpApiClient", () => {
   })
 
   describe("urlBuilder", () => {
-    it("should use method/path keys with encoded params and query", () => {
+    it("should mirror client shape and use schema input types", () => {
       const Api = HttpApi.make("Api")
         .add(
           HttpApiGroup.make("users")
@@ -76,32 +76,32 @@ describe("HttpApiClient", () => {
             )
         )
 
-      const builder = HttpApiClient.urlBuilder<typeof Api>({
+      const builder = HttpApiClient.urlBuilder(Api, {
         baseUrl: "https://api.example.com"
       })
 
-      const getUserUrl = builder("users", "GET /users/:id", {
-        params: { id: "123" },
-        query: { page: "1" }
+      const getUserUrl = builder.users.getUser({
+        params: { id: 123 },
+        query: { page: 1 }
       })
 
       expect<typeof getUserUrl>().type.toBe<string>()
 
-      const healthUrl = builder("users", "GET /health")
+      const healthUrl = builder.users.health()
 
       expect<typeof healthUrl>().type.toBe<string>()
 
       // @ts-expect-error!
-      builder("users", "GET /users/:id", { params: { id: 123 }, query: { page: "1" } })
+      builder.users.getUser({ params: { id: "123" }, query: { page: 1 } })
 
       // @ts-expect-error!
-      builder("users", "GET /users/:id", { params: { id: "123" }, query: { page: 1 } })
+      builder.users.getUser({ params: { id: 123 }, query: { page: "1" } })
 
       // @ts-expect-error!
-      builder("users", "POST /users/:id", { params: { id: "123" }, query: { page: "1" } })
+      builder.users.missing()
     })
 
-    it("should reflect api-level prefix in endpoint keys", () => {
+    it("should support prefixes and top-level endpoints", () => {
       const Api = HttpApi.make("Api")
         .add(
           HttpApiGroup.make("users")
@@ -110,21 +110,35 @@ describe("HttpApiClient", () => {
                 params: {
                   id: Schema.FiniteFromString
                 }
-              })
+              }),
+              HttpApiEndpoint.get("health", "/health")
+            )
+        )
+        .add(
+          HttpApiGroup.make("top", { topLevel: true })
+            .add(
+              HttpApiEndpoint.get("topHealth", "/top-health")
             )
         )
         .prefix("/v1")
 
-      const builder = HttpApiClient.urlBuilder<typeof Api>()
+      const builder = HttpApiClient.urlBuilder(Api)
 
-      const prefixedUrl = builder("users", "GET /v1/users/:id", {
-        params: { id: "123" }
+      const prefixedUrl = builder.users.getUser({
+        params: { id: 123 }
       })
 
       expect<typeof prefixedUrl>().type.toBe<string>()
 
+      const topLevelUrl = builder.topHealth()
+
+      expect<typeof topLevelUrl>().type.toBe<string>()
+
       // @ts-expect-error!
-      builder("users", "GET /users/:id", { params: { id: "123" } })
+      builder.users.getUser({ params: { id: "123" } })
+
+      // @ts-expect-error!
+      builder.top.topHealth()
     })
   })
 

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -120,24 +120,11 @@ export declare namespace Client {
       never
 }
 
-type ApiGroups<Api extends HttpApi.Any> = Api extends HttpApi.HttpApi<infer _ApiId, infer Groups> ? Groups : never
-
-type EndpointId<Endpoint extends HttpApiEndpoint.Any> = Endpoint extends {
-  readonly method: infer Method extends HttpMethod.HttpMethod
-  readonly path: infer Path extends string
-} ? `${Method} ${Path}`
-  : never
-
-type EndpointWithId<Endpoints extends HttpApiEndpoint.Any, Id extends string> = Id extends
-  `${infer Method extends HttpMethod.HttpMethod} ${infer Path extends string}` ?
-  Extract<Endpoints, { readonly method: Method; readonly path: Path }> :
-  never
-
 type UrlBuilderRequest<Endpoint extends HttpApiEndpoint.Any> = (
-  & ([HttpApiEndpoint.Params<Endpoint>["Encoded"]] extends [never] ? {}
-    : { readonly params: HttpApiEndpoint.Params<Endpoint>["Encoded"] })
-  & ([HttpApiEndpoint.Query<Endpoint>["Encoded"]] extends [never] ? {}
-    : { readonly query: HttpApiEndpoint.Query<Endpoint>["Encoded"] })
+  & ([HttpApiEndpoint.Params<Endpoint>["Type"]] extends [never] ? {}
+    : { readonly params: HttpApiEndpoint.Params<Endpoint>["Type"] })
+  & ([HttpApiEndpoint.Query<Endpoint>["Type"]] extends [never] ? {}
+    : { readonly query: HttpApiEndpoint.Query<Endpoint>["Type"] })
 ) extends infer Request ? keyof Request extends never ? void | undefined : Request
   : never
 
@@ -149,14 +136,32 @@ type UrlBuilderArgs<Endpoint extends HttpApiEndpoint.Any> = [UrlBuilderRequest<E
  * @since 4.0.0
  * @category models
  */
-export type UrlBuilder<Api extends HttpApi.Any> = <
-  const GroupName extends HttpApiGroup.Name<ApiGroups<Api>>,
-  const Id extends EndpointId<HttpApiGroup.EndpointsWithName<ApiGroups<Api>, GroupName>>
->(
-  group: GroupName,
-  endpoint: Id,
-  ...args: UrlBuilderArgs<EndpointWithId<HttpApiGroup.EndpointsWithName<ApiGroups<Api>, GroupName>, Id>>
+export type UrlBuilder<Api extends HttpApi.Any> = Api extends HttpApi.HttpApi<infer _ApiId, infer Groups> ? Simplify<
+    & {
+      readonly [Group in Extract<Groups, { readonly topLevel: false }> as HttpApiGroup.Name<Group>]: UrlBuilderGroup<
+        HttpApiGroup.Endpoints<Group>
+      >
+    }
+    & {
+      readonly [Method in UrlBuilderTopLevelMethods<Groups> as Method[0]]: Method[1]
+    }
+  >
+  : never
+
+type UrlBuilderGroup<Endpoints extends HttpApiEndpoint.Any> = {
+  readonly [Endpoint in Endpoints as HttpApiEndpoint.Name<Endpoint>]: UrlBuilderMethod<Endpoint>
+}
+
+type UrlBuilderMethod<Endpoint extends HttpApiEndpoint.Any> = (
+  ...args: UrlBuilderArgs<Endpoint>
 ) => string
+
+type UrlBuilderTopLevelMethods<Groups extends HttpApiGroup.Any> = Extract<Groups, { readonly topLevel: true }> extends
+  HttpApiGroup.HttpApiGroup<infer _Id, infer _Endpoints, infer _TopLevel> ?
+  _Endpoints extends infer Endpoint extends HttpApiEndpoint.Any ?
+    [HttpApiEndpoint.Name<Endpoint>, UrlBuilderMethod<Endpoint>]
+  : never :
+  never
 
 const makeClient = <ApiId extends string, Groups extends HttpApiGroup.Any, E, R>(
   api: HttpApi.HttpApi<ApiId, Groups>,
@@ -477,7 +482,7 @@ export const endpoint = <
 }
 
 /**
- * Creates a type-safe URL builder keyed by `${method} ${path}`.
+ * Creates a type-safe URL builder that mirrors `HttpApiClient.make`.
  *
  * @example
  * ```ts
@@ -492,11 +497,11 @@ export const endpoint = <
  *   )
  * )
  *
- * const buildUrl = HttpApiClient.urlBuilder<typeof Api>({
+ * const buildUrl = HttpApiClient.urlBuilder(Api, {
  *   baseUrl: "https://api.example.com"
  * })
  *
- * buildUrl("users", "GET /users/:id", {
+ * buildUrl.users.getUser({
  *   params: { id: "123" }
  * })
  * //=> "https://api.example.com/users/123"
@@ -504,19 +509,45 @@ export const endpoint = <
  * @since 4.0.0
  * @category constructors
  */
-export const urlBuilder = <Api extends HttpApi.Any>(options?: {
+export const urlBuilder = <Api extends HttpApi.AnyWithProps>(api: Api, options?: {
   readonly baseUrl?: URL | string | undefined
 }): UrlBuilder<Api> => {
-  return ((_: string, endpoint: string, request?: {
-    readonly params?: Record<string, string | undefined> | undefined
-    readonly query?: UrlParams.Input | undefined
-  }) => {
-    const path = endpoint.slice(endpoint.indexOf(" ") + 1)
-    const withParams = request?.params === undefined ? path : compilePath(path)(request.params)
-    const query = request?.query === undefined ? "" : UrlParams.toString(UrlParams.fromInput(request.query))
-    const url = query === "" ? withParams : `${withParams}?${query}`
-    return options?.baseUrl === undefined ? url : new URL(url, options.baseUrl.toString()).toString()
-  }) as UrlBuilder<Api>
+  const builder: Record<string, any> = {}
+
+  HttpApi.reflect(api, {
+    onGroup({ group }) {
+      if (group.topLevel) return
+      builder[group.identifier] = {}
+    },
+    onEndpoint({ group, endpoint }) {
+      const makeUrl = compilePath(endpoint.path)
+      const encodeParams = endpoint.params === undefined
+        ? undefined
+        : Schema.encodeSync(endpoint.params as Schema.Encoder<unknown>)
+      const encodeQuery = endpoint.query === undefined
+        ? undefined
+        : Schema.encodeSync(endpoint.query as Schema.Encoder<unknown>)
+
+      const endpointBuilder = (request?: {
+        readonly params?: unknown
+        readonly query?: unknown
+      }) => {
+        const params = request?.params
+        const path = params === undefined
+          ? endpoint.path
+          : makeUrl((encodeParams === undefined ? params : encodeParams(params)) as Record<string, string | undefined>)
+        const queryInput = request?.query === undefined
+          ? undefined
+          : (encodeQuery === undefined ? request.query : encodeQuery(request.query)) as UrlParams.Input
+        const query = queryInput === undefined ? "" : UrlParams.toString(UrlParams.fromInput(queryInput))
+        const url = query === "" ? path : `${path}?${query}`
+        return options?.baseUrl === undefined ? url : new URL(url, options.baseUrl.toString()).toString()
+      }
+      ;(group.topLevel ? builder : builder[group.identifier])[endpoint.name] = endpointBuilder
+    }
+  })
+
+  return builder as UrlBuilder<Api>
 }
 
 // ----------------------------------------------------------------------------

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -11,40 +11,57 @@ describe("HttpApiClient", () => {
           .add(
             HttpApiEndpoint.get("getUser", "/users/:id", {
               params: {
-                id: Schema.String
+                id: Schema.FiniteFromString
               },
               query: {
-                page: Schema.String,
-                tags: Schema.Array(Schema.String)
+                page: Schema.FiniteFromString,
+                tags: Schema.Array(Schema.FiniteFromString)
               }
             }),
             HttpApiEndpoint.get("health", "/health")
           )
       )
 
-    it("builds urls from endpoint method/path", () => {
-      const builder = HttpApiClient.urlBuilder<typeof Api>({
+    it("builds urls using endpoint schemas", () => {
+      const builder = HttpApiClient.urlBuilder(Api, {
         baseUrl: "https://api.example.com"
       })
 
       strictEqual(
-        builder("users", "GET /users/:id", {
+        builder.users.getUser({
           params: {
-            id: "123"
+            id: 123
           },
           query: {
-            page: "1",
-            tags: ["a", "b"]
+            page: 1,
+            tags: [1, 2]
           }
         }),
-        "https://api.example.com/users/123?page=1&tags=a&tags=b"
+        "https://api.example.com/users/123?page=1&tags=1&tags=2"
       )
     })
 
     it("returns relative urls when baseUrl is omitted", () => {
-      const builder = HttpApiClient.urlBuilder<typeof Api>()
+      const builder = HttpApiClient.urlBuilder(Api)
 
-      strictEqual(builder("users", "GET /health"), "/health")
+      strictEqual(builder.users.health(), "/health")
+    })
+
+    it("supports top-level endpoints", () => {
+      const TopLevelApi = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("top", { topLevel: true })
+            .add(
+              HttpApiEndpoint.get("health", "/health")
+            )
+        )
+        .prefix("/v1")
+
+      const builder = HttpApiClient.urlBuilder(TopLevelApi, {
+        baseUrl: "https://api.example.com"
+      })
+
+      strictEqual(builder.health(), "https://api.example.com/v1/health")
     })
   })
 })


### PR DESCRIPTION
## Summary
- update `HttpApiClient.urlBuilder` to accept the API value and return a builder that mirrors `HttpApiClient.make` shape (`builder.group.endpoint(request)` plus top-level endpoints)
- switch urlBuilder request types from encoded values to schema `Type` values for params/query
- encode params and query using endpoint schemas via `Schema.encodeSync` before path interpolation / query serialization
- update runtime + dts tests for the new API shape and schema-driven encoding behavior
- add a changeset for `effect`

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/httpapi/HttpApiClient.test.ts`
- `pnpm test-types packages/effect/dtslint/unstable/httpapi/HttpApiClient.tst.ts`
- `pnpm check:tsgo`
- `pnpm docgen`