### PR TITLE
feat(Queue): add non-blocking drain API

### DIFF
--- a/.changeset/add-queue-drain.md
+++ b/.changeset/add-queue-drain.md
@@ -1,0 +1,10 @@
+---
+"effect": minor
+---
+
+Add `Queue.drain` for non-blocking take of all available messages.
+
+Unlike `Queue.takeAll` which blocks until at least one item is available,
+`Queue.drain` returns whatever is currently in the queue, including an
+empty array if no messages are present. Returns `[]` on graceful
+completion (`Done`) and propagates non-Done errors.

--- a/packages/effect/src/Queue.ts
+++ b/packages/effect/src/Queue.ts
@@ -1029,6 +1029,45 @@ export const takeAll = <A, E>(self: Dequeue<A, E>): Effect<Arr.NonEmptyArray<A>,
   takeBetween(self, 1, Number.POSITIVE_INFINITY) as any
 
 /**
+ * Take all available messages from the queue without blocking.
+ *
+ * Returns whatever is currently in the queue, including an empty array if the
+ * queue has no messages. Unlike `takeAll`, this will not wait for items to
+ * become available.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Queue } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const queue = yield* Queue.unbounded<number>()
+ *   yield* Queue.offerAll(queue, [1, 2, 3])
+ *
+ *   const items = yield* Queue.drain(queue)
+ *   console.log(items) // [1, 2, 3]
+ *
+ *   const empty = yield* Queue.drain(queue)
+ *   console.log(empty) // []
+ * })
+ * ```
+ *
+ * @category Taking
+ * @since 4.0.0
+ */
+export const drain = <A, E>(self: Dequeue<A, E>): Effect<Array<A>, Pull.ExcludeDone<E>> =>
+  internalEffect.suspend(() => {
+    if (self.state._tag === "Done") {
+      if (Pull.isDoneCause(self.state.exit.cause)) {
+        return internalEffect.succeed([])
+      }
+      return self.state.exit
+    }
+    const messages = takeAllUnsafe(self)
+    releaseCapacity(self)
+    return internalEffect.succeed(messages)
+  }) as any
+
+/**
  * Take all messages from the queue, until the queue has errored or is done.
  *
  * @example

--- a/packages/effect/test/Queue.test.ts
+++ b/packages/effect/test/Queue.test.ts
@@ -47,6 +47,45 @@ describe("Queue", () => {
       assert.isTrue(Queue.isDequeue(dequeue))
     }))
 
+  it.effect("drain returns available items without blocking on empty", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.unbounded<string>()
+      yield* Queue.offerAll(queue, ["a", "b"])
+      const items = yield* Queue.drain(queue)
+      assert.deepStrictEqual(items, ["a", "b"])
+
+      const empty = yield* Queue.drain(queue)
+      assert.deepStrictEqual(empty, [])
+    }))
+
+  it.effect("drain returns [] after end", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number, Cause.Done>(5)
+      yield* Queue.offerAll(queue, [1, 2])
+      yield* Queue.end(queue)
+      const items = yield* Queue.drain(queue)
+      assert.deepStrictEqual(items, [1, 2])
+      const empty = yield* Queue.drain(queue)
+      assert.deepStrictEqual(empty, [])
+    }))
+
+  it.effect("drain fails on non-Done error", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number, string>(5)
+      yield* Queue.fail(queue, "boom")
+      const error = yield* Queue.drain(queue).pipe(Effect.flip)
+      assert.deepStrictEqual(error, "boom")
+    }))
+
+  it.effect("drain on zero-capacity queue with pending offer", () =>
+    Effect.gen(function*() {
+      const queue = yield* Queue.bounded<number>(0)
+      yield* Queue.offer(queue, 1).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      const items = yield* Queue.drain(queue)
+      assert.deepStrictEqual(items, [1])
+    }))
+
   it.effect("offerAll with capacity", () =>
     Effect.gen(function*() {
       const queue = yield* Queue.bounded<number>(2)


### PR DESCRIPTION
Adds `Queue.drain` — takes all available messages without blocking, returning `[]` on empty. Thought this could be useful for cleanup/shutdown paths where you want to grab whatever's there without waiting.

`takeAll` blocks until ≥1 item which seems intentional (returns `NonEmptyArray`, `collect` depends on it), so this is a separate non-blocking alternative following the same Done/error semantics as `clear` and `poll`.

Purely additive, totally optional — sorry if inconvenient. Made with the help of AI.

---

Should `TxQueue` and `PubSub` get a matching `drain` for parity?