### PR TITLE
chore: update TSTyche to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rulesync": "^6.2.0",
     "terser": "^5.46.0",
     "ts-patch": "^3.3.0",
-    "tstyche": "^6.2.0",
+    "tstyche": "7.0.0-rc.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vite-tsconfig-paths": "^6.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tstyche:
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: 7.0.0-rc.0
+        version: 7.0.0-rc.0(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -6156,8 +6156,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tstyche@6.2.0:
-    resolution: {integrity: sha512-WBiB6fGGsmQCFFRGwYaKq528pCLJ0CUUdrIdUm2rnVJ1Ineskbrv9uQADWsD3uHndEV/Hesdx1Gj8PdkBahxlQ==}
+  tstyche@7.0.0-rc.0:
+    resolution: {integrity: sha512-lUF6/kiw/E3Z9OMA6qcyxqguTQPMZGybNw5dDA1l5aKfI4uYP/ZajKHPHnfJ1ix2GxfkyV0JJWvMol/w2gcKgA==}
     engines: {node: '>=22.12'}
     hasBin: true
     peerDependencies:
@@ -12488,7 +12488,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@6.2.0(typescript@5.9.3):
+  tstyche@7.0.0-rc.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://tstyche.org/schemas/config.json",
-  "testFileMatch": [
-    "packages/*/dtslint/**/*.tst.*"
-  ],
-  "tsconfig": "ignore"
-}

--- a/tstyche.json
+++ b/tstyche.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/tstyche/schemas/config.json",
+  "testFileMatch": [
+    "packages/*/dtslint/**/*.tst.*"
+  ],
+  "tsconfig": "baseline"
+}


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR updates TSTyche to v7. Release notes: https://tstyche.org/releases/tstyche-7

Mostly configuration refinements and clean up.

To draw your attention, a new matcher `.toBeInstantiableWith()` to test generics got added. Covers some corner cases. At this moment not useful is `effect`, but who knows (;