### PR TITLE
Update HTTPAPI docs for automatic HttpApiEndpoint codec coercion

### DIFF
--- a/.changeset/eff-752-httpapi-docs.md
+++ b/.changeset/eff-752-httpapi-docs.md
@@ -1,5 +1,0 @@
----
-"effect": patch
----
-
-Update HTTP API docs to reflect automatic schema codec coercion in HttpApiEndpoint defaults.


### PR DESCRIPTION
## Summary
- update `packages/effect/HTTPAPI.md` to document that `HttpApiEndpoint` now auto-coerces schemas via `Schema.toCodecStringTree` / `Schema.toCodecJson` by default
- replace path/query/body examples that explicitly used `Schema.FiniteFromString.check(Schema.isInt())` with natural domain schemas (for example `Schema.Int`)
- add a changeset for the docs update

## Validation
- pnpm lint-fix
- pnpm test packages/platform-node/test/HttpApi.test.ts
- pnpm check:tsgo
- pnpm docgen