### PR TITLE
feat(vitest): add layer lifecycle hooks

### DIFF
--- a/.changeset/five-taxis-sit.md
+++ b/.changeset/five-taxis-sit.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Add effectful layer-scoped lifecycle hooks to `layer` and `it.layer`.

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -36,6 +36,34 @@ This import enhances the standard `it` function from `vitest` with several power
 | `it.scopedLive` | Combines the features of `scoped` and `live`, using a live Effect environment that requires a `Scope`. |
 | `it.flakyTest`  | Facilitates the execution of tests that might occasionally fail.                                       |
 
+# Layer-Scoped Hooks
+
+The `layer` and `it.layer` helpers return an `it` value with effectful lifecycle hooks. These hooks run with the same provided layer context as `it.effect`.
+
+```ts
+import { expect, layer } from "@effect/vitest"
+import { Effect, Layer, ServiceMap } from "effect"
+
+class Database extends ServiceMap.Service<Database, {
+  readonly reset: Effect.Effect<void>
+}>()("Database") {}
+
+layer(DatabaseLive)("database", (it) => {
+  it.beforeEach(() =>
+    Effect.gen(function*() {
+      const database = yield* Database
+      return yield* database.reset
+    })
+  )
+
+  it.effect("uses layer services in hooks", () =>
+    Effect.gen(function*() {
+      const database = yield* Database
+      expect(database).toBeDefined()
+    }))
+})
+```
+
 # Writing Tests with `it.effect`
 
 Here's how to use `it.effect` to write your tests:

--- a/packages/vitest/dtslint/index.tst.ts
+++ b/packages/vitest/dtslint/index.tst.ts
@@ -1,5 +1,5 @@
-import { it, layer } from "@effect/vitest"
-import { Layer, ServiceMap } from "effect"
+import { it, layer, type TestContext } from "@effect/vitest"
+import { Effect, Layer, Scope, ServiceMap } from "effect"
 import { describe, expect, it as test } from "tstyche"
 
 class Foo extends ServiceMap.Service<Foo, "foo">()("Foo") {}
