### PR TITLE
fix(schema): preserve jump-to-definition and typedoc for fields in Schema.Struct

### DIFF
--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2288,10 +2288,10 @@ export declare namespace Struct {
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
   > =
-    & { readonly [K in Exclude<keyof F, M | O>]: F[K]["Type"] }
-    & { readonly [K in Exclude<O, M>]?: F[K]["Type"] }
-    & { [K in Exclude<M, O>]: F[K]["Type"] }
-    & { [K in M & O]?: F[K]["Type"] }
+    & { readonly [K in keyof Pick<F, Exclude<keyof F, M | O>>]: F[K]["Type"] }
+    & { readonly [K in keyof Pick<F, Exclude<O, M>>]?: F[K]["Type"] }
+    & { [K in keyof Pick<F, Exclude<M, O>>]: F[K]["Type"] }
+    & { [K in keyof Pick<F, M & O>]?: F[K]["Type"] }
 
   /**
    * @since 4.0.0


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Schema.Struct and Schema.Class do not preserve symbol references for fields. The language server can't jump to the definition of a property or see its typedoc:
```ts
class Foo extends Schema.Class<Foo>("Foo")({
  /** Some typedoc */
  someProp: S.String
}) {}

new Foo().someProp; // <- connection lost, no typedoc, not jump-to-def
Foo.fields.someProp; // <- connect preserved
```
