### PR TITLE
add unstable machine prototype

### DIFF
--- a/.changeset/silent-cameras-wave.md
+++ b/.changeset/silent-cameras-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add an unstable machine prototype with schema-backed tagged events and states, typed handlers, and a scoped actor runtime under `effect/unstable/machine/Machine`.

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ scratchpad/**/*
 # lalph
 .lalph/
 .repos/
+.specs/
 
 # ralph auto loop (runtime output)
 .ralph-auto/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ scratchpad/**/*
 
 # Claude Code
 .claude/
+
+# OpenCode
+.opencode/

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -1,4 +1,6 @@
+import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
+import * as ServiceMap from "effect/ServiceMap"
 import * as Machine from "effect/unstable/machine/Machine"
 import { describe, expect, it } from "tstyche"
 
@@ -57,6 +59,9 @@ describe("Machine", () => {
       | Created
       | Deleted
     >()
+    expect<Machine.DeferredServicesOf<typeof UserMachine>>().type.toBe<never>()
+    const next = Machine.next(UserMachine, Machine.initial(UserMachine), new Create({ email: "a@example.com" }))
+    expect<typeof next>().type.toBe<Effect.Effect<Uncreated | Created | Deleted, Machine.UnhandledEventError>>()
   })
 
   it("contextually types handlers", () => {
@@ -86,6 +91,34 @@ describe("Machine", () => {
         return new Created({ email: event.email })
       }
     })
+  })
+
+  it("does not infer deferred requirements from plain effectful handlers", () => {
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      { email: Schema.String }
+    ) {}
+
+    class Uncreated extends Schema.TaggedClass<Uncreated, { readonly _: unique symbol }>()(
+      "Uncreated",
+      {}
+    ) {}
+
+    class Created extends Schema.TaggedClass<Created, { readonly _: unique symbol }>()(
+      "Created",
+      { email: Schema.String }
+    ) {}
+
+    const machine = Machine.make({
+      events: [Create],
+      initial: () => new Uncreated({}),
+      states: [Uncreated, Created]
+    }).handlers("Uncreated")({
+      Create: ({ event }) => Effect.succeed(new Created({ email: event.email }))
+    })
+
+    expect<Machine.DeferredErrorOf<typeof machine>>().type.toBe<never>()
+    expect<Machine.DeferredServicesOf<typeof machine>>().type.toBe<never>()
   })
 
   it("accepts events as a tuple of tagged schemas", () => {
@@ -195,5 +228,50 @@ describe("Machine", () => {
         return new Unauthenticated({})
       }
     })
+  })
+
+  it("tracks deferred effect errors and services separately from plan requirements", () => {
+    class DeferredError extends Schema.TaggedErrorClass<DeferredError, { readonly _: unique symbol }>()(
+      "DeferredError",
+      {}
+    ) {}
+
+    class DeferredDependency extends ServiceMap.Service<DeferredDependency, {
+      readonly emit: Effect.Effect<void, DeferredError>
+    }>()("test/Machine/DeferredDependency") {}
+
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      {}
+    ) {}
+
+    class Idle extends Schema.TaggedClass<Idle, { readonly _: unique symbol }>()(
+      "Idle",
+      {}
+    ) {}
+
+    const machine = Machine.make({
+      events: [Create],
+      initial: () => new Idle({}),
+      states: [Idle]
+    }).handlers("Idle")({
+      Create: () =>
+        Effect.gen(function*() {
+          yield* Machine.defer(DeferredDependency.use((deferred) => deferred.emit))
+          return new Idle({})
+        })
+    })
+
+    const planned = Machine.plan(machine, Machine.initial(machine), new Create({}))
+
+    expect<Machine.PlanErrorOf<typeof machine>>().type.toBe<never>()
+    expect<Machine.PlanServicesOf<typeof machine>>().type.toBe<never>()
+    expect<Machine.DeferredErrorOf<typeof machine>>().type.toBe<DeferredError>()
+    expect<Machine.DeferredServicesOf<typeof machine>>().type.toBe<DeferredDependency>()
+    expect<Machine.ErrorOf<typeof machine>>().type.toBe<DeferredError>()
+    expect<Machine.ServicesOf<typeof machine>>().type.toBe<DeferredDependency>()
+    expect<typeof planned>().type.toBe<
+      Effect.Effect<Machine.Plan<Machine.StateSchemasOf<typeof machine>, typeof machine.event, Idle>, Machine.UnhandledEventError>
+    >()
   })
 })

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
-import * as ServiceMap from "effect/ServiceMap"
+import * as Context from "effect/Context"
 import * as Machine from "effect/unstable/machine/Machine"
 import { describe, expect, it } from "tstyche"
 
