### PR TITLE
improve Effect.repeat ergonomics

### DIFF
--- a/.changeset/fair-squids-pull.md
+++ b/.changeset/fair-squids-pull.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add a `passthrough` option to `Effect.repeat` so scheduled repetitions can preserve the final successful effect value.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -7000,6 +7000,14 @@ export declare namespace Repeat {
   /**
    * @since 2.0.0
    * @category Repetition / Recursion
+   */
+  export type Output<A, O extends Options<A>> = O extends { until: Predicate.Refinement<A, infer B> } ? B
+    : O extends { while: Predicate.Refinement<A, infer B> } ? Exclude<A, B>
+    : A
+
+  /**
+   * @since 2.0.0
+   * @category Repetition / Recursion
    * @example
    * ```ts
    * import type { Effect } from "effect"
@@ -7011,10 +7019,10 @@ export declare namespace Repeat {
    * ```
    */
   export type Return<R, E, A, O extends Options<A>> = Effect<
-    O extends { schedule: Schedule<infer Out, infer _I, infer _E, infer _R> } ? Out
-      : O extends { until: Predicate.Refinement<A, infer B> } ? B
-      : O extends { while: Predicate.Refinement<A, infer B> } ? Exclude<A, B>
-      : A,
+    O extends { schedule: Schedule<infer Out, infer _I, infer _E, infer _R> }
+      ? O extends { passthrough: true } ? Output<A, O>
+      : Out
+      : Output<A, O>,
     | E
     | (O extends { schedule: Schedule<infer _Out, infer _I, infer E, infer _R> } ? E
       : never)
@@ -7048,7 +7056,8 @@ export declare namespace Repeat {
    * const repeatOptions: Effect.Repeat.Options<number> = {
    *   times: 5,
    *   schedule: Schedule.fixed("100 millis"),
-   *   while: (result) => result < 10
+   *   while: (result) => result < 10,
+   *   passthrough: true
    * }
    * ```
    */
@@ -7057,6 +7066,7 @@ export declare namespace Repeat {
     until?: ((_: A) => boolean | Effect<boolean, any, any>) | undefined
     times?: number | undefined
     schedule?: Schedule<any, A, any, any> | undefined
+    passthrough?: boolean | undefined
   }
 }
 
@@ -7121,6 +7131,10 @@ export const forever: <
  * for tasks like retrying operations with backoff, periodic execution, or
  * performing a series of dependent actions.
  *
+ * When using the options form, pass `{ passthrough: true }` to preserve the
+ * last successful effect result while still using the schedule for timing or
+ * limiting repetitions.
+ *
  * You can combine schedules for more advanced repetition logic, such as adding
  * delays, limiting recursions, or dynamically adjusting based on the outcome of
  * each execution.
@@ -7137,6 +7151,29 @@ export const forever: <
  * const program = Effect.repeat(action, policy)
  *
  * // Effect.runPromise(program).then((n) => console.log(`repetitions: ${n}`))
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Poll until the response is no longer pending, keeping the final response
+ * import { Effect, Schedule } from "effect"
+ *
+ * const responses = [
+ *   { status: "pending" as const },
+ *   { status: "processing" as const },
+ *   { status: "valid" as const }
+ * ]
+ * let current = 0
+ *
+ * const poll = Effect.sync(() => responses[Math.min(current++, responses.length - 1)])
+ *
+ * const program = Effect.repeat(poll, {
+ *   schedule: Schedule.spaced("1 second"),
+ *   while: (response) => response.status === "pending" || response.status === "processing",
+ *   passthrough: true
+ * })
+ *
+ * // Effect.runPromise(program).then((response) => console.log(response.status))
  * ```
  *
  * @example

--- a/packages/effect/src/internal/schedule.ts
+++ b/packages/effect/src/internal/schedule.ts
@@ -225,8 +225,12 @@ export const buildFromOptions = <Input>(options: {
   while?: ((input: Input) => boolean | Effect<boolean, any, any>) | undefined
   until?: ((input: Input) => boolean | Effect<boolean, any, any>) | undefined
   times?: number | undefined
+  passthrough?: boolean | undefined
 }) => {
   let schedule: Schedule.Schedule<any, Input, any, any> = options.schedule ?? passthroughForever
+  if (options.passthrough) {
+    schedule = Schedule.passthrough(schedule)
+  }
   if (options.while) {
     schedule = Schedule.while(schedule, ({ input }) => {
       const applied = options.while!(input)

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -747,6 +747,46 @@ describe("Effect", () => {
         assert.strictEqual(n, 3)
         assert.strictEqual(result, 2) // schedule result
       }))
+
+    it.effect("repeat/schedule - with while + passthrough", () =>
+      Effect.gen(function*() {
+        const responses = [
+          { status: "pending" as const },
+          { status: "processing" as const },
+          { status: "valid" as const }
+        ]
+        let polls = 0
+        const poll = Effect.sync(() => responses[Math.min(polls++, responses.length - 1)])
+        const fiber = yield* Effect.repeat(poll, {
+          schedule: Schedule.spaced("1 second"),
+          while: (response) => response.status === "pending" || response.status === "processing",
+          passthrough: true
+        }).pipe(Effect.forkChild)
+        yield* TestClock.setTime(Number.POSITIVE_INFINITY)
+        const result = yield* Fiber.join(fiber)
+        assert.deepStrictEqual(result, { status: "valid" })
+        assert.strictEqual(polls, 3)
+      }))
+
+    it.effect("repeat/schedule - with until + passthrough", () =>
+      Effect.gen(function*() {
+        const responses = [
+          { status: "pending" as const },
+          { status: "processing" as const },
+          { status: "valid" as const }
+        ]
+        let polls = 0
+        const poll = Effect.sync(() => responses[Math.min(polls++, responses.length - 1)])
+        const fiber = yield* Effect.repeat(poll, {
+          schedule: Schedule.spaced("1 second"),
+          until: (response) => response.status === "valid",
+          passthrough: true
+        }).pipe(Effect.forkChild)
+        yield* TestClock.setTime(Number.POSITIVE_INFINITY)
+        const result = yield* Fiber.join(fiber)
+        assert.deepStrictEqual(result, { status: "valid" })
+        assert.strictEqual(polls, 3)
+      }))
   })
 
   describe("retry", () => {


### PR DESCRIPTION
Sometimes you want to repeat a successful effect while a response is still pending, but keep the response that finally succeeds.

```ts
const order = yield* Effect.repeat(fetchOrder(orderUrl), {
  schedule: Schedule.spaced("1 second"),
  while: (order) => order.status === "pending" || order.status === "processing"
})
```

That feels like the obvious thing to write.

Today, once a schedule is involved, `repeat` returns the schedule output instead of `order`. You can get this with `Schedule.passthrough(...)`, but in practice that can push you into the builder overload and make the code much uglier than just passing `schedule` and `while` directly.

My guess is that most people will be surprised by this. In the simple polling case, what you usually want is the final successful value, not the schedule output.

I do not think this has to be the final design. It might be better for `repeat` (or maybe when called with `while`?) to return the last successful value by default and move the schedule-output behavior to a separate API. This PR is just one small possible fix for the common case. Or possibly a different method could do this.

The ability to use Schedule's output type is very cool, but I feel like 90% of the time people will be confused why calling repeat with `while` and Schedule.spaced("1 second") returns a number instead of the result of the repeated effect.