### PR TITLE
EFF-768 Use more compatible Prompt.select icons

### DIFF
--- a/.changeset/eff-768-compatible-prompt-select-icons.md
+++ b/.changeset/eff-768-compatible-prompt-select-icons.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update Prompt icon glyphs to use more cross-system compatible symbols, including ASCII pointer and ellipsis characters used by `Prompt.select` rendering.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -478,12 +478,12 @@ const defaultFigures = {
   radioOff: "◯",
   checkboxOn: "☒",
   checkboxOff: "☐",
-  tick: "✔",
+  tick: "√",
   cross: "✖",
-  ellipsis: "…",
-  pointerSmall: "›",
+  ellipsis: "...",
+  pointerSmall: ">",
   line: "─",
-  pointer: "❯"
+  pointer: ">"
 }
 
 const windowsFigures = {
@@ -498,7 +498,7 @@ const windowsFigures = {
   tick: "√",
   cross: "×",
   ellipsis: "...",
-  pointerSmall: "»",
+  pointerSmall: ">",
   line: "─",
   pointer: ">"
 }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -361,6 +361,32 @@ describe("Prompt.autoComplete", () => {
     }).pipe(Effect.provide(TestLayer)))
 })
 
+describe("Prompt.select", () => {
+  it.effect("uses ASCII-compatible pointer icons", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.select({
+        message: "Pick fruit",
+        choices: [
+          { title: "Apple", value: "apple" },
+          { title: "Banana", value: "banana" }
+        ]
+      })
+
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "banana")
+
+      const output = yield* TestConsole.logLines
+      const rendered = toFrames(output).join("\n")
+
+      assert.isTrue(rendered.includes(">"))
+      assert.isFalse(rendered.includes("›"))
+      assert.isFalse(rendered.includes("❯"))
+    }).pipe(Effect.provide(TestLayer)))
+})
+
 describe("Prompt.file", () => {
   const FilePromptLayer = Layer.mergeAll(
     ConsoleLayer,


### PR DESCRIPTION
## Summary
- update Prompt figure glyphs used by select rendering to more compatible symbols (>, ..., and √)
- align Windows pointerSmall with ASCII > for consistency
- add a Prompt.select test that verifies ASCII pointer rendering and guards against the previous glyphs
- add a changeset for the effect package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/cli/Prompt.test.ts
- pnpm check:tsgo
- pnpm docgen