### PR TITLE
EFF-772 Fix generateObject OpenAI schema root for identified objects

### DIFF
--- a/.changeset/twenty-gifts-cheer.md
+++ b/.changeset/twenty-gifts-cheer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix OpenAI structured output schema generation to inline top-level `$ref` definitions so the root schema is an object (required by OpenAI for `json_schema` response formats).

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -475,6 +475,56 @@ describe("OpenAiLanguageModel", () => {
         assert.strictEqual(requestBody.response_format.json_schema.strict, true)
       }))
 
+    it.effect("uses object schema at the top level for identified schemas", () =>
+      Effect.gen(function*() {
+        class ThreadSummary extends Schema.Class<ThreadSummary>("ThreadSummary")({
+          summary: Schema.String
+        }) {}
+
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "stop",
+                    message: {
+                      role: "assistant",
+                      content: JSON.stringify({ summary: "Thread summary" })
+                    }
+                  }]
+                })
+              ))
+            })
+          ))
+        )
+
+        const summary = yield* LanguageModel.generateObject({
+          prompt: "Summarize the thread",
+          schema: ThreadSummary
+        }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        assert.strictEqual(summary.value.summary, "Thread summary")
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const requestBody = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(requestBody.response_format.type, "json_schema")
+        assert.strictEqual(requestBody.response_format.json_schema.schema.type, "object")
+      }))
+
     it.effect("uses OpenAI codec transformer for optional structured fields", () =>
       Effect.gen(function*() {
         let capturedRequest: HttpClientRequest.HttpClientRequest | undefined

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -556,6 +556,28 @@ describe("OpenAiLanguageModel", () => {
             output: [makeTextOutput(JSON.stringify({ name: "John", age: 30 }))]
           }
         }))))
+
+      it.effect("uses object schema at the top level for identified schemas", () =>
+        Effect.gen(function*() {
+          class ThreadSummary extends Schema.Class<ThreadSummary>("ThreadSummary")({
+            summary: Schema.String
+          }) {}
+
+          yield* LanguageModel.generateObject({
+            prompt: "Summarize the thread",
+            schema: ThreadSummary
+          }).pipe(Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")))
+
+          const requests = yield* MockHttpClient.requests
+          const body = yield* getRequestBody(requests[0])
+
+          strictEqual(body.text?.format?.type, "json_schema")
+          strictEqual(body.text?.format?.schema.type, "object")
+        }).pipe(Effect.provide(makeTestLayer({
+          body: {
+            output: [makeTextOutput(JSON.stringify({ summary: "Thread summary" }))]
+          }
+        }))))
     })
 
     describe("response handling", () => {

--- a/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
+++ b/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
@@ -50,12 +50,53 @@ export function toCodecOpenAI<T, E, RD, RE>(
   const from = recurOpenAI(AST.toEncoded(to))
   const codec = from === to ? schema : Schema.make<typeof schema>(AST.decodeTo(from, to, Transformation.passthrough()))
   const document = Schema.toJsonSchemaDocument(codec)
-  const jsonSchema = rewriteOpenAI(document.schema)
-  if (Object.keys(document.definitions).length > 0) {
-    jsonSchema.$defs = Rec.map(document.definitions, rewriteOpenAI)
+  const definitions = Object.keys(document.definitions).length > 0
+    ? Rec.map(document.definitions, rewriteOpenAI)
+    : undefined
+  const jsonSchema = resolveRootRef({
+    schema: rewriteOpenAI(document.schema),
+    definitions
+  })
+  if (definitions !== undefined) {
+    jsonSchema.$defs = definitions
   }
   return { codec, jsonSchema }
 }
+
+function resolveRootRef({
+  schema,
+  definitions
+}: {
+  readonly schema: JsonSchema.JsonSchema
+  readonly definitions: Record<string, JsonSchema.JsonSchema> | undefined
+}): JsonSchema.JsonSchema {
+  if (definitions === undefined) {
+    return schema
+  }
+
+  let current = schema
+  const visited = new Set<string>()
+
+  while (Object.keys(current).length === 1 && typeof current.$ref === "string") {
+    const ref = decodeDefRef(current.$ref)
+    if (ref === undefined || visited.has(ref)) {
+      break
+    }
+    const definition = definitions[ref]
+    if (definition === undefined) {
+      break
+    }
+    visited.add(ref)
+    current = definition
+  }
+
+  return current === schema ? schema : { ...current }
+}
+
+const decodeDefRef = (ref: string): string | undefined =>
+  ref.startsWith("#/$defs/")
+    ? ref.slice("#/$defs/".length).replaceAll("~1", "/").replaceAll("~0", "~")
+    : undefined
 
 /**
  * Post-processes the JSON schema produced by `Schema.toJsonSchemaDocument`,

--- a/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
+++ b/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
@@ -149,6 +149,28 @@ describe("toCodecOpenAI", () => {
     })
   })
 
+  it("dereferences top-level refs for identified object schemas", () => {
+    class ThreadSummary extends Schema.Class<ThreadSummary>("ThreadSummary")({
+      summary: Schema.String
+    }) {}
+
+    const objectSchema = {
+      "type": "object",
+      "properties": {
+        "summary": { "type": "string" }
+      },
+      "required": ["summary"],
+      "additionalProperties": false
+    }
+
+    assertJsonSchema(ThreadSummary, {
+      ...objectSchema,
+      "$defs": {
+        "ThreadSummary": objectSchema
+      }
+    })
+  })
+
   it("Null", () => {
     assertJsonSchema(Schema.Null, {
       "type": "null"


### PR DESCRIPTION
## Summary
- fix `toCodecOpenAI` to resolve top-level `$ref` entries into their referenced schema definitions before sending to providers
- ensure generated OpenAI structured output schemas keep `$defs` while exposing an object schema at the root
- add regression coverage for identified/class schemas in:
  - `OpenAiStructuredOutput` unit tests
  - OpenAI language model request-format tests (responses API)
  - OpenAI-compat language model request-format tests (chat completions)

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts`
- `pnpm test packages/ai/openai/test/OpenAiLanguageModel.test.ts`
- `pnpm test packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts`
- `pnpm check:tsgo`
- `pnpm docgen`