@@ -51,6 +51,26 @@ describe("layer", () => {
       expect(it.layer).type.not.toBeCallableWith(Layer.succeed(Bar, "bar"), {
         memoMap: undefined as any
       })
+    })
+  })
+
+  test("layer helper exposes effectful hooks", () => {
+    layer(Layer.succeed(Foo, "foo"))((it) => {
+      expect(it.beforeEach).type.toBeCallableWith(
+        (_ctx: TestContext) => Effect.succeed("ok"),
+        "1 second"
+      )
+      expect(it.afterEach).type.toBeCallableWith(
+        (_ctx: TestContext) => Effect.void,
+        1_000
+      )
+      expect(it.beforeAll).type.toBeCallableWith(
+        Scope.make(),
+        "1 second"
+      )
+      expect(it.afterAll).type.toBeCallableWith(
+        Effect.succeed(1)
+      )
     })
   })
 })

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -106,10 +106,10 @@ export namespace Vitest {
     readonly layer: <R2, E>(layer: Layer.Layer<R2, E, R>, options?: {
       readonly timeout?: Duration.Input
     }) => {
-      (f: (it: Vitest.MethodsNonLive<R | R2>) => void): void
+      (f: (it: Vitest.LayerMethods<R | R2>) => void): void
       (
         name: string,
-        f: (it: Vitest.MethodsNonLive<R | R2>) => void
+        f: (it: Vitest.LayerMethods<R | R2>) => void
       ): void
     }
 
@@ -142,6 +142,30 @@ export namespace Vitest {
   /**
    * @since 1.0.0
    */
+  export interface LayerMethods<R = never>
+    extends Omit<MethodsNonLive<R>, "beforeEach" | "afterEach" | "beforeAll" | "afterAll">
+  {
+    readonly beforeEach: <A, E>(
+      self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
+      timeout?: Duration.Input
+    ) => void
+    readonly afterEach: <A, E>(
+      self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
+      timeout?: Duration.Input
+    ) => void
+    readonly beforeAll: <A, E>(
+      self: Effect.Effect<A, E, R | Scope.Scope>,
+      timeout?: Duration.Input
+    ) => void
+    readonly afterAll: <A, E>(
+      self: Effect.Effect<A, E, R | Scope.Scope>,
+      timeout?: Duration.Input
+    ) => void
+  }
+
+  /**
+   * @since 1.0.0
+   */
   export interface Methods<R = never> extends MethodsNonLive<R> {
     readonly live: Vitest.Tester<Scope.Scope | R>
     readonly layer: <R2, E>(layer: Layer.Layer<R2, E, R>, options?: {
@@ -149,10 +173,10 @@ export namespace Vitest {
       readonly timeout?: Duration.Input
       readonly excludeTestServices?: boolean
     }) => {
-      (f: (it: Vitest.MethodsNonLive<R | R2>) => void): void
+      (f: (it: Vitest.LayerMethods<R | R2>) => void): void
       (
         name: string,
-        f: (it: Vitest.MethodsNonLive<R | R2>) => void
+        f: (it: Vitest.LayerMethods<R | R2>) => void
       ): void
     }
   }
@@ -195,6 +219,12 @@ export const live: Vitest.Tester<Scope.Scope> = internal.live
  * }
  *
  * layer(Foo.Live)("layer", (it) => {
+ *   it.beforeEach(() =>
+ *     Effect.gen(function*() {
+ *       const foo = yield* Foo
+ *       expect(foo).toEqual("foo")
+ *     }))
+ *
  *   it.effect("adds context", () =>
  *     Effect.gen(function*() {
  *       const foo = yield* Foo
@@ -221,8 +251,8 @@ export const layer: <R, E>(
     readonly excludeTestServices?: boolean
   }
 ) => {
-  (f: (it: Vitest.MethodsNonLive<R>) => void): void
-  (name: string, f: (it: Vitest.MethodsNonLive<R>) => void): void
+  (f: (it: Vitest.LayerMethods<R>) => void): void
+  (name: string, f: (it: Vitest.LayerMethods<R>) => void): void
 } = internal.layer
 
 /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -142,66 +142,74 @@ export namespace Vitest {
   /**
    * @since 1.0.0
    */
-  export type LayerMethods<R = never> = {
-    <ExtraContext extends {}>(name: string | Function, fn?: V.TestFunction<ExtraContext>, options?: number): void
-    <ExtraContext extends {}>(name: string | Function, options?: V.TestOptions, fn?: V.TestFunction<ExtraContext>): void
-  } & Omit<API, "beforeEach" | "afterEach" | "beforeAll" | "afterAll"> & {
-    readonly effect: Vitest.Tester<R | Scope.Scope>
-    readonly flakyTest: <A, E, R2>(
-      self: Effect.Effect<A, E, R2 | Scope.Scope>,
-      timeout?: Duration.Input
-    ) => Effect.Effect<A, never, R2>
-    readonly layer: <R2, E>(layer: Layer.Layer<R2, E, R>, options?: {
-      readonly timeout?: Duration.Input
-    }) => {
-      (f: (it: Vitest.LayerMethods<R | R2>) => void): void
-      (
-        name: string,
-        f: (it: Vitest.LayerMethods<R | R2>) => void
+  export type LayerMethods<R = never> =
+    & {
+      <ExtraContext extends {}>(name: string | Function, fn?: V.TestFunction<ExtraContext>, options?: number): void
+      <ExtraContext extends {}>(
+        name: string | Function,
+        options?: V.TestOptions,
+        fn?: V.TestFunction<ExtraContext>
       ): void
     }
+    & Omit<API, "beforeEach" | "afterEach" | "beforeAll" | "afterAll">
+    & {
+      readonly effect: Vitest.Tester<R | Scope.Scope>
+      readonly flakyTest: <A, E, R2>(
+        self: Effect.Effect<A, E, R2 | Scope.Scope>,
+        timeout?: Duration.Input
+      ) => Effect.Effect<A, never, R2>
+      readonly layer: <R2, E>(layer: Layer.Layer<R2, E, R>, options?: {
+        readonly timeout?: Duration.Input
+      }) => {
+        (f: (it: Vitest.LayerMethods<R | R2>) => void): void
+        (
+          name: string,
+          f: (it: Vitest.LayerMethods<R | R2>) => void
+        ): void
+      }
 
-    /**
-     * @since 1.0.0
-     */
-    readonly prop: <const Arbs extends Arbitraries>(
-      name: string,
-      arbitraries: Arbs,
-      self: (
-        properties: {
-          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Arbs[K] extends Schema.Schema<infer T> ? T
-          : never
-        },
-        ctx: V.TestContext
-      ) => void,
-      timeout?:
-        | number
-        | V.TestOptions & {
-          fastCheck?: FC.Parameters<
-            {
-              [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Arbs[K] extends Schema.Schema<infer T> ? T
-              : never
-            }
-          >
-        }
-    ) => void
-    readonly beforeEach: <A, E>(
-      self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
-      timeout?: Duration.Input
-    ) => void
-    readonly afterEach: <A, E>(
-      self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
-      timeout?: Duration.Input
-    ) => void
-    readonly beforeAll: <A, E>(
-      self: Effect.Effect<A, E, R | Scope.Scope>,
-      timeout?: Duration.Input
-    ) => void
-    readonly afterAll: <A, E>(
-      self: Effect.Effect<A, E, R | Scope.Scope>,
-      timeout?: Duration.Input
-    ) => void
-  }
+      /**
+       * @since 1.0.0
+       */
+      readonly prop: <const Arbs extends Arbitraries>(
+        name: string,
+        arbitraries: Arbs,
+        self: (
+          properties: {
+            [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Arbs[K] extends Schema.Schema<infer T> ? T
+            : never
+          },
+          ctx: V.TestContext
+        ) => void,
+        timeout?:
+          | number
+          | V.TestOptions & {
+            fastCheck?: FC.Parameters<
+              {
+                [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T :
+                  Arbs[K] extends Schema.Schema<infer T> ? T
+                  : never
+              }
+            >
+          }
+      ) => void
+      readonly beforeEach: <A, E>(
+        self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) => void
+      readonly afterEach: <A, E>(
+        self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) => void
+      readonly beforeAll: <A, E>(
+        self: Effect.Effect<A, E, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) => void
+      readonly afterAll: <A, E>(
+        self: Effect.Effect<A, E, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) => void
+    }
 
   /**
    * @since 1.0.0

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -142,9 +142,49 @@ export namespace Vitest {
   /**
    * @since 1.0.0
    */
-  export interface LayerMethods<R = never>
-    extends Omit<MethodsNonLive<R>, "beforeEach" | "afterEach" | "beforeAll" | "afterAll">
-  {
+  export type LayerMethods<R = never> = {
+    <ExtraContext extends {}>(name: string | Function, fn?: V.TestFunction<ExtraContext>, options?: number): void
+    <ExtraContext extends {}>(name: string | Function, options?: V.TestOptions, fn?: V.TestFunction<ExtraContext>): void
+  } & Omit<API, "beforeEach" | "afterEach" | "beforeAll" | "afterAll"> & {
+    readonly effect: Vitest.Tester<R | Scope.Scope>
+    readonly flakyTest: <A, E, R2>(
+      self: Effect.Effect<A, E, R2 | Scope.Scope>,
+      timeout?: Duration.Input
+    ) => Effect.Effect<A, never, R2>
+    readonly layer: <R2, E>(layer: Layer.Layer<R2, E, R>, options?: {
+      readonly timeout?: Duration.Input
+    }) => {
+      (f: (it: Vitest.LayerMethods<R | R2>) => void): void
+      (
+        name: string,
+        f: (it: Vitest.LayerMethods<R | R2>) => void
+      ): void
+    }
+
+    /**
+     * @since 1.0.0
+     */
+    readonly prop: <const Arbs extends Arbitraries>(
+      name: string,
+      arbitraries: Arbs,
+      self: (
+        properties: {
+          [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Arbs[K] extends Schema.Schema<infer T> ? T
+          : never
+        },
+        ctx: V.TestContext
+      ) => void,
+      timeout?:
+        | number
+        | V.TestOptions & {
+          fastCheck?: FC.Parameters<
+            {
+              [K in keyof Arbs]: Arbs[K] extends FC.Arbitrary<infer T> ? T : Arbs[K] extends Schema.Schema<infer T> ? T
+              : never
+            }
+          >
+        }
+    ) => void
     readonly beforeEach: <A, E>(
       self: (ctx: V.TestContext) => Effect.Effect<A, E, R | Scope.Scope>,
       timeout?: Duration.Input

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -49,6 +49,10 @@ export const addEqualityTesters = () => {
 const testOptions = (timeout?: number | V.TestOptions) => typeof timeout === "number" ? { timeout } : timeout ?? {}
 
 /** @internal */
+const hookTimeout = (timeout?: Duration.Input) =>
+  timeout === undefined ? undefined : Duration.toMillis(Duration.fromInputUnsafe(timeout))
+
+/** @internal */
 const makeTester = <R>(
   mapEffect: <A, E>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, never>,
   it: V.TestAPI = V.it
@@ -180,20 +184,20 @@ export const layer = <R, E>(
     readonly excludeTestServices?: boolean
   }
 ): {
-  (f: (it: Vitest.Vitest.MethodsNonLive<R>) => void): void
+  (f: (it: Vitest.Vitest.LayerMethods<R>) => void): void
   (
     name: string,
-    f: (it: Vitest.Vitest.MethodsNonLive<R>) => void
+    f: (it: Vitest.Vitest.LayerMethods<R>) => void
   ): void
 } =>
 (
   ...args: [
     name: string,
     f: (
-      it: Vitest.Vitest.MethodsNonLive<R>
+      it: Vitest.Vitest.LayerMethods<R>
     ) => void
   ] | [
-    f: (it: Vitest.Vitest.MethodsNonLive<R>) => void
+    f: (it: Vitest.Vitest.LayerMethods<R>) => void
   ]
 ) => {
   const excludeTestServices = options?.excludeTestServices ?? false
@@ -207,18 +211,79 @@ export const layer = <R, E>(
     Effect.cached,
     Effect.runSync
   )
+  let beforeAllScope: Scope.Closeable | undefined
 
-  const makeIt = (it: V.TestAPI): Vitest.Vitest.MethodsNonLive<R> =>
+  const provideLayerContext = <A, E2>(effect: Effect.Effect<A, E2, R>) =>
+    Effect.flatMap(contextEffect, (context) => Effect.provide(effect, context))
+
+  const runScopedHook = <A, E2>(
+    effect: Effect.Effect<A, E2, R | Scope.Scope>,
+    scope: Scope.Closeable,
+    ctx?: V.TestContext
+  ) =>
+    runPromise(
+      provideLayerContext(
+        Effect.provideService(effect, Scope.Scope, scope)
+      ),
+      ctx
+    )
+
+  const makeIt = (it: V.TestAPI): Vitest.Vitest.LayerMethods<R> =>
     Object.assign(it, {
       effect: makeTester<R | Scope.Scope>(
-        (effect) =>
-          Effect.flatMap(contextEffect, (context) =>
-            effect.pipe(
-              Effect.scoped,
-              Effect.provide(context)
-            )),
+        (effect) => provideLayerContext(effect.pipe(Effect.scoped)),
         it
       ),
+      beforeEach<A, E2>(
+        self: (ctx: V.TestContext) => Effect.Effect<A, E2, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) {
+        return V.beforeEach(async (ctx) => {
+          const scope = Effect.runSync(Scope.make())
+          try {
+            await runScopedHook(self(ctx), scope, ctx)
+          } catch (error) {
+            await runPromise(Scope.close(scope, Exit.void), ctx)
+            throw error
+          }
+          return () => runPromise(Scope.close(scope, Exit.void), ctx)
+        }, hookTimeout(timeout))
+      },
+      afterEach<A, E2>(
+        self: (ctx: V.TestContext) => Effect.Effect<A, E2, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) {
+        return V.afterEach(async (ctx) => {
+          const scope = Effect.runSync(Scope.make())
+          try {
+            await runScopedHook(self(ctx), scope, ctx)
+          } finally {
+            await runPromise(Scope.close(scope, Exit.void), ctx)
+          }
+        }, hookTimeout(timeout))
+      },
+      beforeAll<A, E2>(
+        self: Effect.Effect<A, E2, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) {
+        return V.beforeAll(() => {
+          beforeAllScope ??= Effect.runSync(Scope.make())
+          return runScopedHook(self, beforeAllScope)
+        }, hookTimeout(timeout))
+      },
+      afterAll<A, E2>(
+        self: Effect.Effect<A, E2, R | Scope.Scope>,
+        timeout?: Duration.Input
+      ) {
+        return V.afterAll(async () => {
+          const scope = Effect.runSync(Scope.make())
+          try {
+            await runScopedHook(self, scope)
+          } finally {
+            await runPromise(Scope.close(scope, Exit.void))
+          }
+        }, hookTimeout(timeout))
+      },
       prop,
       flakyTest,
       layer<R2, E2>(nestedLayer: Layer.Layer<R2, E2, R>, options?: {
@@ -231,11 +296,15 @@ export const layer = <R, E>(
   if (args.length === 1) {
     V.beforeAll(
       () => runPromise(Effect.asVoid(contextEffect)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      hookTimeout(options?.timeout)
+    )
+    V.afterAll(
+      () => beforeAllScope === undefined ? undefined : runPromise(Scope.close(beforeAllScope, Exit.void)),
+      hookTimeout(options?.timeout)
     )
     V.afterAll(
       () => runPromise(Scope.close(scope, Exit.void)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      hookTimeout(options?.timeout)
     )
     return args[0](makeIt(V.it))
   }
@@ -243,11 +312,15 @@ export const layer = <R, E>(
   return V.describe(args[0], () => {
     V.beforeAll(
       () => runPromise(Effect.asVoid(contextEffect)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      hookTimeout(options?.timeout)
+    )
+    V.afterAll(
+      () => beforeAllScope === undefined ? undefined : runPromise(Scope.close(beforeAllScope, Exit.void)),
+      hookTimeout(options?.timeout)
     )
     V.afterAll(
       () => runPromise(Scope.close(scope, Exit.void)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      hookTimeout(options?.timeout)
     )
     return args[1](makeIt(V.it))
   })

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -64,7 +64,7 @@ it.live.fails("interrupts on timeout", (ctx) =>
   }), 1)
 
 class Foo extends ServiceMap.Service<Foo, "foo">()("Foo") {
-  static Live = Layer.succeed(Foo)("foo")
+  static layer = Layer.succeed(Foo)("foo")
 }
 
 class Bar extends ServiceMap.Service<Bar, "bar">()("Bar") {
@@ -86,7 +86,7 @@ class Sleeper extends ServiceMap.Service<Sleeper, {
 }
 
 describe("layer", () => {
-  layer(Foo.Live)((it) => {
+  layer(Foo.layer)((it) => {
     it.effect("adds context", () =>
       Effect.gen(function*() {
         const foo = yield* Foo
@@ -163,7 +163,7 @@ describe("layer", () => {
       }))
   })
 
-  layer(Foo.Live)("with a name", (it) => {
+  layer(Foo.layer)("with a name", (it) => {
     describe("with a nested describe", () => {
       it.effect("adds context", () =>
         Effect.gen(function*() {
@@ -172,6 +172,72 @@ describe("layer", () => {
         }))
     })
     it.effect("adds context", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        expect(foo).toEqual("foo")
+      }))
+  })
+
+  layer(Foo.layer)("effectful hooks", (it) => {
+    let beforeEachCount = 0
+    let afterEachCount = 0
+    let beforeEachReleased = 0
+    let beforeAllCount = 0
+    let afterAllCount = 0
+    let beforeAllReleased = false
+
+    it.beforeEach(() =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        expect(foo).toEqual("foo")
+        beforeEachCount += 1
+        return yield* Effect.acquireRelease(
+          Effect.succeed(beforeEachCount),
+          () => Effect.sync(() => beforeEachReleased += 1)
+        )
+      })
+    )
+
+    it.afterEach(() =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        expect(foo).toEqual("foo")
+        afterEachCount += 1
+      })
+    )
+
+    it.beforeAll(Effect.gen(function*() {
+      const foo = yield* Foo
+      expect(foo).toEqual("foo")
+      beforeAllCount += 1
+      return yield* Effect.acquireRelease(
+        Effect.succeed("before-all"),
+        () => Effect.sync(() => beforeAllReleased = true)
+      )
+    }))
+
+    afterAll(() => {
+      expect(beforeEachCount).toEqual(2)
+      expect(afterEachCount).toEqual(2)
+      expect(beforeEachReleased).toEqual(2)
+      expect(beforeAllCount).toEqual(1)
+      expect(afterAllCount).toEqual(1)
+    })
+
+    it.afterAll(Effect.gen(function*() {
+      const foo = yield* Foo
+      expect(foo).toEqual("foo")
+      afterAllCount += 1
+      expect(beforeAllReleased).toEqual(false)
+    }))
+
+    it.effect("first hook test", () =>
+      Effect.gen(function*() {
+        const foo = yield* Foo
+        expect(foo).toEqual("foo")
+      }))
+
+    it.effect("second hook test", () =>
       Effect.gen(function*() {
         const foo = yield* Foo
         expect(foo).toEqual("foo")


### PR DESCRIPTION
## Summary
- add effectful `beforeEach`, `afterEach`, `beforeAll`, and `afterAll` hooks to the `it` returned by `layer(...)` / `it.layer(...)`