### PR TITLE
fix(Number): handle scientific notation in `remainder`

### DIFF
--- a/.changeset/fix-remainder-scientific-notation.md
+++ b/.changeset/fix-remainder-scientific-notation.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+`Number.remainder`: fix incorrect results for small floats in scientific notation (e.g. `1e-7`).

--- a/packages/effect/src/Number.ts
+++ b/packages/effect/src/Number.ts
@@ -495,14 +495,24 @@ export const remainder: {
   (divisor: number): (self: number) => number
   (self: number, divisor: number): number
 } = dual(2, (self: number, divisor: number): number => {
-  // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
-  const selfDecCount = (self.toString().split(".")[1] || "").length
-  const divisorDecCount = (divisor.toString().split(".")[1] || "").length
+  const selfDecCount = decimalCount(self)
+  const divisorDecCount = decimalCount(divisor)
   const decCount = selfDecCount > divisorDecCount ? selfDecCount : divisorDecCount
   const selfInt = parseInt(self.toFixed(decCount).replace(".", ""))
   const divisorInt = parseInt(divisor.toFixed(decCount).replace(".", ""))
   return (selfInt % divisorInt) / Math.pow(10, decCount)
 })
+
+function decimalCount(n: number): number {
+  const s = n.toString()
+  const eIndex = s.indexOf("e-")
+  if (eIndex !== -1) {
+    const exp = parseInt(s.slice(eIndex + 2))
+    const mantissaDecimals = (s.slice(0, eIndex).split(".")[1] || "").length
+    return mantissaDecimals + exp
+  }
+  return (s.split(".")[1] || "").length
+}
 
 /**
  * Returns the next power of 2 from the given number.

--- a/packages/effect/test/Number.test.ts
+++ b/packages/effect/test/Number.test.ts
@@ -297,6 +297,20 @@ describe("remainder", () => {
   it("returns NaN when the divisor is zero", () => {
     assertNaN(N.remainder(5, 0))
   })
+
+  it("handles small floats / scientific notation", () => {
+    const divisor = 1e-7
+
+    // Valid multiples (integer * 1e-7)
+    assert.strictEqual(N.remainder(0, divisor), 0)
+    assert.strictEqual(N.remainder(1e-7, divisor), 0)
+    assert.strictEqual(N.remainder(2e-7, divisor), 0)
+    assert.strictEqual(N.remainder(3e-7, divisor), 0)
+
+    // Invalid — 2.5 and 1.5 are not integers
+    assert.notStrictEqual(N.remainder(2.5e-7, divisor), 0)
+    assert.notStrictEqual(N.remainder(1.5e-7, divisor), 0)
+  })
 })
 
 describe("nextPow2", () => {


### PR DESCRIPTION
The decimal-counting logic used `.toString().split(".")` which fails for small floats like `1e-7` whose string representation uses scientific notation instead of decimal notation.
