### PR TITLE
fix(platform-bun): settle response Promise on client abort

### DIFF
--- a/.changeset/fix-bun-http-abort-promise.md
+++ b/.changeset/fix-bun-http-abort-promise.md
@@ -1,0 +1,10 @@
+---
+"@effect/platform-bun": patch
+---
+
+Settle the response Promise on client abort in BunHttpServer.
+
+When a client aborted an HTTP request, the abort handler interrupted the
+fiber but never resolved the `Promise<Response>`, causing Bun to hold
+the request context alive. Server-side scope finalizers wouldn't fire,
+leaking streaming RPC fibers.

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -131,6 +131,7 @@ export const make = Effect.fnUntraced(
             const fiber = Fiber.runIn(Effect.runForkWith(ServiceMap.makeUnsafe<any>(map))(httpEffect), scope)
             request.signal.addEventListener("abort", () => {
               fiber.interruptUnsafe(parent.id, Error.ClientAbort.annotation)
+              resolve(new Response(null, { status: 499 }))
             }, { once: true })
           })
         }


### PR DESCRIPTION
Settles the `Promise<Response>` when a client aborts an HTTP request to a Bun server. Without this, Bun holds the request context alive and server-side scope finalizers never fire — streaming RPC fibers leak.

Same class of bug as [Firebun](https://trigger.dev/blog/firebun): Bun's `request.signal` abort fires, but if the handler's Promise never resolves, Bun pins the connection. One-line fix — resolve with 499 on abort.

Made with the help of AI.