### PR TITLE
Add Stream service accessors

### DIFF
--- a/.changeset/neat-goats-wave.md
+++ b/.changeset/neat-goats-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Stream.service` and `Stream.serviceOption` for accessing services as single-element streams.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -355,6 +355,79 @@ export const fromEffect = <A, E, R>(effect: Effect.Effect<A, E, R>): Stream<A, E
   fromChannel(Channel.fromEffect(Effect.map(effect, Arr.of)))
 
 /**
+ * Accesses a service from the context and emits it as a single element.
+ *
+ * @example
+ * ```ts
+ * import { Effect, ServiceMap, Stream } from "effect"
+ *
+ * class Greeter extends ServiceMap.Service<Greeter, {
+ *   readonly greet: (name: string) => string
+ * }>()("Greeter") {}
+ *
+ * const stream = Stream.service(Greeter).pipe(
+ *   Stream.map((greeter) => greeter.greet("World"))
+ * )
+ *
+ * const program = Effect.gen(function*() {
+ *   return yield* stream.pipe(
+ *     Stream.provideService(Greeter, {
+ *       greet: (name) => `Hello, ${name}!`
+ *     }),
+ *     Stream.runCollect
+ *   )
+ * })
+ *
+ * Effect.runPromise(program)
+ * // Output: [ "Hello, World!" ]
+ * ```
+ *
+ * @since 4.0.0
+ * @category ServiceMap
+ */
+export const service = <I, S>(service: ServiceMap.Key<I, S>): Stream<S, never, I> => fromEffect(Effect.service(service))
+
+/**
+ * Optionally accesses a service from the context and emits the result as a
+ * single element.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Option, ServiceMap, Stream } from "effect"
+ *
+ * class Greeter extends ServiceMap.Service<Greeter, {
+ *   readonly greet: (name: string) => string
+ * }>()("Greeter") {}
+ *
+ * const stream = Stream.serviceOption(Greeter).pipe(
+ *   Stream.map((maybeGreeter) =>
+ *     Option.match(maybeGreeter, {
+ *       onNone: () => "No greeter",
+ *       onSome: (greeter) => greeter.greet("World")
+ *     })
+ *   )
+ * )
+ *
+ * const program = Effect.gen(function*() {
+ *   return yield* stream.pipe(
+ *     Stream.provideService(Greeter, {
+ *       greet: (name) => `Hello, ${name}!`
+ *     }),
+ *     Stream.runCollect
+ *   )
+ * })
+ *
+ * Effect.runPromise(program)
+ * // Output: [ "Hello, World!" ]
+ * ```
+ *
+ * @since 4.0.0
+ * @category ServiceMap
+ */
+export const serviceOption = <I, S>(service: ServiceMap.Key<I, S>): Stream<Option.Option<S>> =>
+  fromEffect(Effect.serviceOption(service))
+
+/**
  * Creates a stream that runs the effect and emits no elements.
  *
  * @example

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -20,6 +20,7 @@ import {
   References,
   Result,
   Schedule,
+  ServiceMap,
   Sink,
   Stream
 } from "effect"
@@ -131,10 +132,44 @@ describe("Stream", () => {
   })
 
   describe("constructors", () => {
+    class Greeter extends ServiceMap.Service<Greeter, {
+      readonly greet: (name: string) => string
+    }>()("Greeter") {}
+
     it.effect("range - min less than max", () =>
       Effect.gen(function*() {
         const result = yield* Stream.range(1, 3).pipe(Stream.runCollect)
         assert.deepStrictEqual(result, [1, 2, 3])
+      }))
+
+    it.effect("service", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.service(Greeter).pipe(
+          Stream.map((greeter) => greeter.greet("World")),
+          Stream.provideService(Greeter, {
+            greet: (name) => `Hello, ${name}!`
+          }),
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(result, ["Hello, World!"])
+      }))
+
+    it.effect("serviceOption - some", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.serviceOption(Greeter).pipe(
+          Stream.map((option) => Option.map(option, (greeter) => greeter.greet("World"))),
+          Stream.provideService(Greeter, {
+            greet: (name) => `Hello, ${name}!`
+          }),
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(result, [Option.some("Hello, World!")])
+      }))
+
+    it.effect("serviceOption - none", () =>
+      Effect.gen(function*() {
+        const result = yield* Stream.serviceOption(Greeter).pipe(Stream.runCollect)
+        assert.deepStrictEqual(result, [Option.none()])
       }))
 
     it.effect("range - min greater than max", () =>


### PR DESCRIPTION
## Summary
- add `Stream.service` to mirror `Effect.service` for single-element service streams
- add `Stream.serviceOption` to mirror optional service lookup without requiring the service
- cover both APIs with `Stream` tests and include a patch changeset