### PR TITLE
feat(sql-sqlite-do): add transaction support via DurableObjectStorage.transactionSync

### DIFF
--- a/.changeset/sql-sqlite-do-transaction-support.md
+++ b/.changeset/sql-sqlite-do-transaction-support.md
@@ -1,0 +1,13 @@
+---
+"@effect/sql-sqlite-do": minor
+---
+
+Add transaction support via `DurableObjectStorage.transactionSync`.
+
+Cloudflare DO's `sql.exec()` cannot execute transaction control statements (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`). Pass the `storage` option to enable real transactions:
+
+```typescript
+SqliteClient.make({ storage: ctx.storage })
+```
+
+Without `storage`, `withTransaction` now dies with a clear error message instead of silently failing.

--- a/packages/sql/sqlite-do/package.json
+++ b/packages/sql/sqlite-do/package.json
@@ -60,6 +60,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260131.0",
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "^12.6.2",
     "effect": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -2,8 +2,10 @@
  * @since 1.0.0
  */
 import type { SqlStorage } from "@cloudflare/workers-types"
+import { Clock } from "effect/Clock"
 import * as Config from "effect/Config"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
@@ -11,6 +13,7 @@ import * as Scope from "effect/Scope"
 import * as Semaphore from "effect/Semaphore"
 import * as ServiceMap from "effect/ServiceMap"
 import * as Stream from "effect/Stream"
