### PR TITLE
EFF-774 Fix MutableList.appendAll with empty arrays

### DIFF
--- a/.changeset/eff-774-mutable-list-append-all-empty-array.md
+++ b/.changeset/eff-774-mutable-list-append-all-empty-array.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `MutableList.appendAll` / `appendAllUnsafe` so empty arrays are treated as a no-op instead of leaving behind an empty internal bucket.

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -507,6 +507,9 @@ export const appendAll = <A>(self: MutableList<A>, messages: Iterable<A>): numbe
  * @category mutations
  */
 export const appendAllUnsafe = <A>(self: MutableList<A>, messages: ReadonlyArray<A>, mutable = false): number => {
+  if (messages.length === 0) {
+    return 0
+  }
   const chunk: MutableList.Bucket<A> = {
     array: messages as Array<A>,
     mutable,

--- a/packages/effect/test/MutableList.test.ts
+++ b/packages/effect/test/MutableList.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "@effect/vitest"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { MutableList } from "effect"
+
+describe("MutableList", () => {
+  it("appendAll with an empty array keeps an empty list empty", () => {
+    const list = MutableList.make<number>()
+
+    strictEqual(MutableList.appendAll(list, []), 0)
+    strictEqual(list.length, 0)
+    strictEqual(list.head, undefined)
+    strictEqual(list.tail, undefined)
+    strictEqual(MutableList.take(list), MutableList.Empty)
+  })
+
+  it("appendAll with an empty array does not break subsequent appends", () => {
+    const list = MutableList.make<number>()
+
+    MutableList.appendAll(list, [])
+    MutableList.append(list, 1)
+    MutableList.appendAll(list, [])
+    MutableList.append(list, 2)
+
+    deepStrictEqual(MutableList.takeAll(list), [1, 2])
+    strictEqual(MutableList.take(list), MutableList.Empty)
+  })
+
+  it("appendAllUnsafe with an empty array is a no-op", () => {
+    const list = MutableList.make<number>()
+
+    MutableList.appendAll(list, [1])
+    strictEqual(MutableList.appendAllUnsafe(list, []), 0)
+    MutableList.append(list, 2)
+
+    deepStrictEqual(MutableList.takeAll(list), [1, 2])
+    strictEqual(MutableList.take(list), MutableList.Empty)
+  })
+})


### PR DESCRIPTION
## Summary
- make MutableList.appendAllUnsafe return early for empty arrays so no empty bucket is linked into the list
- add MutableList regression tests covering appendAll([]), appendAllUnsafe([]), and subsequent append/take behavior
- add a changeset for the effect package

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/MutableList.test.ts
- pnpm check:tsgo
- pnpm docgen