### PR TITLE
fix(cluster): Entity.toLayerQueue crash with streaming RPCs

### DIFF
--- a/.changeset/fix-entity-tolayerqueue-streaming.md
+++ b/.changeset/fix-entity-tolayerqueue-streaming.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `Entity.toLayerQueue` crash with streaming RPCs when using `replier.succeed` with a `Stream` value.
+
+`RpcServer.streamEffect` now handles both `Stream` and `Queue.Dequeue` values when the handler is an `Effect` (as produced by `toLayerQueue`).

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -351,11 +351,24 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
     }
     if (Effect.isEffect(stream)) {
       return stream.pipe(
-        Effect.flatMap((queue) =>
-          Effect.whileLoop({
+        Effect.flatMap((queueOrStream) => {
+          if (Stream.isStream(queueOrStream)) {
+            return Stream.runForEachArray(queueOrStream as any as Stream.Stream<any, any>, (values) => {
+              const write = options.onFromServer({
+                _tag: "Chunk",
+                clientId: client.id,
+                requestId: request.id,
+                values
+              })
+              if (!latch) return write
+              latch.closeUnsafe()
+              return Effect.andThen(write, latch.await)
+            })
+          }
+          return Effect.whileLoop({
             while: constTrue,
             body: constant(
-              Effect.flatMap(Queue.takeAll(queue), (values) => {
+              Effect.flatMap(Queue.takeAll(queueOrStream), (values) => {
                 const write = options.onFromServer({
                   _tag: "Chunk",
                   clientId: client.id,
@@ -369,7 +382,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
             ),
             step: constVoid
           })
-        ),
+        }),
         Pull.catchDone(() => Effect.void),
         Effect.scoped
       )

--- a/packages/effect/test/cluster/Entity.test.ts
+++ b/packages/effect/test/cluster/Entity.test.ts
@@ -1,7 +1,16 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import type { Cause } from "effect"
+import { Effect, Queue, Schema, Stream } from "effect"
 import { Entity, ShardingConfig } from "effect/unstable/cluster"
+import { Rpc } from "effect/unstable/rpc"
 import { TestEntity, TestEntityLayer, User } from "./TestEntity.ts"
+
+const StreamEntity = Entity.make("StreamEntity", [
+  Rpc.make("Watch", {
+    success: Schema.Number,
+    stream: true
+  })
+])
 
 describe.concurrent("Entity", () => {
   describe("makeTestClient", () => {
@@ -11,6 +20,55 @@ describe.concurrent("Entity", () => {
         const client = yield* makeClient("123")
         const user = yield* client.GetUser({ id: 1 })
         assert.deepEqual(user, new User({ id: 1, name: "User 1" }))
+      }).pipe(Effect.provide(TestShardingConfig)))
+  })
+
+  describe("toLayerQueue", () => {
+    it.effect("streaming RPC with Stream via replier.succeed", () =>
+      Effect.gen(function*() {
+        const layer = StreamEntity.toLayerQueue((mailbox, replier) =>
+          Effect.gen(function*() {
+            while (true) {
+              const req = yield* Queue.take(mailbox)
+              yield* replier.succeed(req, Stream.make(1, 2, 3))
+            }
+          }) as Effect.Effect<never>
+        )
+
+        const makeClient = yield* Entity.makeTestClient(StreamEntity, layer)
+        const client = yield* makeClient("entity-1")
+        const results: Array<number> = []
+        yield* client.Watch().pipe(
+          Stream.take(3),
+          Stream.runForEach((n) => Effect.sync(() => results.push(n)))
+        )
+        assert.deepEqual(results, [1, 2, 3])
+      }).pipe(Effect.provide(TestShardingConfig)))
+
+    it.effect("streaming RPC with Dequeue via replier.succeed", () =>
+      Effect.gen(function*() {
+        const layer = StreamEntity.toLayerQueue((mailbox, replier) =>
+          Effect.gen(function*() {
+            while (true) {
+              const req = yield* Queue.take(mailbox)
+              const q = yield* Queue.make<number, Cause.Done>()
+              yield* replier.succeed(req, q)
+              yield* Queue.offer(q, 1)
+              yield* Queue.offer(q, 2)
+              yield* Queue.offer(q, 3)
+              yield* Queue.end(q)
+            }
+          }) as Effect.Effect<never>
+        )
+
+        const makeClient = yield* Entity.makeTestClient(StreamEntity, layer)
+        const client = yield* makeClient("entity-1")
+        const results: Array<number> = []
+        yield* client.Watch().pipe(
+          Stream.take(3),
+          Stream.runForEach((n) => Effect.sync(() => results.push(n)))
+        )
+        assert.deepEqual(results, [1, 2, 3])
       }).pipe(Effect.provide(TestShardingConfig)))
   })
 })


### PR DESCRIPTION
## Summary

- `Entity.toLayerQueue` wraps all handlers in `Effect.callback`, including streaming RPCs
- `RpcServer.streamEffect` assumes the Effect resolves to a `Queue.Dequeue`, but `replier.succeed(req, stream)` resolves to a `Stream`
- `Queue.takeAll` on a non-Queue object crashes: `TypeError: self.state._tag`
- Fix: check `Stream.isStream` in `streamEffect`'s Effect branch, use `Stream.runForEachArray` for Streams

## Test plan

- `toLayerQueue` streaming RPC with Stream via `replier.succeed`
- `toLayerQueue` streaming RPC with Dequeue via `replier.succeed`