+import * as Tracer from "effect/Tracer"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
@@ -56,12 +59,37 @@ export const SqliteClient = ServiceMap.Service<SqliteClient>("@effect/sql-sqlite
  * @category models
  * @since 1.0.0
  */
-export interface SqliteClientConfig {
-  readonly db: SqlStorage
-  readonly spanAttributes?: Record<string, unknown> | undefined
+export type SqliteClientConfig = SqliteClientConfig.Base & (
+  | { readonly storage: SqliteClientConfig.Storage; readonly db?: SqlStorage | undefined }
+  | { readonly db: SqlStorage; readonly storage?: undefined }
+)
 
-  readonly transformResultNames?: ((str: string) => string) | undefined
-  readonly transformQueryNames?: ((str: string) => string) | undefined
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export declare namespace SqliteClientConfig {
+  /**
+   * The DurableObjectStorage instance (`ctx.storage`). When provided,
+   * `withTransaction` uses `storage.transactionSync()` to wrap SQL operations
+   * in a real transaction and `db` is derived from `storage.sql`.
+   *
+   * Without this, transactions are not supported (DO's `sql.exec()` cannot
+   * execute BEGIN/COMMIT/ROLLBACK).
+   *
+   * Note: Effects run inside `withTransaction` must be fully synchronous
+   * (no async operations, no Effect.sleep, no concurrent effects). This is a
+   * fundamental constraint of Cloudflare DO's transactionSync API.
+   */
+  export interface Storage {
+    readonly sql: SqlStorage
+    readonly transactionSync: <T>(closure: () => T) => T
+  }
+  export interface Base {
+    readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly transformResultNames?: ((str: string) => string) | undefined
+    readonly transformQueryNames?: ((str: string) => string) | undefined
+  }
 }
 
 /**
@@ -72,13 +100,14 @@ export const make = (
   options: SqliteClientConfig
 ): Effect.Effect<SqliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function*() {
+    const db = options.storage ? options.storage.sql : options.db
+
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
     const transformRows = options.transformResultNames
       ? Statement.defaultTransforms(options.transformResultNames).array
       : undefined
 
     const makeConnection = Effect.gen(function*() {
-      const db = options.db
 
       function* runIterator(
         sql: string,
@@ -157,32 +186,120 @@ export const make = (
     const connection = yield* makeConnection
 
     const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
-    const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
-      const fiber = Fiber.getCurrent()!
-      const scope = ServiceMap.getUnsafe(fiber.services, Scope.Scope)
-      return Effect.as(
-        Effect.tap(
-          restore(semaphore.take(1)),
-          () => Scope.addFinalizer(scope, semaphore.release(1))
-        ),
-        connection
-      )
+
+    const spanAttributes: Array<readonly [string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "sqlite"]
+    ]
+
+    // When storage is provided, the custom withTransaction below overrides the
+    // base client's transaction handling. This acquirer is still required by
+    // Client.make but won't be exercised in the storage-provided path.
+    const transactionAcquirer = options.storage
+      ? Effect.uninterruptibleMask((restore) => {
+        const fiber = Fiber.getCurrent()!
+        const scope = ServiceMap.getUnsafe(fiber.services, Scope.Scope)
+        return Effect.as(
+          Effect.tap(
+            restore(semaphore.take(1)),
+            () => Scope.addFinalizer(scope, semaphore.release(1))
+          ),
+          connection
+        )
+      })
+      : Effect.die("transactions are not supported without providing `storage` to SqliteClient config")
+
+    const baseClient = yield* Client.make({
+      acquirer,
+      compiler,
+      transactionAcquirer,
+      spanAttributes,
+      transformRows
     })
 
+    // When storage is provided, override withTransaction to use transactionSync.
+    //
+    // We cannot use Client.makeWithTransaction here because DO's sql.exec()
+    // rejects transaction control statements (BEGIN, COMMIT, ROLLBACK,
+    // SAVEPOINT). The only way to get a transaction is via the callback-based
+    // storage.transactionSync(closure) API, which wraps the closure in
+    // BEGIN/COMMIT internally. Since this is a single callback rather than
+    // separate begin/commit/rollback steps, we run the entire user effect
+    // synchronously via Effect.runSyncExitWith inside the closure, and throw
+    // the failure Exit to trigger rollback.
+    const { storage } = options
+    const withTransaction = storage
+      ? <R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+        Effect.uninterruptibleMask((restore) =>
+          Effect.useSpan(
+            "sql.transaction",
+            { kind: "client" },
+            (span) =>
+              Effect.withFiber<A, E | SqlError, R>((fiber) => {
+                for (const [key, value] of spanAttributes) {
+                  span.attribute(key, value)
+                }
+                const services = fiber.services
+                const clock = fiber.getRef(Clock)
+                const connOption = ServiceMap.getOption(services, Client.TransactionConnection)
+
+                if (connOption._tag === "Some") {
+                  // Already in a transaction - run flat (no savepoint support in DO)
+                  return restore(effect)
+                }
+
+                // Provide TransactionConnection so the client's getConnection
+                // finds it directly (bypassing the semaphore acquirer which
+                // doesn't work inside runSyncExitWith), and so nested
+                // withTransaction calls are detected.
+                const txServices = ServiceMap.mutate(services, (s) =>
+                  s.pipe(
+                    ServiceMap.add(Client.TransactionConnection, [connection, 0] as const),
+                    ServiceMap.add(Tracer.ParentSpan, span)
+                  )
+                )
+
+                return Effect.suspend(() => {
+                  try {
+                    const value = storage.transactionSync(() => {
+                      // txServices is built from fiber.services via ServiceMap.mutate,
+                      // so it contains all ambient services. The `as any` cast is needed
+                      // because the mutated map's type doesn't reflect R.
+                      const exit = Effect.runSyncExitWith(txServices as any)(
+                        restore(effect) as Effect.Effect<A, E | SqlError>
+                      )
+                      if (exit._tag === "Failure") {
+                        throw exit // Trigger rollback
+                      }
+                      return exit.value
+                    })
+                    // Transaction committed
+                    span.event("db.transaction.commit", clock.currentTimeNanosUnsafe())
+                    return Effect.succeed(value) as Effect.Effect<A, E | SqlError, R>
+                  } catch (thrown: any) {
+                    span.event("db.transaction.rollback", clock.currentTimeNanosUnsafe())
+                    if (Exit.isExit(thrown) && thrown._tag === "Failure") {
+                      return Effect.failCause(thrown.cause) as Effect.Effect<A, E | SqlError, R>
+                    }
+                    // Unexpected error from transactionSync itself
+                    return Effect.fail(
+                      new SqlError({
+                        reason: classifyError(thrown, "Transaction failed", "transaction")
+                      })
+                    ) as Effect.Effect<A, E | SqlError, R>
+                  }
+                })
+              })
+          )
+        )
+      : baseClient.withTransaction
+
     return Object.assign(
-      (yield* Client.make({
-        acquirer,
-        compiler,
-        transactionAcquirer,
-        spanAttributes: [
-          ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [ATTR_DB_SYSTEM_NAME, "sqlite"]
-        ],
-        transformRows
-      })) as SqliteClient,
+      baseClient as SqliteClient,
       {
         [TypeId]: TypeId as TypeId,
-        config: options
+        config: options,
+        withTransaction
       }
     )
   })

--- a/packages/sql/sqlite-do/test/Transaction.test.ts
+++ b/packages/sql/sqlite-do/test/Transaction.test.ts
@@ -1,0 +1,182 @@
+import { SqliteClient } from "@effect/sql-sqlite-do"
+import { assert, describe, it } from "@effect/vitest"
+import { Cause, Effect } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import { makeDurableObjectStorage } from "./utils.ts"
+
+describe("Transaction", () => {
+  it.effect("commit persists data", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+        yield* sql`INSERT INTO users (name) VALUES (${"bob"})`
+      }).pipe(sql.withTransaction)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [
+        { id: 1, name: "alice" },
+        { id: 2, name: "bob" }
+      ])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("rollback on failure discards all writes", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+      yield* sql`INSERT INTO users (name) VALUES (${"pre-existing"})`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+        yield* sql`INSERT INTO users (name) VALUES (${"bob"})`
+        return yield* Effect.fail("simulated failure")
+      }).pipe(sql.withTransaction, Effect.ignore)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [{ id: 1, name: "pre-existing" }])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("rollback on defect discards writes", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+        return yield* Effect.die("unexpected defect")
+      }).pipe(sql.withTransaction, Effect.sandbox, Effect.ignore)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("nested withTransaction commits atomically", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"outer"})`
+        yield* Effect.gen(function*() {
+          yield* sql`INSERT INTO users (name) VALUES (${"inner"})`
+        }).pipe(sql.withTransaction)
+      }).pipe(sql.withTransaction)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [
+        { id: 1, name: "outer" },
+        { id: 2, name: "inner" }
+      ])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("nested failure rolls back entire transaction", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"outer"})`
+        yield* Effect.gen(function*() {
+          yield* sql`INSERT INTO users (name) VALUES (${"inner"})`
+          return yield* Effect.fail("inner failure")
+        }).pipe(sql.withTransaction)
+      }).pipe(sql.withTransaction, Effect.ignore)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("can read own writes within transaction", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+        const rows = yield* sql`SELECT * FROM users`
+        assert.deepStrictEqual(rows, [{ id: 1, name: "alice" }])
+
+        yield* sql`INSERT INTO users (name) VALUES (${"bob"})`
+        const rows2 = yield* sql`SELECT * FROM users`
+        assert.deepStrictEqual(rows2, [
+          { id: 1, name: "alice" },
+          { id: 2, name: "bob" }
+        ])
+      }).pipe(sql.withTransaction)
+
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("constraint violation triggers rollback", () =>
+    Effect.gen(function*() {
+      const { storage, close } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ storage })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE)`
+
+      yield* Effect.gen(function*() {
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+        yield* sql`INSERT INTO users (name) VALUES (${"alice"})`
+      }).pipe(sql.withTransaction, Effect.ignore)
+
+      const rows = yield* sql`SELECT * FROM users`
+      assert.deepStrictEqual(rows, [])
+      close()
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+
+  it.effect("withTransaction without storage dies", () =>
+    Effect.gen(function*() {
+      const { storage } = makeDurableObjectStorage()
+      const sql = yield* SqliteClient.make({ db: storage.sql })
+
+      yield* sql`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)`
+      const result = yield* sql`INSERT INTO users (name) VALUES (${"hello"})`.pipe(
+        sql.withTransaction,
+        Effect.sandbox,
+        Effect.flip
+      )
+      assert.equal(Cause.hasDies(result), true)
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(Reactivity.layer)
+    ))
+})

--- a/packages/sql/sqlite-do/test/utils.ts
+++ b/packages/sql/sqlite-do/test/utils.ts
@@ -1,0 +1,50 @@
+import type { SqlStorage } from "@cloudflare/workers-types"
+import Database from "better-sqlite3"
+
+/**
+ * Creates a real SQLite-backed mock of DurableObjectStorage with sql and
+ * transactionSync. Uses better-sqlite3 for actual SQLite transactions.
+ */
+export function makeDurableObjectStorage() {
+  const sqlite = new Database(":memory:")
+
+  const sql: SqlStorage = {
+    exec(query: string, ...bindings: any[]) {
+      const stmt = sqlite.prepare(query)
+      const isSelect = query.trimStart().toUpperCase().startsWith("SELECT")
+      if (isSelect) {
+        const rows = stmt.all(...bindings)
+        const columns = rows.length > 0 ? Object.keys(rows[0] as any) : stmt.columns().map((c) => c.name)
+        return {
+          columnNames: columns,
+          raw: () => rows.map((r: any) => columns.map((c) => r[c])),
+          rowsRead: rows.length,
+          rowsWritten: 0
+        } as any
+      } else {
+        const result = stmt.run(...bindings)
+        return {
+          columnNames: [],
+          raw: () => [],
+          rowsRead: 0,
+          rowsWritten: result.changes
+        } as any
+      }
+    },
+    get databaseSize() {
+      return 0
+    }
+  } as any
+
+  const storage = {
+    sql,
+    transactionSync<T>(closure: () => T): T {
+      const tx = sqlite.transaction(closure)
+      return tx()
+    }
+  }
+
+  const close = () => sqlite.close()
+
+  return { storage, close }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260131.0
         version: 4.20260131.0
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^12.6.2
+        version: 12.6.2
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -6352,7 +6358,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6656,7 +6662,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8043,7 +8049,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.54.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -8060,7 +8066,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/visitor-keys': 8.54.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 9.0.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -8771,10 +8777,6 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -9373,18 +9375,11 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
   http2-client@1.3.5: {}
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
@@ -9698,7 +9693,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -9879,7 +9874,7 @@ snapshots:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       dependency-tree: 11.2.0
       ora: 5.4.1
       pluralize: 8.0.0
@@ -10928,7 +10923,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.2)(rollup@4.57.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       esbuild: 0.27.2
       get-tsconfig: 4.13.1
@@ -11595,7 +11590,7 @@ snapshots:
 
   vite-tsconfig-paths@6.0.5(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.2.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

Adds transaction support to `@effect/sql-sqlite-do` using Cloudflare's `DurableObjectStorage.transactionSync()` API.

Closes Effect-TS/effect#5987

- New `storage` config option accepts the `DurableObjectStorage` instance — `db` is derived from `storage.sql`
- `withTransaction` wraps effects in a real SQLite transaction via `storage.transactionSync()` + `Effect.runSyncExitWith`
- Nested `withTransaction` calls run flat (no savepoint support — DO's `sql.exec()` rejects `SAVEPOINT`)
- Without `storage`, `withTransaction` dies with a clear error instead of silently failing
- Fully backward compatible — existing `{ db: ctx.storage.sql }` usage is unchanged

### Why

Cloudflare DO's `sql.exec()` [cannot execute transaction control statements](https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api) (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`). The only way to get a transaction is via the callback-based `storage.transactionSync()` API. This cannot be implemented through `Client.makeWithTransaction` since that expects separate begin/commit/rollback steps.

### Usage

```typescript
// Before — transactions unsupported
SqliteClient.make({ db: ctx.storage.sql })

// After — transactions via transactionSync
SqliteClient.make({ storage: ctx.storage })
```

Effects inside `withTransaction` must be fully synchronous (no async, no `Effect.sleep`) — this is a fundamental constraint of DO's `transactionSync` API.

## Verification

Verified locally against a real Cloudflare DO runtime (miniflare/workerd):
https://github.com/m9tdev/effect-sql-sqlite-do-transaction-test

```
$ npm test

DO Transaction Integration Tests

  ✓ commit persists data
  ✓ rollback discards writes on failure
  ✓ read own writes within transaction
  ✓ nested transactions commit
  ✓ nested failure rolls back everything
  ✓ migrator runs migrations in a transaction
  ✓ schema model + sql.insert/update + makeRepository

7 passed, 0 failed
```

## Test plan

8 tests using real SQLite via `better-sqlite3` (new `test/Transaction.test.ts`):

- [x] Transaction commit persists data
- [x] Rollback on `Effect.fail` discards writes
- [x] Rollback on `Effect.die` (defect) discards writes
- [x] Nested `withTransaction` commits atomically
- [x] Nested failure rolls back entire transaction
- [x] Read-own-writes within transaction
- [x] Constraint violation triggers rollback
- [x] `withTransaction` without `storage` dies with clear error