### PR TITLE
EFF-776 Fix class schema refs in ai generateObject JSON schema

### DIFF
--- a/.changeset/flat-chicken-remain.md
+++ b/.changeset/flat-chicken-remain.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix AI structured output schema generation for `Schema.Class` and `Schema.ErrorClass` by resolving top-level `$ref` entries before passing JSON Schema to providers and default codec transformers.

--- a/packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts
+++ b/packages/effect/src/unstable/ai/AnthropicStructuredOutput.ts
@@ -16,7 +16,7 @@
  * @since 1.0.0
  */
 import * as Arr from "../../Array.ts"
-import type * as JsonSchema from "../../JsonSchema.ts"
+import * as JsonSchema from "../../JsonSchema.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Schema from "../../Schema.ts"
@@ -58,8 +58,8 @@ export function toCodecAnthropic<T, E, RD, RE>(
   const to = schema.ast
   const from = recur(AST.toEncoded(to))
   const codec = from === to ? schema : Schema.make<typeof schema>(AST.decodeTo(from, to, Transformation.passthrough()))
-  const document = Schema.toJsonSchemaDocument(codec)
-  const jsonSchema = document.schema
+  const document = JsonSchema.resolveTopLevel$ref(Schema.toJsonSchemaDocument(codec))
+  const jsonSchema = { ...document.schema }
   if (Object.keys(document.definitions).length > 0) {
     jsonSchema.$defs = document.definitions
   }

--- a/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
+++ b/packages/effect/src/unstable/ai/OpenAiStructuredOutput.ts
@@ -4,7 +4,7 @@
  * @since 1.0.0
  */
 import * as Arr from "../../Array.ts"
-import type * as JsonSchema from "../../JsonSchema.ts"
+import * as JsonSchema from "../../JsonSchema.ts"
 import * as Option from "../../Option.ts"
 import * as Predicate from "../../Predicate.ts"
 import * as Rec from "../../Record.ts"
@@ -49,7 +49,7 @@ export function toCodecOpenAI<T, E, RD, RE>(
   const to = schema.ast
   const from = recurOpenAI(AST.toEncoded(to))
   const codec = from === to ? schema : Schema.make<typeof schema>(AST.decodeTo(from, to, Transformation.passthrough()))
-  const document = Schema.toJsonSchemaDocument(codec)
+  const document = JsonSchema.resolveTopLevel$ref(Schema.toJsonSchemaDocument(codec))
   const jsonSchema = rewriteOpenAI(document.schema)
   if (Object.keys(document.definitions).length > 0) {
     jsonSchema.$defs = Rec.map(document.definitions, rewriteOpenAI)

--- a/packages/effect/src/unstable/ai/internal/codec-transformer.ts
+++ b/packages/effect/src/unstable/ai/internal/codec-transformer.ts
@@ -1,10 +1,11 @@
+import * as JsonSchema from "../../../JsonSchema.ts"
 import * as Schema from "../../../Schema.ts"
 import type { CodecTransformer } from "../LanguageModel.ts"
 
 /** @internal */
 export const defaultCodecTransformer: CodecTransformer = (codec) => {
-  const document = Schema.toJsonSchemaDocument(codec)
-  const jsonSchema = document.schema
+  const document = JsonSchema.resolveTopLevel$ref(Schema.toJsonSchemaDocument(codec))
+  const jsonSchema = { ...document.schema }
   if (Object.keys(document.definitions).length > 0) {
     jsonSchema.$defs = document.definitions
   }

--- a/packages/effect/test/unstable/ai/AnthropicStructuredOutput.test.ts
+++ b/packages/effect/test/unstable/ai/AnthropicStructuredOutput.test.ts
@@ -464,6 +464,31 @@ describe("toCodecAnthropic", () => {
     })
   })
 
+  it("Class", () => {
+    class Person extends Schema.Class<Person>("Person")({
+      name: Schema.String
+    }) {}
+
+    assertJsonSchema(Person, {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"],
+      "additionalProperties": false,
+      "$defs": {
+        "Person": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      }
+    })
+  })
+
   describe("Record", () => {
     it("EmptyParams", async () => {
       assertJsonSchema(Tool.EmptyParams, {

--- a/packages/effect/test/unstable/ai/LanguageModel.test.ts
+++ b/packages/effect/test/unstable/ai/LanguageModel.test.ts
@@ -178,6 +178,37 @@ describe("LanguageModel", () => {
           strictEqual(error.reason.responseText, "{\"count\":\"oops\"}")
         }
       }))
+
+    it("resolves top-level $ref for class schemas in defaultCodecTransformer", () => {
+      class Person extends Schema.Class<Person>("Person")({
+        name: Schema.String
+      }) {}
+
+      const transformed = LanguageModel.defaultCodecTransformer(Person)
+
+      deepStrictEqual(transformed.jsonSchema, {
+        type: "object",
+        properties: {
+          name: {
+            type: "string"
+          }
+        },
+        required: ["name"],
+        additionalProperties: false,
+        $defs: {
+          Person: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string"
+              }
+            },
+            required: ["name"],
+            additionalProperties: false
+          }
+        }
+      })
+    })
   })
 
   describe("provider options", () => {

--- a/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
+++ b/packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
@@ -592,6 +592,31 @@ describe("toCodecOpenAI", () => {
     })
   })
 
+  it("Class", () => {
+    class Person extends Schema.Class<Person>("Person")({
+      name: Schema.String
+    }) {}
+
+    assertJsonSchema(Person, {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"],
+      "additionalProperties": false,
+      "$defs": {
+        "Person": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      }
+    })
+  })
+
   describe("Record", () => {
     it("EmptyParams", async () => {
       assertJsonSchema(Tool.EmptyParams, {


### PR DESCRIPTION
## Summary
- resolve top-level `$ref` entries when transforming Effect schemas to JSON Schema for AI structured outputs
- apply the fix in the default AI codec transformer and OpenAI/Anthropic structured output transformers
- add regression tests for `Schema.Class` output in LanguageModel/OpenAI/Anthropic transformer test suites
- add a changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/ai/LanguageModel.test.ts
- pnpm test packages/effect/test/unstable/ai/OpenAiStructuredOutput.test.ts
- pnpm test packages/effect/test/unstable/ai/AnthropicStructuredOutput.test.ts
- pnpm check:tsgo
- pnpm docgen