@@ -236,7 +236,7 @@ describe("Machine", () => {
       {}
     ) {}
 
-    class DeferredDependency extends ServiceMap.Service<DeferredDependency, {
+    class DeferredDependency extends Context.Service<DeferredDependency, {
       readonly emit: Effect.Effect<void, DeferredError>
     }>()("test/Machine/DeferredDependency") {}
 

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -41,7 +41,7 @@ describe("Machine", () => {
 
     const UserMachine = Machine.make({
       events: [Create, Rename, Delete],
-      initial: new Uncreated({}),
+      initial: () => new Uncreated({}),
       states: [Uncreated, Created, Deleted]
     }).handlers({
       Uncreated: {
@@ -78,7 +78,7 @@ describe("Machine", () => {
 
     Machine.make({
       events: [Create],
-      initial: new Uncreated({ count: 0 }),
+      initial: () => new Uncreated({ count: 0 }),
       states: [Uncreated, Created]
     }).handlers({
       Uncreated: {
@@ -115,7 +115,7 @@ describe("Machine", () => {
 
     const machine = Machine.make({
       events: [Create, Rename],
-      initial: new Idle({}),
+      initial: () => new Idle({}),
       states: [Idle, Running]
     }).handlers({
       Idle: {
@@ -134,5 +134,39 @@ describe("Machine", () => {
 
     expect<Machine.Event<typeof machine.event>>().type.toBe<Create | Rename>()
     expect<Machine.MachineErrorOf<typeof machine>>().type.toBe<Machine.UnhandledEventError>()
+  })
+
+  it("accepts schema-backed input for initial state", () => {
+    const Input = Schema.Struct({
+      email: Schema.String
+    })
+
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      { email: Schema.String }
+    ) {}
+
+    class Uncreated extends Schema.TaggedClass<Uncreated, { readonly _: unique symbol }>()(
+      "Uncreated",
+      {}
+    ) {}
+
+    class Created extends Schema.TaggedClass<Created, { readonly _: unique symbol }>()(
+      "Created",
+      { email: Schema.String }
+    ) {}
+
+    const machine = Machine.make({
+      input: Input,
+      events: [Create],
+      initial: ({ input }) => new Created({ email: input.email }),
+      states: [Uncreated, Created]
+    }).handlers({
+      Uncreated: {
+        Create: ({ event }) => new Created({ email: event.email })
+      }
+    })
+
+    expect<Machine.InputOf<typeof machine>>().type.toBe<{ readonly email: string }>()
   })
 })

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import * as Schema from "effect/Schema"
 import * as Machine from "effect/unstable/machine/Machine"
 import { describe, expect, it } from "tstyche"
 

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -1,0 +1,138 @@
+import { Schema } from "effect"
+import * as Machine from "effect/unstable/machine/Machine"
+import { describe, expect, it } from "tstyche"
+
+describe("Machine", () => {
+  it("infers machine state schemas from state definitions", () => {
+    const User = Schema.Struct({
+      id: Schema.String,
+      email: Schema.String
+    })
+
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      { email: Schema.String }
+    ) {}
+
+    class Rename extends Schema.TaggedClass<Rename, { readonly _: unique symbol }>()(
+      "Rename",
+      { email: Schema.String }
+    ) {}
+
+    class Delete extends Schema.TaggedClass<Delete, { readonly _: unique symbol }>()(
+      "Delete",
+      {}
+    ) {}
+
+    class Uncreated extends Schema.TaggedClass<Uncreated, { readonly _: unique symbol }>()(
+      "Uncreated",
+      {}
+    ) {}
+
+    class Created extends Schema.TaggedClass<Created, { readonly _: unique symbol }>()(
+      "Created",
+      { user: User }
+    ) {}
+
+    class Deleted extends Schema.TaggedClass<Deleted, { readonly _: unique symbol }>()(
+      "Deleted",
+      { userId: Schema.String }
+    ) {}
+
+    const UserMachine = Machine.make({
+      events: [Create, Rename, Delete],
+      initial: new Uncreated({}),
+      states: [Uncreated, Created, Deleted]
+    }).handlers({
+      Uncreated: {
+        Create: ({ event }) => new Created({ user: { id: "user-1", email: event.email } })
+      },
+      Created: {
+        Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
+        Delete: ({ data }) => new Deleted({ userId: data.user.id })
+      }
+    })
+
+    expect<Machine.Snapshot<Machine.StateSchemasOf<typeof UserMachine>>>().type.toBe<
+      | Uncreated
+      | Created
+      | Deleted
+    >()
+  })
+
+  it("contextually types handlers", () => {
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      { email: Schema.String }
+    ) {}
+
+    class Uncreated extends Schema.TaggedClass<Uncreated, { readonly _: unique symbol }>()(
+      "Uncreated",
+      { count: Schema.Number }
+    ) {}
+
+    class Created extends Schema.TaggedClass<Created, { readonly _: unique symbol }>()(
+      "Created",
+      { email: Schema.String }
+    ) {}
+
+    Machine.make({
+      events: [Create],
+      initial: new Uncreated({ count: 0 }),
+      states: [Uncreated, Created]
+    }).handlers({
+      Uncreated: {
+        Create: ({ event, data, snapshot }) => {
+          expect<typeof event>().type.toBe<Create>()
+          expect<typeof data>().type.toBe<{ readonly count: number }>()
+          expect<typeof snapshot>().type.toBe<Uncreated>()
+          return new Created({ email: event.email })
+        }
+      }
+    })
+  })
+
+  it("accepts events as a tuple of tagged schemas", () => {
+    class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+      "Create",
+      { email: Schema.String }
+    ) {}
+
+    class Rename extends Schema.TaggedClass<Rename, { readonly _: unique symbol }>()(
+      "Rename",
+      { email: Schema.String }
+    ) {}
+
+    class Idle extends Schema.TaggedClass<Idle, { readonly _: unique symbol }>()(
+      "Idle",
+      {}
+    ) {}
+
+    class Running extends Schema.TaggedClass<Running, { readonly _: unique symbol }>()(
+      "Running",
+      { email: Schema.String }
+    ) {}
+
+    const machine = Machine.make({
+      events: [Create, Rename],
+      initial: new Idle({}),
+      states: [Idle, Running]
+    }).handlers({
+      Idle: {
+        Create: ({ event }) => {
+          expect<typeof event>().type.toBe<Create>()
+          return new Running({ email: event.email })
+        }
+      },
+      Running: {
+        Rename: ({ event }) => {
+          expect<typeof event>().type.toBe<Rename>()
+          return new Running({ email: event.email })
+        }
+      }
+    })
+
+    expect<Machine.Event<typeof machine.event>>().type.toBe<Create | Rename>()
+    expect<Machine.MachineErrorOf<typeof machine>>().type.toBe<Machine.UnhandledEventError>()
+  })
+})

--- a/packages/effect/dtslint/unstable/machine/Machine.tst.ts
+++ b/packages/effect/dtslint/unstable/machine/Machine.tst.ts
@@ -43,15 +43,14 @@ describe("Machine", () => {
       events: [Create, Rename, Delete],
       initial: () => new Uncreated({}),
       states: [Uncreated, Created, Deleted]
-    }).handlers({
-      Uncreated: {
-        Create: ({ event }) => new Created({ user: { id: "user-1", email: event.email } })
-      },
-      Created: {
-        Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
-        Delete: ({ data }) => new Deleted({ userId: data.user.id })
-      }
     })
+      .handlers("Uncreated")({
+        Create: ({ event }) => new Created({ user: { id: "user-1", email: event.email } })
+      })
+      .handlers("Created")({
+        Rename: ({ state, event }) => new Created({ user: { ...state.user, email: event.email } }),
+        Delete: ({ state }) => new Deleted({ userId: state.user.id })
+      })
 
     expect<Machine.Snapshot<Machine.StateSchemasOf<typeof UserMachine>>>().type.toBe<
       | Uncreated
@@ -80,14 +79,11 @@ describe("Machine", () => {
       events: [Create],
       initial: () => new Uncreated({ count: 0 }),
       states: [Uncreated, Created]
-    }).handlers({
-      Uncreated: {
-        Create: ({ event, data, snapshot }) => {
-          expect<typeof event>().type.toBe<Create>()
-          expect<typeof data>().type.toBe<{ readonly count: number }>()
-          expect<typeof snapshot>().type.toBe<Uncreated>()
-          return new Created({ email: event.email })
-        }
+    }).handlers("Uncreated")({
+      Create: ({ event, state }) => {
+        expect<typeof event>().type.toBe<Create>()
+        expect<typeof state>().type.toBe<Uncreated>()
+        return new Created({ email: event.email })
       }
     })
   })
@@ -117,20 +113,19 @@ describe("Machine", () => {
       events: [Create, Rename],
       initial: () => new Idle({}),
       states: [Idle, Running]
-    }).handlers({
-      Idle: {
+    })
+      .handlers("Idle")({
         Create: ({ event }) => {
           expect<typeof event>().type.toBe<Create>()
           return new Running({ email: event.email })
         }
-      },
-      Running: {
+      })
+      .handlers("Running")({
         Rename: ({ event }) => {
           expect<typeof event>().type.toBe<Rename>()
           return new Running({ email: event.email })
         }
-      }
-    })
+      })
 
     expect<Machine.Event<typeof machine.event>>().type.toBe<Create | Rename>()
     expect<Machine.MachineErrorOf<typeof machine>>().type.toBe<Machine.UnhandledEventError>()
@@ -161,12 +156,44 @@ describe("Machine", () => {
       events: [Create],
       initial: ({ input }) => new Created({ email: input.email }),
       states: [Uncreated, Created]
-    }).handlers({
-      Uncreated: {
-        Create: ({ event }) => new Created({ email: event.email })
-      }
+    }).handlers("Uncreated")({
+      Create: ({ event }) => new Created({ email: event.email })
     })
 
     expect<Machine.InputOf<typeof machine>>().type.toBe<{ readonly email: string }>()
+  })
+
+  it("uses unions for parent-scope snapshot and data", () => {
+    class Logout extends Schema.TaggedClass<Logout, { readonly _: unique symbol }>()(
+      "Logout",
+      {}
+    ) {}
+
+    class Idle extends Schema.TaggedClass<Idle, { readonly _: unique symbol }>()(
+      "Authenticated.Idle",
+      { userId: Schema.String }
+    ) {}
+
+    class Refreshing extends Schema.TaggedClass<Refreshing, { readonly _: unique symbol }>()(
+      "Authenticated.Refreshing",
+      { userId: Schema.String, retryCount: Schema.Number }
+    ) {}
+
+    class Unauthenticated extends Schema.TaggedClass<Unauthenticated, { readonly _: unique symbol }>()(
+      "Unauthenticated",
+      {}
+    ) {}
+
+    Machine.make({
+      events: [Logout],
+      initial: () => new Idle({ userId: "user-1" }),
+      states: [Unauthenticated, Idle, Refreshing]
+    }).handlers("Authenticated")({
+      Logout: ({ event, state }) => {
+        expect<typeof event>().type.toBe<Logout>()
+        expect<typeof state>().type.toBe<Idle | Refreshing>()
+        return new Unauthenticated({})
+      }
+    })
   })
 })

--- a/packages/effect/src/unstable/machine/Machine.ts
+++ b/packages/effect/src/unstable/machine/Machine.ts
@@ -34,6 +34,9 @@ type StatePayload<StateSchemas extends AnyStateSchemas, Name extends keyof State
   DataSchema<StateSchemas, Name>["~type.make.in"],
   "_tag"
 >
+type InputValue<InputSchema> = InputSchema extends Schema.Top ? Schema.Schema.Type<InputSchema> : never
+type Initializer<InputSchema, State> = [InputSchema] extends [undefined] ? () => State
+  : (args: { readonly input: InputValue<InputSchema> }) => State
 
 /**
  * @since 4.0.0
@@ -143,14 +146,16 @@ export interface Plan<
 export interface Machine<
   EventSchema extends AnyEventSchema,
   StateSchemas extends AnyStateSchemas,
+  InputSchema = undefined,
   E = never,
   R = never
 > {
   readonly [TypeId]: typeof TypeId
   readonly id: string | undefined
+  readonly input: InputSchema
   readonly event: EventSchema
   readonly snapshot: AnyTaggedUnion
-  readonly initial: Snapshot<StateSchemas>
+  readonly initial: Initializer<InputSchema, Snapshot<StateSchemas>>
   readonly states: { readonly [Name in keyof StateSchemas & string]: DataSchema<StateSchemas, Name> }
   readonly handlers: Handlers<EventSchema, StateSchemas, E, R>
 }
@@ -189,19 +194,22 @@ interface Envelope<E, A> {
  */
 export interface Builder<
   EventSchema extends AnyEventSchema,
-  States extends AnyStateTuple
+  States extends AnyStateTuple,
+  InputSchema = undefined
 > {
   readonly [BuilderTypeId]: typeof BuilderTypeId
   readonly id: string | undefined
+  readonly input: InputSchema
   readonly event: EventSchema
   readonly snapshot: AnyTaggedUnion
-  readonly initial: Snapshot<StateSchemasOfStates<States>>
+  readonly initial: Initializer<InputSchema, Snapshot<StateSchemasOfStates<States>>>
   readonly states: States
   readonly handlers: <HandlersDef extends Handlers<EventSchema, StateSchemasOfStates<States>, any, any>>(
     handlers: HandlersDef
   ) => Machine<
     EventSchema,
     StateSchemasOfStates<States>,
+    InputSchema,
     InferHandlerError<HandlersDef>,
     InferHandlerServices<HandlersDef>
   >
@@ -211,25 +219,39 @@ export interface Builder<
  * @since 4.0.0
  * @category models
  */
-export type Any = Machine<any, any, any, any>
+export type Any = Machine<any, any, any, any, any>
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type StateSchemasOf<M extends Any> = M extends Machine<any, infer StateSchemas, any, any> ? StateSchemas : never
+export type StateSchemasOf<M extends Any> = M extends Machine<any, infer StateSchemas, any, any, any> ? StateSchemas
+  : never
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type ErrorOf<M extends Any> = M extends Machine<any, any, infer E, any> ? E : never
+export type InputSchemaOf<M extends Any> = M extends Machine<any, any, infer InputSchema, any, any> ? InputSchema
+  : never
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type ServicesOf<M extends Any> = M extends Machine<any, any, any, infer R> ? R : never
+export type InputOf<M extends Any> = InputValue<InputSchemaOf<M>>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ErrorOf<M extends Any> = M extends Machine<any, any, any, infer E, any> ? E : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ServicesOf<M extends Any> = M extends Machine<any, any, any, any, infer R> ? R : never
 
 /**
  * @since 4.0.0
@@ -252,18 +274,21 @@ const toEffect = <A, E, R>(value: A | Effect.Effect<A, E, R>): Effect.Effect<A, 
  */
 export const make = <
   const Events extends AnyEventTuple,
-  const States extends AnyStateTuple
+  const States extends AnyStateTuple,
+  InputSchema = undefined
 >(definition: {
   readonly id?: string | undefined
+  readonly input?: InputSchema
   readonly events: Events
-  readonly initial: Snapshot<StateSchemasOfStates<States>>
+  readonly initial: Initializer<InputSchema, Snapshot<StateSchemasOfStates<States>>>
   readonly states: States
-}): Builder<Schema.toTaggedUnion<"_tag", Events>, States> => {
+}): Builder<Schema.toTaggedUnion<"_tag", Events>, States, InputSchema> => {
   const event = normalizeEventSchema(definition)
   const initial = definition.initial
   return {
     [BuilderTypeId]: BuilderTypeId,
     id: definition.id,
+    input: definition.input as InputSchema,
     event,
     snapshot: snapshotSchemaFromStates(definition.states),
     initial,
@@ -271,6 +296,7 @@ export const make = <
     handlers: (handlers) => ({
       [TypeId]: TypeId,
       id: definition.id,
+      input: definition.input as InputSchema,
       event,
       snapshot: snapshotSchemaFromStates(definition.states),
       initial,
@@ -290,51 +316,34 @@ const normalizeEventSchema = <const Events extends AnyEventTuple>(
 
 /**
  * @since 4.0.0
- * @category accessors
- */
-export const eventSchema = <M extends Any>(self: M): M["event"] => self.event
-
-/**
- * @since 4.0.0
- * @category accessors
- */
-export const snapshotSchema = <M extends Any>(self: M): M["snapshot"] => self.snapshot
-
-/**
- * @since 4.0.0
  * @category constructors
  */
-export const decodeEvent = <M extends Any>(self: M, input: unknown) =>
-  Schema.decodeUnknownEffect(self.event as any)(input) as Effect.Effect<
-    Event<M["event"]>,
-    Schema.SchemaError,
-    M["event"]["DecodingServices"]
-  >
+type InitialArguments<M extends Any> = [InputSchemaOf<M>] extends [undefined] ? [] : [input: InputOf<M>]
 
-/**
- * @since 4.0.0
- * @category constructors
- */
-export const decodeSnapshot = <M extends Any>(self: M, input: unknown) =>
-  Schema.decodeUnknownEffect(self.snapshot as any)(input) as Effect.Effect<
-    Snapshot<StateSchemasOf<M>>,
-    Schema.SchemaError,
-    M["snapshot"]["DecodingServices"]
-  >
+const resolveInitial = <M extends Any>(self: M, args: ReadonlyArray<InputOf<M>>): Snapshot<StateSchemasOf<M>> => {
+  if (self.input === undefined) {
+    return (self.initial as () => Snapshot<StateSchemasOf<M>>)()
+  }
+  return (self.initial as (args: { readonly input: InputOf<M> }) => Snapshot<StateSchemasOf<M>>)({
+    input: args[0] as InputOf<M>
+  })
+}
 
 /**
  * @since 4.0.0
  * @category constructors
  */
 export const initial = <M extends Any>(
-  self: M
-): Effect.Effect<Snapshot<StateSchemasOf<M>>> => Effect.succeed(self.initial as any)
+  self: M,
+  ...args: InitialArguments<M>
+): Effect.Effect<Snapshot<StateSchemasOf<M>>> =>
+  Effect.sync(() => resolveInitial(self, args as ReadonlyArray<InputOf<M>>))
 
 /**
  * @since 4.0.0
  * @category constructors
  */
-export const plan = <
+export const transition = <
   M extends Any,
   Source extends Snapshot<StateSchemasOf<M>>
 >(
@@ -392,7 +401,7 @@ export const next = <
   Snapshot<StateSchemasOf<M>>,
   MachineErrorOf<M>,
   ServicesOf<M>
-> => Effect.map(plan(self, snapshot, event), (plan) => plan.next)
+> => Effect.map(transition(self, snapshot, event), (plan) => plan.next)
 
 /**
  * @since 4.0.0
@@ -404,11 +413,10 @@ export const enabled = <
 >(
   self: M,
   snapshot: Source
-): Effect.Effect<ReadonlyArray<EventTag<M["event"]>>> =>
-  Effect.sync(() => {
-    const handlers = self.handlers[snapshot._tag as keyof typeof self.handlers] ?? {}
-    return Object.keys(handlers) as ReadonlyArray<EventTag<M["event"]>>
-  })
+): ReadonlyArray<EventTag<M["event"]>> => {
+  const handlers = self.handlers[snapshot._tag as keyof typeof self.handlers] ?? {}
+  return Object.keys(handlers) as ReadonlyArray<EventTag<M["event"]>>
+}
 
 /**
  * @since 4.0.0
@@ -424,10 +432,11 @@ export const graph = <M extends Any>(self: M) => ({
  * @category constructors
  */
 export const start = <M extends Any>(
-  machine: M
+  machine: M,
+  ...args: InitialArguments<M>
 ): Effect.Effect<Actor<M>, never, Scope.Scope | ServicesOf<M>> =>
   Effect.gen(function*() {
-    const initialSnapshot = yield* initial(machine)
+    const initialSnapshot = resolveInitial(machine, args as ReadonlyArray<InputOf<M>>)
     const snapshots = yield* Ref.make(initialSnapshot)
     const mailbox = yield* Queue.unbounded<Envelope<Event<M["event"]>, MachineErrorOf<M>>>()
     const changesHub = yield* PubSub.unbounded<Snapshot<StateSchemasOf<M>>>()
@@ -436,7 +445,7 @@ export const start = <M extends Any>(
       while (true) {
         const envelope = yield* Queue.take(mailbox)
         const current = yield* Ref.get(snapshots)
-        const result = yield* exit(machine, current as any, envelope.event as any)
+        const result = yield* Effect.exit(next(machine, current as any, envelope.event as any))
         if (Exit.isSuccess(result)) {
           yield* Ref.set(snapshots, result.value as any)
           yield* PubSub.publish(changesHub, result.value as any)
@@ -466,10 +475,3 @@ export const start = <M extends Any>(
       changes: Stream.concat(Stream.make(initialSnapshot), Stream.fromPubSub(changesHub))
     }
   })
-
-/**
- * @since 4.0.0
- * @category constructors
- */
-export const exit = <M extends Any>(self: M, snapshot: Snapshot<StateSchemasOf<M>>, event: Event<M["event"]>) =>
-  Effect.exit(next(self, snapshot, event))

--- a/packages/effect/src/unstable/machine/Machine.ts
+++ b/packages/effect/src/unstable/machine/Machine.ts
@@ -2,6 +2,7 @@
  * @since 4.0.0
  */
 import * as Deferred from "../../Deferred.ts"
+import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
 import * as Exit from "../../Exit.ts"
 import * as Predicate from "../../Predicate.ts"
@@ -10,7 +11,6 @@ import * as Queue from "../../Queue.ts"
 import * as Ref from "../../Ref.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
-import * as ServiceMap from "../../ServiceMap.ts"
 import type * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
@@ -136,7 +136,7 @@ type HandlerUnion<HandlersDef extends Record<string, any>> = Exclude<HandlersDef
  * @since 4.0.0
  * @category context
  */
-export class HandlerContext extends ServiceMap.Service<HandlerContext, {
+export class HandlerContext extends Context.Service<HandlerContext, {
   readonly defer: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<void, never, HandlerContext.Marker<E, R>>
   readonly read: Effect.Effect<ReadonlyArray<Effect.Effect<void, any, any>>>
 }>()("effect/unstable/machine/Machine/HandlerContext") {}
@@ -536,10 +536,10 @@ const evaluate = <
       )
     }
     const handlerContext = makeHandlerContext()
-    const next = yield* (toEffect(handler({
+    const next = yield* (Effect.provideService(toEffect(handler({
       state: current as any,
       event: currentEvent as any
-    })).pipe(Effect.provideService(HandlerContext, handlerContext)) as Effect.Effect<
+    })), HandlerContext, handlerContext) as Effect.Effect<
       Snapshot<StateSchemasOf<M>>,
       PlanErrorOf<M>,
       PlanServicesOf<M>

--- a/packages/effect/src/unstable/machine/Machine.ts
+++ b/packages/effect/src/unstable/machine/Machine.ts
@@ -1,0 +1,475 @@
+/**
+ * @since 4.0.0
+ */
+import * as Deferred from "../../Deferred.ts"
+import * as Effect from "../../Effect.ts"
+import * as Exit from "../../Exit.ts"
+import * as Predicate from "../../Predicate.ts"
+import * as PubSub from "../../PubSub.ts"
+import * as Queue from "../../Queue.ts"
+import * as Ref from "../../Ref.ts"
+import * as Schema from "../../Schema.ts"
+import type * as Scope from "../../Scope.ts"
+import * as Stream from "../../Stream.ts"
+
+const TypeId = "~effect/unstable/machine/Machine" as const
+const BuilderTypeId = "~effect/unstable/machine/Machine/Builder" as const
+
+type AnyTaggedEvent = Schema.Top & { readonly Type: { readonly _tag: PropertyKey } }
+type AnyTaggedUnion = Schema.Top & { readonly Type: { readonly _tag: PropertyKey }; readonly cases: any }
+type AnyEventSchema = Schema.Top & {
+  readonly Type: { readonly _tag: PropertyKey }
+  readonly cases: any
+}
+type AnyEventTuple = readonly [AnyTaggedEvent, ...Array<AnyTaggedEvent>]
+type AnyTaggedState = Schema.Top & { readonly Type: { readonly _tag: PropertyKey } }
+type AnyStateTuple = readonly [AnyTaggedState, ...Array<AnyTaggedState>]
+type AnyStateSchemas = Record<string, AnyTaggedState>
+
+type StateSchemasOfStates<States extends AnyStateTuple> = {
+  readonly [State in States[number] as State["Type"]["_tag"] & string]: State
+}
+type DataSchema<StateSchemas extends AnyStateSchemas, Name extends keyof StateSchemas & string> = StateSchemas[Name]
+type StatePayload<StateSchemas extends AnyStateSchemas, Name extends keyof StateSchemas & string> = Omit<
+  DataSchema<StateSchemas, Name>["~type.make.in"],
+  "_tag"
+>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Snapshot<StateSchemas extends AnyStateSchemas> = {
+  readonly [Name in keyof StateSchemas & string]:
+    & { readonly _tag: Name }
+    & Schema.Schema.Type<DataSchema<StateSchemas, Name>>
+}[keyof StateSchemas & string]
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Event<EventSchema extends AnyEventSchema> = EventSchema["Type"]
+
+type EventTag<EventSchema extends AnyEventSchema> = keyof EventSchema["cases"] & string
+type EventByTag<EventSchema extends AnyEventSchema, Tag extends EventTag<EventSchema>> =
+  EventSchema["cases"][Tag]["Type"]
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Transition<StateSchemas extends AnyStateSchemas> = Snapshot<StateSchemas>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface HandlerArgs<
+  EventSchema extends AnyEventSchema,
+  StateSchemas extends AnyStateSchemas,
+  Source extends keyof StateSchemas & string,
+  Tag extends EventTag<EventSchema>
+> {
+  readonly snapshot: Extract<Snapshot<StateSchemas>, { readonly _tag: Source }>
+  readonly data: StatePayload<StateSchemas, Source>
+  readonly event: EventByTag<EventSchema, Tag>
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Handler<
+  StateSchemas extends AnyStateSchemas,
+  Source extends keyof StateSchemas & string,
+  EventSchema extends AnyEventSchema,
+  Tag extends EventTag<EventSchema>,
+  E = never,
+  R = never
+> = (
+  args: HandlerArgs<EventSchema, StateSchemas, Source, Tag>
+) => Transition<StateSchemas> | Effect.Effect<Transition<StateSchemas>, E, R>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Handlers<
+  EventSchema extends AnyEventSchema,
+  StateSchemas extends AnyStateSchemas,
+  E = never,
+  R = never
+> = {
+  readonly [Name in keyof StateSchemas & string]?: {
+    readonly [Tag in EventTag<EventSchema>]?: Handler<StateSchemas, Name, EventSchema, Tag, E, R>
+  }
+}
+
+type HandlerUnion<HandlersDef extends Record<string, any>> = {
+  readonly [Name in keyof HandlersDef & string]: Exclude<
+    HandlersDef[Name],
+    undefined
+  >[keyof Exclude<HandlersDef[Name], undefined>]
+}[keyof HandlersDef & string]
+
+type InferHandlerError<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, infer E, any> ? E : never
+  : never
+
+type InferHandlerServices<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, infer R> ? R : never
+  : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface Plan<
+  StateSchemas extends AnyStateSchemas,
+  EventSchema extends AnyEventSchema,
+  Source extends Snapshot<StateSchemas> = Snapshot<StateSchemas>
+> {
+  readonly snapshot: Source
+  readonly event: Event<EventSchema>
+  readonly next: Snapshot<StateSchemas>
+  readonly changed: boolean
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface Machine<
+  EventSchema extends AnyEventSchema,
+  StateSchemas extends AnyStateSchemas,
+  E = never,
+  R = never
+> {
+  readonly [TypeId]: typeof TypeId
+  readonly id: string | undefined
+  readonly event: EventSchema
+  readonly snapshot: AnyTaggedUnion
+  readonly initial: Snapshot<StateSchemas>
+  readonly states: { readonly [Name in keyof StateSchemas & string]: DataSchema<StateSchemas, Name> }
+  readonly handlers: Handlers<EventSchema, StateSchemas, E, R>
+}
+
+/**
+ * @since 4.0.0
+ * @category errors
+ */
+export class UnhandledEventError extends Schema.TaggedErrorClass<UnhandledEventError, { readonly _: unique symbol }>()(
+  "UnhandledEventError",
+  {
+    machineId: Schema.optional(Schema.String),
+    state: Schema.String,
+    event: Schema.String
+  }
+) {}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface Actor<M extends Any> {
+  readonly send: (event: Event<M["event"]>) => Effect.Effect<void, MachineErrorOf<M>>
+  readonly snapshot: Effect.Effect<Snapshot<StateSchemasOf<M>>>
+  readonly changes: Stream.Stream<Snapshot<StateSchemasOf<M>>>
+}
+
+interface Envelope<E, A> {
+  readonly event: E
+  readonly ack: Deferred.Deferred<Exit.Exit<void, A>>
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface Builder<
+  EventSchema extends AnyEventSchema,
+  States extends AnyStateTuple
+> {
+  readonly [BuilderTypeId]: typeof BuilderTypeId
+  readonly id: string | undefined
+  readonly event: EventSchema
+  readonly snapshot: AnyTaggedUnion
+  readonly initial: Snapshot<StateSchemasOfStates<States>>
+  readonly states: States
+  readonly handlers: <HandlersDef extends Handlers<EventSchema, StateSchemasOfStates<States>, any, any>>(
+    handlers: HandlersDef
+  ) => Machine<
+    EventSchema,
+    StateSchemasOfStates<States>,
+    InferHandlerError<HandlersDef>,
+    InferHandlerServices<HandlersDef>
+  >
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type Any = Machine<any, any, any, any>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type StateSchemasOf<M extends Any> = M extends Machine<any, infer StateSchemas, any, any> ? StateSchemas : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ErrorOf<M extends Any> = M extends Machine<any, any, infer E, any> ? E : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ServicesOf<M extends Any> = M extends Machine<any, any, any, infer R> ? R : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type MachineErrorOf<M extends Any> = ErrorOf<M> | UnhandledEventError
+
+/**
+ * @since 4.0.0
+ * @category guards
+ */
+export const isMachine = (u: unknown): u is Any => Predicate.hasProperty(u, TypeId)
+
+const toEffect = <A, E, R>(value: A | Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+  Effect.isEffect(value) ? value : Effect.succeed(value)
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const make = <
+  const Events extends AnyEventTuple,
+  const States extends AnyStateTuple
+>(definition: {
+  readonly id?: string | undefined
+  readonly events: Events
+  readonly initial: Snapshot<StateSchemasOfStates<States>>
+  readonly states: States
+}): Builder<Schema.toTaggedUnion<"_tag", Events>, States> => {
+  const event = normalizeEventSchema(definition)
+  const initial = definition.initial
+  return {
+    [BuilderTypeId]: BuilderTypeId,
+    id: definition.id,
+    event,
+    snapshot: snapshotSchemaFromStates(definition.states),
+    initial,
+    states: definition.states,
+    handlers: (handlers) => ({
+      [TypeId]: TypeId,
+      id: definition.id,
+      event,
+      snapshot: snapshotSchemaFromStates(definition.states),
+      initial,
+      states: definition.states as any,
+      handlers: handlers as any
+    })
+  }
+}
+
+const snapshotSchemaFromStates = <const States extends AnyStateTuple>(states: States): AnyTaggedUnion =>
+  Schema.Union(states as any).pipe(Schema.toTaggedUnion("_tag")) as AnyTaggedUnion
+
+const normalizeEventSchema = <const Events extends AnyEventTuple>(
+  definition: { readonly events: Events }
+): Schema.toTaggedUnion<"_tag", Events> =>
+  Schema.Union(definition.events as any).pipe(Schema.toTaggedUnion("_tag")) as Schema.toTaggedUnion<"_tag", Events>
+
+/**
+ * @since 4.0.0
+ * @category accessors
+ */
+export const eventSchema = <M extends Any>(self: M): M["event"] => self.event
+
+/**
+ * @since 4.0.0
+ * @category accessors
+ */
+export const snapshotSchema = <M extends Any>(self: M): M["snapshot"] => self.snapshot
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const decodeEvent = <M extends Any>(self: M, input: unknown) =>
+  Schema.decodeUnknownEffect(self.event as any)(input) as Effect.Effect<
+    Event<M["event"]>,
+    Schema.SchemaError,
+    M["event"]["DecodingServices"]
+  >
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const decodeSnapshot = <M extends Any>(self: M, input: unknown) =>
+  Schema.decodeUnknownEffect(self.snapshot as any)(input) as Effect.Effect<
+    Snapshot<StateSchemasOf<M>>,
+    Schema.SchemaError,
+    M["snapshot"]["DecodingServices"]
+  >
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const initial = <M extends Any>(
+  self: M
+): Effect.Effect<Snapshot<StateSchemasOf<M>>> => Effect.succeed(self.initial as any)
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const plan = <
+  M extends Any,
+  Source extends Snapshot<StateSchemasOf<M>>
+>(
+  self: M,
+  snapshot: Source,
+  event: Event<M["event"]>
+): Effect.Effect<
+  Plan<StateSchemasOf<M>, M["event"], Source>,
+  MachineErrorOf<M>,
+  ServicesOf<M>
+> =>
+  Effect.gen(function*() {
+    const current = snapshot as Source
+    const currentEvent = event as Event<M["event"]>
+    const handlers = self.handlers[current._tag as keyof typeof self.handlers]
+    const handler = handlers?.[(currentEvent as { readonly _tag: string })._tag as keyof typeof handlers] as
+      | Handler<StateSchemasOf<M>, Source["_tag"], M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
+      | undefined
+    if (handler === undefined) {
+      return yield* Effect.fail(
+        new UnhandledEventError({
+          machineId: self.id,
+          state: current._tag,
+          event: (currentEvent as { readonly _tag: string })._tag
+        })
+      )
+    }
+    const { _tag: _, ...data } = current as any
+    const decision = yield* toEffect(handler({
+      snapshot: current as any,
+      data,
+      event: currentEvent as any
+    }))
+    const next = decision
+    return {
+      snapshot: current,
+      event: currentEvent,
+      next,
+      changed: next !== current
+    }
+  })
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const next = <
+  M extends Any,
+  Source extends Snapshot<StateSchemasOf<M>>
+>(
+  self: M,
+  snapshot: Source,
+  event: Event<M["event"]>
+): Effect.Effect<
+  Snapshot<StateSchemasOf<M>>,
+  MachineErrorOf<M>,
+  ServicesOf<M>
+> => Effect.map(plan(self, snapshot, event), (plan) => plan.next)
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const enabled = <
+  M extends Any,
+  Source extends Snapshot<StateSchemasOf<M>>
+>(
+  self: M,
+  snapshot: Source
+): Effect.Effect<ReadonlyArray<EventTag<M["event"]>>> =>
+  Effect.sync(() => {
+    const handlers = self.handlers[snapshot._tag as keyof typeof self.handlers] ?? {}
+    return Object.keys(handlers) as ReadonlyArray<EventTag<M["event"]>>
+  })
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const graph = <M extends Any>(self: M) => ({
+  id: self.id,
+  states: Object.keys(self.states)
+})
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const start = <M extends Any>(
+  machine: M
+): Effect.Effect<Actor<M>, never, Scope.Scope | ServicesOf<M>> =>
+  Effect.gen(function*() {
+    const initialSnapshot = yield* initial(machine)
+    const snapshots = yield* Ref.make(initialSnapshot)
+    const mailbox = yield* Queue.unbounded<Envelope<Event<M["event"]>, MachineErrorOf<M>>>()
+    const changesHub = yield* PubSub.unbounded<Snapshot<StateSchemasOf<M>>>()
+
+    const loop = Effect.gen(function*() {
+      while (true) {
+        const envelope = yield* Queue.take(mailbox)
+        const current = yield* Ref.get(snapshots)
+        const result = yield* exit(machine, current as any, envelope.event as any)
+        if (Exit.isSuccess(result)) {
+          yield* Ref.set(snapshots, result.value as any)
+          yield* PubSub.publish(changesHub, result.value as any)
+        }
+        yield* Deferred.succeed(envelope.ack, Exit.map(result, () => void 0))
+      }
+    })
+
+    yield* Effect.forkScoped(loop)
+    yield* Effect.addFinalizer(() => Queue.shutdown(mailbox))
+    yield* Effect.addFinalizer(() => PubSub.shutdown(changesHub))
+
+    const send = (event: Event<M["event"]>): Effect.Effect<void, MachineErrorOf<M>> =>
+      Effect.gen(function*() {
+        const ack = yield* Deferred.make<Exit.Exit<void, MachineErrorOf<M>>>()
+        yield* Queue.offer(mailbox, { event, ack })
+        const exit = yield* Deferred.await(ack)
+        return yield* Exit.match(exit, {
+          onSuccess: () => Effect.void,
+          onFailure: Effect.failCause
+        })
+      })
+
+    return {
+      send,
+      snapshot: Ref.get(snapshots),
+      changes: Stream.concat(Stream.make(initialSnapshot), Stream.fromPubSub(changesHub))
+    }
+  })
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const exit = <M extends Any>(self: M, snapshot: Snapshot<StateSchemasOf<M>>, event: Event<M["event"]>) =>
+  Effect.exit(next(self, snapshot, event))

--- a/packages/effect/src/unstable/machine/Machine.ts
+++ b/packages/effect/src/unstable/machine/Machine.ts
@@ -9,11 +9,11 @@ import * as PubSub from "../../PubSub.ts"
 import * as Queue from "../../Queue.ts"
 import * as Ref from "../../Ref.ts"
 import * as Schema from "../../Schema.ts"
+import * as SchemaAST from "../../SchemaAST.ts"
 import type * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
 const TypeId = "~effect/unstable/machine/Machine" as const
-const BuilderTypeId = "~effect/unstable/machine/Machine/Builder" as const
 
 type AnyTaggedEvent = Schema.Top & { readonly Type: { readonly _tag: PropertyKey } }
 type AnyTaggedUnion = Schema.Top & { readonly Type: { readonly _tag: PropertyKey }; readonly cases: any }
@@ -29,11 +29,16 @@ type AnyStateSchemas = Record<string, AnyTaggedState>
 type StateSchemasOfStates<States extends AnyStateTuple> = {
   readonly [State in States[number] as State["Type"]["_tag"] & string]: State
 }
+type ScopePrefixes<Tag extends string> = Tag extends `${infer Head}.${infer Tail}`
+  ? Head | `${Head}.${ScopePrefixes<Tail>}`
+  : Tag
+type ScopesOfStates<States extends AnyStateSchemas> = {
+  readonly [Name in keyof States & string]: ScopePrefixes<Name>
+}[keyof States & string]
+type StatesInScope<States extends AnyStateSchemas, Scope extends string> = {
+  readonly [Name in keyof States & string as Name extends Scope | `${Scope}.${string}` ? Name : never]: States[Name]
+}
 type DataSchema<StateSchemas extends AnyStateSchemas, Name extends keyof StateSchemas & string> = StateSchemas[Name]
-type StatePayload<StateSchemas extends AnyStateSchemas, Name extends keyof StateSchemas & string> = Omit<
-  DataSchema<StateSchemas, Name>["~type.make.in"],
-  "_tag"
->
 type InputValue<InputSchema> = InputSchema extends Schema.Top ? Schema.Schema.Type<InputSchema> : never
 type Initializer<InputSchema, State> = [InputSchema] extends [undefined] ? () => State
   : (args: { readonly input: InputValue<InputSchema> }) => State
@@ -43,10 +48,16 @@ type Initializer<InputSchema, State> = [InputSchema] extends [undefined] ? () =>
  * @category models
  */
 export type Snapshot<StateSchemas extends AnyStateSchemas> = {
-  readonly [Name in keyof StateSchemas & string]:
-    & { readonly _tag: Name }
-    & Schema.Schema.Type<DataSchema<StateSchemas, Name>>
+  readonly [Name in keyof StateSchemas & string]: Schema.Schema.Type<DataSchema<StateSchemas, Name>>
 }[keyof StateSchemas & string]
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ReducedSnapshot<StateSchemas extends AnyStateSchemas> = {
+  readonly [Name in keyof StateSchemas & string]: Schema.Schema.Type<DataSchema<StateSchemas, Name>>
+}[keyof StateSchemas & string] extends infer Q ? Q : never
 
 /**
  * @since 4.0.0
@@ -71,11 +82,10 @@ export type Transition<StateSchemas extends AnyStateSchemas> = Snapshot<StateSch
 export interface HandlerArgs<
   EventSchema extends AnyEventSchema,
   StateSchemas extends AnyStateSchemas,
-  Source extends keyof StateSchemas & string,
+  Source extends ScopesOfStates<StateSchemas>,
   Tag extends EventTag<EventSchema>
 > {
-  readonly snapshot: Extract<Snapshot<StateSchemas>, { readonly _tag: Source }>
-  readonly data: StatePayload<StateSchemas, Source>
+  readonly state: ReducedSnapshot<StatesInScope<StateSchemas, Source>>
   readonly event: EventByTag<EventSchema, Tag>
 }
 
@@ -85,7 +95,7 @@ export interface HandlerArgs<
  */
 export type Handler<
   StateSchemas extends AnyStateSchemas,
-  Source extends keyof StateSchemas & string,
+  Source extends ScopesOfStates<StateSchemas>,
   EventSchema extends AnyEventSchema,
   Tag extends EventTag<EventSchema>,
   E = never,
@@ -101,20 +111,14 @@ export type Handler<
 export type Handlers<
   EventSchema extends AnyEventSchema,
   StateSchemas extends AnyStateSchemas,
+  Scope extends ScopesOfStates<StateSchemas>,
   E = never,
   R = never
 > = {
-  readonly [Name in keyof StateSchemas & string]?: {
-    readonly [Tag in EventTag<EventSchema>]?: Handler<StateSchemas, Name, EventSchema, Tag, E, R>
-  }
+  readonly [Tag in EventTag<EventSchema>]?: Handler<StateSchemas, Scope, EventSchema, Tag, E, R>
 }
 
-type HandlerUnion<HandlersDef extends Record<string, any>> = {
-  readonly [Name in keyof HandlersDef & string]: Exclude<
-    HandlersDef[Name],
-    undefined
-  >[keyof Exclude<HandlersDef[Name], undefined>]
-}[keyof HandlersDef & string]
+type HandlerUnion<HandlersDef extends Record<string, any>> = Exclude<HandlersDef[keyof HandlersDef], undefined>
 
 type InferHandlerError<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
   (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, infer E, any> ? E : never
@@ -157,7 +161,18 @@ export interface Machine<
   readonly snapshot: AnyTaggedUnion
   readonly initial: Initializer<InputSchema, Snapshot<StateSchemas>>
   readonly states: { readonly [Name in keyof StateSchemas & string]: DataSchema<StateSchemas, Name> }
-  readonly handlers: Handlers<EventSchema, StateSchemas, E, R>
+  readonly scopedHandlers: Partial<Record<ScopesOfStates<StateSchemas>, Handlers<EventSchema, StateSchemas, any, E, R>>>
+  readonly handlers: <Scope extends ScopesOfStates<StateSchemas>>(
+    scope: Scope
+  ) => <HandlersDef extends Handlers<EventSchema, StateSchemas, Scope, any, any>>(
+    handlers: HandlersDef
+  ) => Machine<
+    EventSchema,
+    StateSchemas,
+    InputSchema,
+    InferHandlerError<HandlersDef> | E,
+    InferHandlerServices<HandlersDef> | R
+  >
 }
 
 /**
@@ -186,33 +201,6 @@ export interface Actor<M extends Any> {
 interface Envelope<E, A> {
   readonly event: E
   readonly ack: Deferred.Deferred<Exit.Exit<void, A>>
-}
-
-/**
- * @since 4.0.0
- * @category models
- */
-export interface Builder<
-  EventSchema extends AnyEventSchema,
-  States extends AnyStateTuple,
-  InputSchema = undefined
-> {
-  readonly [BuilderTypeId]: typeof BuilderTypeId
-  readonly id: string | undefined
-  readonly input: InputSchema
-  readonly event: EventSchema
-  readonly snapshot: AnyTaggedUnion
-  readonly initial: Initializer<InputSchema, Snapshot<StateSchemasOfStates<States>>>
-  readonly states: States
-  readonly handlers: <HandlersDef extends Handlers<EventSchema, StateSchemasOfStates<States>, any, any>>(
-    handlers: HandlersDef
-  ) => Machine<
-    EventSchema,
-    StateSchemasOfStates<States>,
-    InputSchema,
-    InferHandlerError<HandlersDef>,
-    InferHandlerServices<HandlersDef>
-  >
 }
 
 /**
@@ -268,6 +256,15 @@ export const isMachine = (u: unknown): u is Any => Predicate.hasProperty(u, Type
 const toEffect = <A, E, R>(value: A | Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
   Effect.isEffect(value) ? value : Effect.succeed(value)
 
+const scopesOf = (tag: string): ReadonlyArray<string> => {
+  const segments = tag.split(".")
+  const scopes = new Array<string>(segments.length)
+  for (let i = segments.length; i >= 1; i--) {
+    scopes[segments.length - i] = segments.slice(0, i).join(".")
+  }
+  return scopes
+}
+
 /**
  * @since 4.0.0
  * @category constructors
@@ -282,32 +279,52 @@ export const make = <
   readonly events: Events
   readonly initial: Initializer<InputSchema, Snapshot<StateSchemasOfStates<States>>>
   readonly states: States
-}): Builder<Schema.toTaggedUnion<"_tag", Events>, States, InputSchema> => {
+}): Machine<Schema.toTaggedUnion<"_tag", Events>, StateSchemasOfStates<States>, InputSchema> => {
   const event = normalizeEventSchema(definition)
   const initial = definition.initial
-  return {
-    [BuilderTypeId]: BuilderTypeId,
+  const snapshot = snapshotSchemaFromStates(definition.states)
+  const states = Object.fromEntries(definition.states.map((state) => [stateTag(state), state])) as {
+    readonly [Name in keyof StateSchemasOfStates<States> & string]: DataSchema<StateSchemasOfStates<States>, Name>
+  }
+  const makeMachine = <E, R>(
+    scopedHandlers: Partial<
+      Record<
+        ScopesOfStates<StateSchemasOfStates<States>>,
+        Handlers<typeof event, StateSchemasOfStates<States>, any, any, any>
+      >
+    >
+  ): Machine<typeof event, StateSchemasOfStates<States>, InputSchema, E, R> => ({
+    [TypeId]: TypeId,
     id: definition.id,
     input: definition.input as InputSchema,
     event,
-    snapshot: snapshotSchemaFromStates(definition.states),
+    snapshot,
     initial,
-    states: definition.states,
-    handlers: (handlers) => ({
-      [TypeId]: TypeId,
-      id: definition.id,
-      input: definition.input as InputSchema,
-      event,
-      snapshot: snapshotSchemaFromStates(definition.states),
-      initial,
-      states: definition.states as any,
-      handlers: handlers as any
-    })
-  }
+    states,
+    scopedHandlers: scopedHandlers as any,
+    handlers: (scope) => (handlers) =>
+      makeMachine<InferHandlerError<typeof handlers> | E, InferHandlerServices<typeof handlers> | R>({
+        ...scopedHandlers,
+        [scope]: handlers
+      })
+  })
+  return makeMachine<never, never>({})
 }
 
 const snapshotSchemaFromStates = <const States extends AnyStateTuple>(states: States): AnyTaggedUnion =>
   Schema.Union(states as any).pipe(Schema.toTaggedUnion("_tag")) as AnyTaggedUnion
+
+const stateTag = (state: AnyTaggedState): string => {
+  const ast = SchemaAST.toEncoded((state as Schema.Top).ast)
+  if (!SchemaAST.isObjects(ast)) {
+    throw new Error("Machine states must be object-like tagged schemas")
+  }
+  const tagField = ast.propertySignatures.find((property) => property.name === "_tag")
+  if (tagField === undefined || !SchemaAST.isLiteral(tagField.type) || typeof tagField.type.literal !== "string") {
+    throw new Error("Machine states must have a string literal _tag")
+  }
+  return tagField.type.literal
+}
 
 const normalizeEventSchema = <const Events extends AnyEventTuple>(
   definition: { readonly events: Events }
@@ -358,23 +375,31 @@ export const transition = <
   Effect.gen(function*() {
     const current = snapshot as Source
     const currentEvent = event as Event<M["event"]>
-    const handlers = self.handlers[current._tag as keyof typeof self.handlers]
-    const handler = handlers?.[(currentEvent as { readonly _tag: string })._tag as keyof typeof handlers] as
-      | Handler<StateSchemasOf<M>, Source["_tag"], M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
-      | undefined
+    const eventTag = (currentEvent as { readonly _tag: string })._tag
+    let handler:
+      | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
+      | undefined = undefined
+    for (const scope of scopesOf(current._tag)) {
+      const handlers = self.scopedHandlers[scope as keyof typeof self.scopedHandlers]
+      const candidate = handlers?.[eventTag as keyof typeof handlers] as
+        | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
+        | undefined
+      if (candidate !== undefined) {
+        handler = candidate
+        break
+      }
+    }
     if (handler === undefined) {
       return yield* Effect.fail(
         new UnhandledEventError({
           machineId: self.id,
           state: current._tag,
-          event: (currentEvent as { readonly _tag: string })._tag
+          event: eventTag
         })
       )
     }
-    const { _tag: _, ...data } = current as any
     const decision = yield* toEffect(handler({
-      snapshot: current as any,
-      data,
+      state: current as any,
       event: currentEvent as any
     }))
     const next = decision
@@ -414,8 +439,14 @@ export const enabled = <
   self: M,
   snapshot: Source
 ): ReadonlyArray<EventTag<M["event"]>> => {
-  const handlers = self.handlers[snapshot._tag as keyof typeof self.handlers] ?? {}
-  return Object.keys(handlers) as ReadonlyArray<EventTag<M["event"]>>
+  const enabled = new Set<EventTag<M["event"]>>()
+  for (const scope of scopesOf(snapshot._tag)) {
+    const handlers = self.scopedHandlers[scope as keyof typeof self.scopedHandlers] ?? {}
+    for (const key of Object.keys(handlers)) {
+      enabled.add(key as EventTag<M["event"]>)
+    }
+  }
+  return Array.from(enabled)
 }
 
 /**

--- a/packages/effect/src/unstable/machine/Machine.ts
+++ b/packages/effect/src/unstable/machine/Machine.ts
@@ -10,10 +10,12 @@ import * as Queue from "../../Queue.ts"
 import * as Ref from "../../Ref.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaAST from "../../SchemaAST.ts"
+import * as ServiceMap from "../../ServiceMap.ts"
 import type * as Scope from "../../Scope.ts"
 import * as Stream from "../../Stream.ts"
 
 const TypeId = "~effect/unstable/machine/Machine" as const
+declare const HandlerContextTypeId: unique symbol
 
 type AnyTaggedEvent = Schema.Top & { readonly Type: { readonly _tag: PropertyKey } }
 type AnyTaggedUnion = Schema.Top & { readonly Type: { readonly _tag: PropertyKey }; readonly cases: any }
@@ -118,14 +120,65 @@ export type Handlers<
   readonly [Tag in EventTag<EventSchema>]?: Handler<StateSchemas, Scope, EventSchema, Tag, E, R>
 }
 
+type HandlerDefinitions<
+  EventSchema extends AnyEventSchema,
+  StateSchemas extends AnyStateSchemas,
+  Scope extends ScopesOfStates<StateSchemas>
+> = {
+  readonly [Tag in EventTag<EventSchema>]?: (
+    args: HandlerArgs<EventSchema, StateSchemas, Scope, Tag>
+  ) => Snapshot<StateSchemas> | Effect.Effect<Snapshot<StateSchemas>, any, any>
+}
+
 type HandlerUnion<HandlersDef extends Record<string, any>> = Exclude<HandlersDef[keyof HandlersDef], undefined>
 
+/**
+ * @since 4.0.0
+ * @category context
+ */
+export class HandlerContext extends ServiceMap.Service<HandlerContext, {
+  readonly defer: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<void, never, HandlerContext.Marker<E, R>>
+  readonly read: Effect.Effect<ReadonlyArray<Effect.Effect<void, any, any>>>
+}>()("effect/unstable/machine/Machine/HandlerContext") {}
+
+export declare namespace HandlerContext {
+  export interface Marker<E = never, R = never> {
+    readonly [HandlerContextTypeId]: {
+      readonly _E: (_: never) => E
+      readonly _R: (_: never) => R
+    }
+  }
+}
+
+type DeferredMarker = HandlerContext.Marker<any, any>
+type DeferredMarkerFromServices<R> = Extract<R, DeferredMarker>
+type InferDeferredErrorFromServices<R> = [DeferredMarkerFromServices<R>] extends [never] ? never
+  : DeferredMarkerFromServices<R> extends HandlerContext.Marker<infer E, any> ? E
+  : never
+type InferDeferredServicesFromServices<R> = [DeferredMarkerFromServices<R>] extends [never] ? never
+  : DeferredMarkerFromServices<R> extends HandlerContext.Marker<any, infer R> ? R
+  : never
+type StripHandlerContext<R> = Exclude<R, HandlerContext | DeferredMarker>
+
 type InferHandlerError<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
-  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, infer E, any> ? E : never
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, any> ? Effect.Error<Return> : never
   : never
 
 type InferHandlerServices<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
-  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, infer R> ? R : never
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, any> ? StripHandlerContext<Effect.Services<Return>>
+  : never
+  : never
+
+type InferDeferredError<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, any>
+    ? InferDeferredErrorFromServices<Effect.Services<Return>>
+  : never
+  : never
+
+type InferDeferredServices<HandlersDef extends Record<string, any>> = HandlerUnion<HandlersDef> extends
+  (...args: Array<any>) => infer Return ? Return extends Effect.Effect<any, any, any>
+    ? InferDeferredServicesFromServices<Effect.Services<Return>>
+  : never
   : never
 
 /**
@@ -152,7 +205,9 @@ export interface Machine<
   StateSchemas extends AnyStateSchemas,
   InputSchema = undefined,
   E = never,
-  R = never
+  R = never,
+  DeferredE = never,
+  DeferredR = never
 > {
   readonly [TypeId]: typeof TypeId
   readonly id: string | undefined
@@ -161,17 +216,19 @@ export interface Machine<
   readonly snapshot: AnyTaggedUnion
   readonly initial: Initializer<InputSchema, Snapshot<StateSchemas>>
   readonly states: { readonly [Name in keyof StateSchemas & string]: DataSchema<StateSchemas, Name> }
-  readonly scopedHandlers: Partial<Record<ScopesOfStates<StateSchemas>, Handlers<EventSchema, StateSchemas, any, E, R>>>
+  readonly scopedHandlers: Partial<Record<ScopesOfStates<StateSchemas>, Handlers<EventSchema, StateSchemas, any, any, any>>>
   readonly handlers: <Scope extends ScopesOfStates<StateSchemas>>(
     scope: Scope
-  ) => <HandlersDef extends Handlers<EventSchema, StateSchemas, Scope, any, any>>(
+  ) => <HandlersDef extends HandlerDefinitions<EventSchema, StateSchemas, Scope>>(
     handlers: HandlersDef
   ) => Machine<
     EventSchema,
     StateSchemas,
     InputSchema,
     InferHandlerError<HandlersDef> | E,
-    InferHandlerServices<HandlersDef> | R
+    InferHandlerServices<HandlersDef> | R,
+    InferDeferredError<HandlersDef> | DeferredE,
+    InferDeferredServices<HandlersDef> | DeferredR
   >
 }
 
@@ -207,20 +264,20 @@ interface Envelope<E, A> {
  * @since 4.0.0
  * @category models
  */
-export type Any = Machine<any, any, any, any, any>
+export type Any = Machine<any, any, any, any, any, any, any>
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type StateSchemasOf<M extends Any> = M extends Machine<any, infer StateSchemas, any, any, any> ? StateSchemas
+export type StateSchemasOf<M extends Any> = M extends Machine<any, infer StateSchemas, any, any, any, any, any> ? StateSchemas
   : never
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type InputSchemaOf<M extends Any> = M extends Machine<any, any, infer InputSchema, any, any> ? InputSchema
+export type InputSchemaOf<M extends Any> = M extends Machine<any, any, infer InputSchema, any, any, any, any> ? InputSchema
   : never
 
 /**
@@ -233,19 +290,60 @@ export type InputOf<M extends Any> = InputValue<InputSchemaOf<M>>
  * @since 4.0.0
  * @category models
  */
-export type ErrorOf<M extends Any> = M extends Machine<any, any, any, infer E, any> ? E : never
+export type ImmediateErrorOf<M extends Any> = M extends Machine<any, any, any, infer E, any, any, any> ? E : never
 
 /**
  * @since 4.0.0
  * @category models
  */
-export type ServicesOf<M extends Any> = M extends Machine<any, any, any, any, infer R> ? R : never
+export type ImmediateServicesOf<M extends Any> = M extends Machine<any, any, any, any, infer R, any, any> ? R : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type DeferredErrorOf<M extends Any> = M extends Machine<any, any, any, any, any, infer E, any> ? E : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type DeferredServicesOf<M extends Any> = M extends Machine<any, any, any, any, any, any, infer R> ? R : never
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ErrorOf<M extends Any> = ImmediateErrorOf<M> | DeferredErrorOf<M>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type ServicesOf<M extends Any> = ImmediateServicesOf<M> | DeferredServicesOf<M>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type PlanErrorOf<M extends Any> = ImmediateErrorOf<M>
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export type PlanServicesOf<M extends Any> = ImmediateServicesOf<M>
 
 /**
  * @since 4.0.0
  * @category models
  */
 export type MachineErrorOf<M extends Any> = ErrorOf<M> | UnhandledEventError
+
+type EvaluateServicesOf<M extends Any> =
+  | ImmediateServicesOf<M>
+  | HandlerContext
+  | HandlerContext.Marker<DeferredErrorOf<M>, DeferredServicesOf<M>>
 
 /**
  * @since 4.0.0
@@ -286,14 +384,14 @@ export const make = <
   const states = Object.fromEntries(definition.states.map((state) => [stateTag(state), state])) as {
     readonly [Name in keyof StateSchemasOfStates<States> & string]: DataSchema<StateSchemasOfStates<States>, Name>
   }
-  const makeMachine = <E, R>(
+  const makeMachine = <E, R, DeferredE, DeferredR>(
     scopedHandlers: Partial<
       Record<
         ScopesOfStates<StateSchemasOfStates<States>>,
         Handlers<typeof event, StateSchemasOfStates<States>, any, any, any>
       >
     >
-  ): Machine<typeof event, StateSchemasOfStates<States>, InputSchema, E, R> => ({
+  ): Machine<typeof event, StateSchemasOfStates<States>, InputSchema, E, R, DeferredE, DeferredR> => ({
     [TypeId]: TypeId,
     id: definition.id,
     input: definition.input as InputSchema,
@@ -303,12 +401,17 @@ export const make = <
     states,
     scopedHandlers: scopedHandlers as any,
     handlers: (scope) => (handlers) =>
-      makeMachine<InferHandlerError<typeof handlers> | E, InferHandlerServices<typeof handlers> | R>({
+      makeMachine<
+        InferHandlerError<typeof handlers> | E,
+        InferHandlerServices<typeof handlers> | R,
+        InferDeferredError<typeof handlers> | DeferredE,
+        InferDeferredServices<typeof handlers> | DeferredR
+      >({
         ...scopedHandlers,
-        [scope]: handlers
+        [scope]: handlers as Handlers<typeof event, StateSchemasOfStates<States>, typeof scope, any, any>
       })
   })
-  return makeMachine<never, never>({})
+  return makeMachine<never, never, never, never>({})
 }
 
 const snapshotSchemaFromStates = <const States extends AnyStateTuple>(states: States): AnyTaggedUnion =>
@@ -353,8 +456,124 @@ const resolveInitial = <M extends Any>(self: M, args: ReadonlyArray<InputOf<M>>)
 export const initial = <M extends Any>(
   self: M,
   ...args: InitialArguments<M>
-): Effect.Effect<Snapshot<StateSchemasOf<M>>> =>
-  Effect.sync(() => resolveInitial(self, args as ReadonlyArray<InputOf<M>>))
+): Snapshot<StateSchemasOf<M>> => resolveInitial(self, args as ReadonlyArray<InputOf<M>>)
+
+/**
+ * @since 4.0.0
+ * @category accessors
+ */
+export const defer = <A, E, R>(
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<void, never, HandlerContext | HandlerContext.Marker<E, R>> =>
+  Effect.gen(function*() {
+    const context = yield* HandlerContext
+    return yield* context.defer(effect)
+  })
+
+interface EvaluatedPlan<
+  StateSchemas extends AnyStateSchemas,
+  EventSchema extends AnyEventSchema,
+  Source extends Snapshot<StateSchemas>,
+  DeferredE = never,
+  DeferredR = never
+> {
+  readonly plan: Plan<StateSchemas, EventSchema, Source>
+  readonly deferred: ReadonlyArray<Effect.Effect<void, DeferredE, DeferredR>>
+}
+
+const makeHandlerContext = (): HandlerContext["Service"] => {
+  const deferred: Array<Effect.Effect<void, any, any>> = []
+  return HandlerContext.of({
+    defer: <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<void, never, HandlerContext.Marker<E, R>> =>
+      Effect.sync(() => {
+        deferred.push(Effect.asVoid(effect))
+      }),
+    read: Effect.sync(() => deferred)
+  })
+}
+
+const runDeferred = <E, R>(
+  deferred: ReadonlyArray<Effect.Effect<void, E, R>>
+): Effect.Effect<void, E, R> =>
+  Effect.forEach(deferred, (effect) => effect, { discard: true })
+
+const evaluate = <
+  M extends Any,
+  Source extends Snapshot<StateSchemasOf<M>>
+>(
+  self: M,
+  snapshot: Source,
+  event: Event<M["event"]>
+): Effect.Effect<
+  EvaluatedPlan<StateSchemasOf<M>, M["event"], Source, DeferredErrorOf<M>, DeferredServicesOf<M>>,
+  UnhandledEventError | PlanErrorOf<M>,
+  PlanServicesOf<M>
+> =>
+  Effect.gen(function*() {
+    const current = snapshot as Source
+    const currentEvent = event as Event<M["event"]>
+    const eventTag = (currentEvent as { readonly _tag: string })._tag
+    let handler:
+      | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, PlanErrorOf<M>, EvaluateServicesOf<M>>
+      | undefined = undefined
+    for (const scope of scopesOf(current._tag)) {
+      const handlers = self.scopedHandlers[scope as keyof typeof self.scopedHandlers]
+      const candidate = handlers?.[eventTag as keyof typeof handlers] as
+        | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, PlanErrorOf<M>, EvaluateServicesOf<M>>
+        | undefined
+      if (candidate !== undefined) {
+        handler = candidate
+        break
+      }
+    }
+    if (handler === undefined) {
+      return yield* Effect.fail(
+        new UnhandledEventError({
+          machineId: self.id,
+          state: current._tag,
+          event: eventTag
+        })
+      )
+    }
+    const handlerContext = makeHandlerContext()
+    const next = yield* (toEffect(handler({
+      state: current as any,
+      event: currentEvent as any
+    })).pipe(Effect.provideService(HandlerContext, handlerContext)) as Effect.Effect<
+      Snapshot<StateSchemasOf<M>>,
+      PlanErrorOf<M>,
+      PlanServicesOf<M>
+    >)
+    const deferred = (yield* handlerContext.read) as ReadonlyArray<
+      Effect.Effect<void, DeferredErrorOf<M>, DeferredServicesOf<M>>
+    >
+    return {
+      plan: {
+        snapshot: current,
+        event: currentEvent,
+        next,
+        changed: next !== current
+      },
+      deferred
+    }
+  })
+
+/**
+ * @since 4.0.0
+ * @category constructors
+ */
+export const plan = <
+  M extends Any,
+  Source extends Snapshot<StateSchemasOf<M>>
+>(
+  self: M,
+  snapshot: Source,
+  event: Event<M["event"]>
+): Effect.Effect<
+  Plan<StateSchemasOf<M>, M["event"], Source>,
+  UnhandledEventError | PlanErrorOf<M>,
+  PlanServicesOf<M>
+> => Effect.map(evaluate(self, snapshot, event), (_) => _.plan)
 
 /**
  * @since 4.0.0
@@ -373,42 +592,9 @@ export const transition = <
   ServicesOf<M>
 > =>
   Effect.gen(function*() {
-    const current = snapshot as Source
-    const currentEvent = event as Event<M["event"]>
-    const eventTag = (currentEvent as { readonly _tag: string })._tag
-    let handler:
-      | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
-      | undefined = undefined
-    for (const scope of scopesOf(current._tag)) {
-      const handlers = self.scopedHandlers[scope as keyof typeof self.scopedHandlers]
-      const candidate = handlers?.[eventTag as keyof typeof handlers] as
-        | Handler<StateSchemasOf<M>, any, M["event"], EventTag<M["event"]>, ErrorOf<M>, ServicesOf<M>>
-        | undefined
-      if (candidate !== undefined) {
-        handler = candidate
-        break
-      }
-    }
-    if (handler === undefined) {
-      return yield* Effect.fail(
-        new UnhandledEventError({
-          machineId: self.id,
-          state: current._tag,
-          event: eventTag
-        })
-      )
-    }
-    const decision = yield* toEffect(handler({
-      state: current as any,
-      event: currentEvent as any
-    }))
-    const next = decision
-    return {
-      snapshot: current,
-      event: currentEvent,
-      next,
-      changed: next !== current
-    }
+    const evaluated = yield* evaluate(self, snapshot, event)
+    yield* runDeferred(evaluated.deferred)
+    return evaluated.plan
   })
 
 /**
@@ -476,10 +662,16 @@ export const start = <M extends Any>(
       while (true) {
         const envelope = yield* Queue.take(mailbox)
         const current = yield* Ref.get(snapshots)
-        const result = yield* Effect.exit(next(machine, current as any, envelope.event as any))
+        const result = yield* Effect.exit(evaluate(machine, current as any, envelope.event as any))
         if (Exit.isSuccess(result)) {
-          yield* Ref.set(snapshots, result.value as any)
-          yield* PubSub.publish(changesHub, result.value as any)
+          yield* Ref.set(snapshots, result.value.plan.next as any)
+          yield* PubSub.publish(changesHub, result.value.plan.next as any)
+          const deferredResult = yield* Effect.exit(runDeferred(result.value.deferred))
+          yield* Deferred.succeed(
+            envelope.ack,
+            Exit.isSuccess(deferredResult) ? Exit.succeed<void>(void 0) : deferredResult
+          )
+          continue
         }
         yield* Deferred.succeed(envelope.ack, Exit.map(result, () => void 0))
       }

--- a/packages/effect/test/unstable/machine/Machine.test.ts
+++ b/packages/effect/test/unstable/machine/Machine.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Ref, Schema, ServiceMap } from "effect"
+import { Effect, Ref, Schema } from "effect"
+import * as Context from "effect/Context"
 import * as Machine from "effect/unstable/machine/Machine"
 
 describe("Machine", () => {
@@ -63,7 +64,7 @@ describe("Machine", () => {
     {}
   ) {}
 
-  class DeferredLog extends ServiceMap.Service<DeferredLog, {
+  class DeferredLog extends Context.Service<DeferredLog, {
     readonly push: (message: string) => Effect.Effect<void>
     readonly read: Effect.Effect<ReadonlyArray<string>>
   }>()("test/Machine/DeferredLog") {}

--- a/packages/effect/test/unstable/machine/Machine.test.ts
+++ b/packages/effect/test/unstable/machine/Machine.test.ts
@@ -38,20 +38,44 @@ describe("Machine", () => {
     { userId: Schema.String }
   ) {}
 
+  class AuthenticatedIdle extends Schema.TaggedClass<AuthenticatedIdle, { readonly _: unique symbol }>()(
+    "Authenticated.Idle",
+    { userId: Schema.String }
+  ) {}
+
+  class AuthenticatedRefreshing extends Schema.TaggedClass<AuthenticatedRefreshing, { readonly _: unique symbol }>()(
+    "Authenticated.Refreshing",
+    { userId: Schema.String }
+  ) {}
+
+  class Logout extends Schema.TaggedClass<Logout, { readonly _: unique symbol }>()(
+    "Logout",
+    {}
+  ) {}
+
+  class Refresh extends Schema.TaggedClass<Refresh, { readonly _: unique symbol }>()(
+    "Refresh",
+    {}
+  ) {}
+
+  class Unauthenticated extends Schema.TaggedClass<Unauthenticated, { readonly _: unique symbol }>()(
+    "Unauthenticated",
+    {}
+  ) {}
+
   const UserMachine = Machine.make({
     id: "UserMachine",
     events: [Create, Rename, Delete],
     initial: () => new Uncreated({}),
     states: [Uncreated, Created, Deleted]
-  }).handlers({
-    Uncreated: {
-      Create: ({ event }) => Effect.succeed(new Created({ user: { id: "user-1", email: event.email } }))
-    },
-    Created: {
-      Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
-      Delete: ({ data }) => new Deleted({ userId: data.user.id })
-    }
   })
+    .handlers("Uncreated")({
+      Create: ({ event }) => Effect.succeed(new Created({ user: { id: "user-1", email: event.email } }))
+    })
+    .handlers("Created")({
+      Rename: ({ state, event }) => new Created({ user: { ...state.user, email: event.email } }),
+      Delete: ({ state }) => new Deleted({ userId: state.user.id })
+    })
 
   it.effect("supports state-dependent snapshots", () =>
     Effect.gen(function*() {
@@ -92,45 +116,41 @@ describe("Machine", () => {
     }))
 
   it.effect("machine actor processes events sequentially", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const actor = yield* Machine.start(UserMachine)
+    Effect.gen(function*() {
+      const actor = yield* Machine.start(UserMachine)
 
-        yield* actor.send(new Create({ email: "a@example.com" }))
-        yield* actor.send(new Rename({ email: "b@example.com" }))
+      yield* actor.send(new Create({ email: "a@example.com" }))
+      yield* actor.send(new Rename({ email: "b@example.com" }))
 
-        const snapshot = yield* actor.snapshot
-        assert.instanceOf(snapshot, Created)
-        assert.strictEqual(snapshot._tag, "Created")
-        assert.deepStrictEqual(snapshot.user, {
-          id: "user-1",
-          email: "b@example.com"
-        })
+      const snapshot = yield* actor.snapshot
+      assert.instanceOf(snapshot, Created)
+      assert.strictEqual(snapshot._tag, "Created")
+      assert.deepStrictEqual(snapshot.user, {
+        id: "user-1",
+        email: "b@example.com"
       })
-    ))
+    }))
 
   it.effect("fails with UnhandledEventError for invalid events in the current state", () =>
-    Effect.scoped(
-      Effect.gen(function*() {
-        const initial = yield* Machine.initial(UserMachine)
-        const planError = yield* Effect.flip(Machine.next(UserMachine, initial, new Rename({ email: "x@example.com" })))
+    Effect.gen(function*() {
+      const initial = yield* Machine.initial(UserMachine)
+      const planError = yield* Effect.flip(Machine.next(UserMachine, initial, new Rename({ email: "x@example.com" })))
 
-        assert.instanceOf(planError, Machine.UnhandledEventError)
-        assert.strictEqual(planError._tag, "UnhandledEventError")
-        assert.strictEqual(planError.machineId, "UserMachine")
-        assert.strictEqual(planError.state, "Uncreated")
-        assert.strictEqual(planError.event, "Rename")
+      assert.instanceOf(planError, Machine.UnhandledEventError)
+      assert.strictEqual(planError._tag, "UnhandledEventError")
+      assert.strictEqual(planError.machineId, "UserMachine")
+      assert.strictEqual(planError.state, "Uncreated")
+      assert.strictEqual(planError.event, "Rename")
 
-        const actor = yield* Machine.start(UserMachine)
-        const sendError = yield* Effect.flip(actor.send(new Rename({ email: "x@example.com" })))
+      const actor = yield* Machine.start(UserMachine)
+      const sendError = yield* Effect.flip(actor.send(new Rename({ email: "x@example.com" })))
 
-        assert.instanceOf(sendError, Machine.UnhandledEventError)
-        assert.strictEqual(sendError._tag, "UnhandledEventError")
-        assert.strictEqual(sendError.machineId, "UserMachine")
-        assert.strictEqual(sendError.state, "Uncreated")
-        assert.strictEqual(sendError.event, "Rename")
-      })
-    ))
+      assert.instanceOf(sendError, Machine.UnhandledEventError)
+      assert.strictEqual(sendError._tag, "UnhandledEventError")
+      assert.strictEqual(sendError.machineId, "UserMachine")
+      assert.strictEqual(sendError.state, "Uncreated")
+      assert.strictEqual(sendError.event, "Rename")
+    }))
 
   it.effect("supports schema-backed input for initial state", () =>
     Effect.gen(function*() {
@@ -143,12 +163,11 @@ describe("Machine", () => {
         events: [Rename, Delete],
         states: [Uncreated, Created, Deleted],
         initial: ({ input }) => new Created({ user: input.user })
-      }).handlers({
-        Created: {
-          Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
-          Delete: ({ data }) => new Deleted({ userId: data.user.id })
-        }
       })
+        .handlers("Created")({
+          Rename: ({ state, event }) => new Created({ user: { ...state.user, email: event.email } }),
+          Delete: ({ state }) => new Deleted({ userId: state.user.id })
+        })
 
       const initial = yield* Machine.initial(InputMachine, {
         user: {
@@ -162,5 +181,75 @@ describe("Machine", () => {
         id: "seed",
         email: "seed@example.com"
       })
+    }))
+
+  it.effect("starts an actor with schema-backed input", () =>
+    Effect.gen(function*() {
+      const ExistingUserInput = Schema.Struct({
+        user: User
+      })
+
+      const InputMachine = Machine.make({
+        input: ExistingUserInput,
+        events: [Rename, Delete],
+        states: [Uncreated, Created, Deleted],
+        initial: ({ input }) => new Created({ user: input.user })
+      })
+        .handlers("Created")({
+          Rename: ({ state, event }) => new Created({ user: { ...state.user, email: event.email } }),
+          Delete: ({ state }) => new Deleted({ userId: state.user.id })
+        })
+
+      const actor = yield* Machine.start(InputMachine, {
+        user: {
+          id: "seed",
+          email: "seed@example.com"
+        }
+      })
+
+      const initial = yield* actor.snapshot
+
+      assert.instanceOf(initial, Created)
+      assert.deepStrictEqual(initial.user, {
+        id: "seed",
+        email: "seed@example.com"
+      })
+
+      yield* actor.send(new Rename({ email: "updated@example.com" }))
+
+      const updated = yield* actor.snapshot
+
+      assert.instanceOf(updated, Created)
+      assert.deepStrictEqual(updated.user, {
+        id: "seed",
+        email: "updated@example.com"
+      })
+    }))
+
+  it.effect("bubbles handler lookup through dotted parent scopes", () =>
+    Effect.gen(function*() {
+      const LoginInput = Schema.Struct({
+        userId: Schema.String
+      })
+
+      const RefreshMachine = Machine.make({
+        input: LoginInput,
+        events: [Logout, Refresh],
+        states: [Unauthenticated, AuthenticatedIdle, AuthenticatedRefreshing],
+        initial: ({ input }) => new AuthenticatedIdle({ userId: input.userId })
+      })
+        .handlers("Authenticated")({
+          Logout: () => new Unauthenticated({})
+        })
+        .handlers("Authenticated.Idle")({
+          Refresh: ({ state }) => new AuthenticatedRefreshing({ userId: state.userId })
+        })
+
+      const initial = yield* Machine.initial(RefreshMachine, { userId: "user-1" })
+      const loggedOut = yield* Machine.next(RefreshMachine, initial, new Logout({}))
+
+      assert.instanceOf(initial, AuthenticatedIdle)
+      assert.instanceOf(loggedOut, Unauthenticated)
+      assert.deepStrictEqual(Machine.enabled(RefreshMachine, initial), ["Refresh", "Logout"])
     }))
 })

--- a/packages/effect/test/unstable/machine/Machine.test.ts
+++ b/packages/effect/test/unstable/machine/Machine.test.ts
@@ -41,7 +41,7 @@ describe("Machine", () => {
   const UserMachine = Machine.make({
     id: "UserMachine",
     events: [Create, Rename, Delete],
-    initial: new Uncreated({}),
+    initial: () => new Uncreated({}),
     states: [Uncreated, Created, Deleted]
   }).handlers({
     Uncreated: {
@@ -87,8 +87,8 @@ describe("Machine", () => {
       const initial = yield* Machine.initial(UserMachine)
       const created = yield* Machine.next(UserMachine, initial, new Create({ email: "a@example.com" }))
 
-      assert.deepStrictEqual(yield* Machine.enabled(UserMachine, initial), ["Create"])
-      assert.deepStrictEqual(yield* Machine.enabled(UserMachine, created), ["Rename", "Delete"])
+      assert.deepStrictEqual(Machine.enabled(UserMachine, initial), ["Create"])
+      assert.deepStrictEqual(Machine.enabled(UserMachine, created), ["Rename", "Delete"])
     }))
 
   it.effect("machine actor processes events sequentially", () =>
@@ -131,4 +131,36 @@ describe("Machine", () => {
         assert.strictEqual(sendError.event, "Rename")
       })
     ))
+
+  it.effect("supports schema-backed input for initial state", () =>
+    Effect.gen(function*() {
+      const ExistingUserInput = Schema.Struct({
+        user: User
+      })
+
+      const InputMachine = Machine.make({
+        input: ExistingUserInput,
+        events: [Rename, Delete],
+        states: [Uncreated, Created, Deleted],
+        initial: ({ input }) => new Created({ user: input.user })
+      }).handlers({
+        Created: {
+          Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
+          Delete: ({ data }) => new Deleted({ userId: data.user.id })
+        }
+      })
+
+      const initial = yield* Machine.initial(InputMachine, {
+        user: {
+          id: "seed",
+          email: "seed@example.com"
+        }
+      })
+
+      assert.instanceOf(initial, Created)
+      assert.deepStrictEqual(initial.user, {
+        id: "seed",
+        email: "seed@example.com"
+      })
+    }))
 })

--- a/packages/effect/test/unstable/machine/Machine.test.ts
+++ b/packages/effect/test/unstable/machine/Machine.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema } from "effect"
+import { Effect, Ref, Schema, ServiceMap } from "effect"
 import * as Machine from "effect/unstable/machine/Machine"
 
 describe("Machine", () => {
@@ -63,6 +63,19 @@ describe("Machine", () => {
     {}
   ) {}
 
+  class DeferredLog extends ServiceMap.Service<DeferredLog, {
+    readonly push: (message: string) => Effect.Effect<void>
+    readonly read: Effect.Effect<ReadonlyArray<string>>
+  }>()("test/Machine/DeferredLog") {}
+
+  const makeDeferredLog = Effect.gen(function*() {
+    const ref = yield* Ref.make<ReadonlyArray<string>>([])
+    return DeferredLog.of({
+      push: (message) => Ref.update(ref, (messages) => [...messages, message]),
+      read: Ref.get(ref)
+    })
+  })
+
   const UserMachine = Machine.make({
     id: "UserMachine",
     events: [Create, Rename, Delete],
@@ -79,7 +92,7 @@ describe("Machine", () => {
 
   it.effect("supports state-dependent snapshots", () =>
     Effect.gen(function*() {
-      const initial = yield* Machine.initial(UserMachine)
+      const initial = Machine.initial(UserMachine)
       const created = yield* Machine.next(UserMachine, initial, new Create({ email: "a@example.com" }))
       const renamed = yield* Machine.next(UserMachine, created, new Rename({ email: "b@example.com" }))
       const deleted = yield* Machine.next(UserMachine, renamed, new Delete({}))
@@ -108,7 +121,7 @@ describe("Machine", () => {
 
   it.effect("returns enabled event tags for the current state", () =>
     Effect.gen(function*() {
-      const initial = yield* Machine.initial(UserMachine)
+      const initial = Machine.initial(UserMachine)
       const created = yield* Machine.next(UserMachine, initial, new Create({ email: "a@example.com" }))
 
       assert.deepStrictEqual(Machine.enabled(UserMachine, initial), ["Create"])
@@ -133,7 +146,7 @@ describe("Machine", () => {
 
   it.effect("fails with UnhandledEventError for invalid events in the current state", () =>
     Effect.gen(function*() {
-      const initial = yield* Machine.initial(UserMachine)
+      const initial = Machine.initial(UserMachine)
       const planError = yield* Effect.flip(Machine.next(UserMachine, initial, new Rename({ email: "x@example.com" })))
 
       assert.instanceOf(planError, Machine.UnhandledEventError)
@@ -169,7 +182,7 @@ describe("Machine", () => {
           Delete: ({ state }) => new Deleted({ userId: state.user.id })
         })
 
-      const initial = yield* Machine.initial(InputMachine, {
+      const initial = Machine.initial(InputMachine, {
         user: {
           id: "seed",
           email: "seed@example.com"
@@ -245,11 +258,80 @@ describe("Machine", () => {
           Refresh: ({ state }) => new AuthenticatedRefreshing({ userId: state.userId })
         })
 
-      const initial = yield* Machine.initial(RefreshMachine, { userId: "user-1" })
+      const initial = Machine.initial(RefreshMachine, { userId: "user-1" })
       const loggedOut = yield* Machine.next(RefreshMachine, initial, new Logout({}))
 
       assert.instanceOf(initial, AuthenticatedIdle)
       assert.instanceOf(loggedOut, Unauthenticated)
       assert.deepStrictEqual(Machine.enabled(RefreshMachine, initial), ["Refresh", "Logout"])
+    }))
+
+  it.effect("plan does not run deferred effects", () =>
+    Effect.gen(function*() {
+      const DeferredMachine = Machine.make({
+        events: [Create],
+        initial: () => new Uncreated({}),
+        states: [Uncreated, Created]
+      }).handlers("Uncreated")({
+        Create: Effect.fn(function*() {
+            const log = yield* DeferredLog
+            yield* Machine.defer(log.push("created"))
+            return new Created({ user: { id: "user-1", email: "a@example.com" } })
+          })
+      })
+
+      const log = yield* makeDeferredLog
+      const initial = Machine.initial(DeferredMachine)
+      const planned = yield* Machine.plan(DeferredMachine, initial, new Create({ email: "a@example.com" })).pipe(
+        Effect.provideService(DeferredLog, log)
+      )
+
+      assert.instanceOf(planned.next, Created)
+      assert.deepStrictEqual(yield* log.read, [])
+    }))
+
+  it.effect("next runs deferred effects", () =>
+    Effect.gen(function*() {
+      const DeferredMachine = Machine.make({
+        events: [Create],
+        initial: () => new Uncreated({}),
+        states: [Uncreated, Created]
+      }).handlers("Uncreated")({
+        Create: Effect.fn(function*() {
+            const log = yield* DeferredLog
+            yield* Machine.defer(log.push("created"))
+            return new Created({ user: { id: "user-1", email: "a@example.com" } })
+          })
+      })
+
+      const log = yield* makeDeferredLog
+      const initial = Machine.initial(DeferredMachine)
+      const next = yield* Machine.next(DeferredMachine, initial, new Create({ email: "a@example.com" })).pipe(
+        Effect.provideService(DeferredLog, log)
+      )
+
+      assert.instanceOf(next, Created)
+      assert.deepStrictEqual(yield* log.read, ["created"])
+    }))
+
+  it.effect("actor commits snapshot before deferred failures surface", () =>
+    Effect.gen(function*() {
+      const DeferredMachine = Machine.make({
+        events: [Create],
+        initial: () => new Uncreated({}),
+        states: [Uncreated, Created]
+      }).handlers("Uncreated")({
+        Create: Effect.fn(function*() {
+            yield* Machine.defer(Effect.fail("boom"))
+            return new Created({ user: { id: "user-1", email: "a@example.com" } })
+          })
+      })
+
+      const actor = yield* Machine.start(DeferredMachine)
+      const error = yield* Effect.flip(actor.send(new Create({ email: "a@example.com" })))
+      const snapshot = yield* actor.snapshot
+
+      assert.strictEqual(error, "boom")
+      assert.instanceOf(snapshot, Created)
     }))
 })

--- a/packages/effect/test/unstable/machine/Machine.test.ts
+++ b/packages/effect/test/unstable/machine/Machine.test.ts
@@ -1,0 +1,134 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import * as Machine from "effect/unstable/machine/Machine"
+
+describe("Machine", () => {
+  const User = Schema.Struct({
+    id: Schema.String,
+    email: Schema.String
+  })
+
+  class Create extends Schema.TaggedClass<Create, { readonly _: unique symbol }>()(
+    "Create",
+    { email: Schema.String }
+  ) {}
+
+  class Rename extends Schema.TaggedClass<Rename, { readonly _: unique symbol }>()(
+    "Rename",
+    { email: Schema.String }
+  ) {}
+
+  class Delete extends Schema.TaggedClass<Delete, { readonly _: unique symbol }>()(
+    "Delete",
+    {}
+  ) {}
+
+  class Uncreated extends Schema.TaggedClass<Uncreated, { readonly _: unique symbol }>()(
+    "Uncreated",
+    {}
+  ) {}
+
+  class Created extends Schema.TaggedClass<Created, { readonly _: unique symbol }>()(
+    "Created",
+    { user: User }
+  ) {}
+
+  class Deleted extends Schema.TaggedClass<Deleted, { readonly _: unique symbol }>()(
+    "Deleted",
+    { userId: Schema.String }
+  ) {}
+
+  const UserMachine = Machine.make({
+    id: "UserMachine",
+    events: [Create, Rename, Delete],
+    initial: new Uncreated({}),
+    states: [Uncreated, Created, Deleted]
+  }).handlers({
+    Uncreated: {
+      Create: ({ event }) => Effect.succeed(new Created({ user: { id: "user-1", email: event.email } }))
+    },
+    Created: {
+      Rename: ({ data, event }) => new Created({ user: { ...data.user, email: event.email } }),
+      Delete: ({ data }) => new Deleted({ userId: data.user.id })
+    }
+  })
+
+  it.effect("supports state-dependent snapshots", () =>
+    Effect.gen(function*() {
+      const initial = yield* Machine.initial(UserMachine)
+      const created = yield* Machine.next(UserMachine, initial, new Create({ email: "a@example.com" }))
+      const renamed = yield* Machine.next(UserMachine, created, new Rename({ email: "b@example.com" }))
+      const deleted = yield* Machine.next(UserMachine, renamed, new Delete({}))
+
+      assert.instanceOf(initial, Uncreated)
+      assert.strictEqual(initial._tag, "Uncreated")
+
+      assert.instanceOf(created, Created)
+      assert.strictEqual(created._tag, "Created")
+      assert.deepStrictEqual(created.user, {
+        id: "user-1",
+        email: "a@example.com"
+      })
+
+      assert.instanceOf(renamed, Created)
+      assert.strictEqual(renamed._tag, "Created")
+      assert.deepStrictEqual(renamed.user, {
+        id: "user-1",
+        email: "b@example.com"
+      })
+
+      assert.instanceOf(deleted, Deleted)
+      assert.strictEqual(deleted._tag, "Deleted")
+      assert.strictEqual(deleted.userId, "user-1")
+    }))
+
+  it.effect("returns enabled event tags for the current state", () =>
+    Effect.gen(function*() {
+      const initial = yield* Machine.initial(UserMachine)
+      const created = yield* Machine.next(UserMachine, initial, new Create({ email: "a@example.com" }))
+
+      assert.deepStrictEqual(yield* Machine.enabled(UserMachine, initial), ["Create"])
+      assert.deepStrictEqual(yield* Machine.enabled(UserMachine, created), ["Rename", "Delete"])
+    }))
+
+  it.effect("machine actor processes events sequentially", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const actor = yield* Machine.start(UserMachine)
+
+        yield* actor.send(new Create({ email: "a@example.com" }))
+        yield* actor.send(new Rename({ email: "b@example.com" }))
+
+        const snapshot = yield* actor.snapshot
+        assert.instanceOf(snapshot, Created)
+        assert.strictEqual(snapshot._tag, "Created")
+        assert.deepStrictEqual(snapshot.user, {
+          id: "user-1",
+          email: "b@example.com"
+        })
+      })
+    ))
+
+  it.effect("fails with UnhandledEventError for invalid events in the current state", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const initial = yield* Machine.initial(UserMachine)
+        const planError = yield* Effect.flip(Machine.next(UserMachine, initial, new Rename({ email: "x@example.com" })))
+
+        assert.instanceOf(planError, Machine.UnhandledEventError)
+        assert.strictEqual(planError._tag, "UnhandledEventError")
+        assert.strictEqual(planError.machineId, "UserMachine")
+        assert.strictEqual(planError.state, "Uncreated")
+        assert.strictEqual(planError.event, "Rename")
+
+        const actor = yield* Machine.start(UserMachine)
+        const sendError = yield* Effect.flip(actor.send(new Rename({ email: "x@example.com" })))
+
+        assert.instanceOf(sendError, Machine.UnhandledEventError)
+        assert.strictEqual(sendError._tag, "UnhandledEventError")
+        assert.strictEqual(sendError.machineId, "UserMachine")
+        assert.strictEqual(sendError.state, "Uncreated")
+        assert.strictEqual(sendError.event, "Rename")
+      })
+    ))
+})

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -9,7 +9,10 @@ const config: ViteUserConfig = {
   optimizeDeps: {
     exclude: ["bun:sqlite"]
   },
-  plugins: [aliases()],
+  plugins: [aliases({
+    ignoreConfigErrors: true,
+    skip: (dir) => dir.includes("/.repos/") || dir.endsWith("/.repos")
+  })],
   server: {
     watch: {
       ignored: [


### PR DESCRIPTION
## Summary
- add an unstable `effect/unstable/machine/Machine` prototype with schema-backed tagged events and states, typed handlers, and a scoped actor runtime
- include focused runtime and dtslint coverage for the current API shape
- ignore `.repos` during vitest tsconfig-path discovery to avoid subtree noise

## Caveat
- this branch is fully vibe coded and should not yet be considered for merge
- this draft PR is for experimentation and API feedback only