### PR TITLE
EFF-780 Unify.unify should work with the Layer module

### DIFF
--- a/.changeset/eff-780-layer-unify.md
+++ b/.changeset/eff-780-layer-unify.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Unify.unify` so Layer unions merge correctly, and add type tests covering Layer unification.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -37,6 +37,7 @@ import * as ServiceMap from "./ServiceMap.ts"
 import type * as Stream from "./Stream.ts"
 import * as Tracer from "./Tracer.ts"
 import type * as Types from "./Types.ts"
+import type * as Unify from "./Unify.ts"
 
 const TypeId = "~effect/Layer"
 
@@ -54,6 +55,29 @@ const TypeId = "~effect/Layer"
 export interface Layer<in ROut, out E = never, out RIn = never> extends Variance<ROut, E, RIn>, Pipeable {
   /** @internal */
   build(memoMap: MemoMap, scope: Scope.Scope): Effect<ServiceMap.ServiceMap<ROut>, E, RIn>
+  [Unify.typeSymbol]?: unknown
+  [Unify.unifySymbol]?: LayerUnify<this>
+  [Unify.ignoreSymbol]?: LayerUnifyIgnore
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface LayerUnify<A extends { [Unify.typeSymbol]?: any }> {
+  Layer?: () => A[Unify.typeSymbol] extends Layer<any, any, any> | infer _ ? Layer<
+      Success<Extract<A[Unify.typeSymbol], Any>>,
+      Error<Extract<A[Unify.typeSymbol], Any>>,
+      Services<Extract<A[Unify.typeSymbol], Any>>
+    >
+    : never
+}
+
+/**
+ * @since 4.0.0
+ * @category models
+ */
+export interface LayerUnifyIgnore {
 }
 
 /**

--- a/packages/effect/src/Unify.ts
+++ b/packages/effect/src/Unify.ts
@@ -142,8 +142,11 @@ export type ignoreSymbol = typeof ignoreSymbol
 
 type MaybeReturn<F> = F extends () => infer R ? R : NonNullable<F>
 
+type Keys<X extends [any, any]> = X extends [infer A, infer Ignore] ? Exclude<keyof A, Ignore>
+  : never
+
 type Values<X extends [any, any]> = X extends [infer A, infer Ignore]
-  ? Exclude<keyof A, Ignore> extends infer k ? k extends keyof A ? MaybeReturn<A[k]> : never : never
+  ? Keys<[A, Ignore]> extends infer K ? K extends keyof A ? MaybeReturn<A[K]> : never : never
   : never
 
 type Ignore<X> = X extends { [ignoreSymbol]?: infer Obj } ? keyof NonNullable<Obj>
@@ -158,6 +161,13 @@ type ExtractTypes<
   : never
 
 type FilterIn<A> = A extends any ? typeSymbol extends keyof A ? A : never : never
+
+type FilterInUnmatched<A, K> = A extends any
+  ? typeSymbol extends keyof A
+    ? A extends { [unifySymbol]?: infer U } ? [Extract<keyof NonNullable<U>, K>] extends [never] ? A : never
+    : A
+  : never
+  : never
 
 type FilterOut<A> = A extends any ? typeSymbol extends keyof A ? never : A : never
 
@@ -201,7 +211,21 @@ export type Unify<A> = Values<
       & { [typeSymbol]: A }
     )
   >
-> extends infer Z ? Z | Exclude<A, Z> | FilterOut<A> : never
+> extends infer Z ?
+    | Z
+    | FilterInUnmatched<
+      A,
+      Keys<
+        ExtractTypes<
+          (
+            & FilterIn<A>
+            & { [typeSymbol]: A }
+          )
+        >
+      >
+    >
+    | FilterOut<A>
+  : never
 
 /**
  * Unifies the return type of a function or value.

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -5,6 +5,7 @@ import {
   Data,
   Effect,
   Fiber,
+  type Layer,
   type Option,
   pipe,
   Result,
@@ -58,6 +59,9 @@ declare const sinkStringOrNumber:
 declare const channelStringOrNumber:
   | Channel.Channel<string, "out-err-1", "out-done-1", string, "in-err", "in-done", "dep-1">
   | Channel.Channel<number, "out-err-2", "out-done-2", string, "in-err", "in-done", "dep-2">
+declare const layerStringOrNumber:
+  | Layer.Layer<"out-1", "err-1", "dep-1">
+  | Layer.Layer<"out-2", "err-2", "dep-2">
 declare const optionStringOrNumber: Option.Option<string> | Option.Option<number>
 declare const resultStringOrNumber: Result.Result<string, "err-1"> | Result.Result<number, "err-2">
 declare const fiberStringOrNumber: Fiber.Fiber<string, "err-1"> | Fiber.Fiber<number, "err-2">
@@ -599,6 +603,11 @@ describe("Unify.unify", () => {
         "dep-1" | "dep-2"
       >
     >()
+  })
+
+  it("unifies layer unions", () => {
+    const result = Unify.unify(layerStringOrNumber)
+    expect(result).type.toBe<Layer.Layer<"out-1" | "out-2", "err-1" | "err-2", "dep-1" | "dep-2">>()
   })
 
   it("unifies option unions", () => {


### PR DESCRIPTION
## Summary
- add Layer unification protocol hooks (type / unify / ignore symbols) so Layer participates in Unify.unify
- fix Unify.Unify member pruning to remove already-unified members by unification key instead of assignability (which failed for Layer because of contravariant ROut)
- add a type-level regression test for Layer union unification in packages/effect/typetest/Effect.tst.ts
- add a changeset for `effect`

## Validation
- pnpm lint-fix
- pnpm test-types packages/effect/typetest/Effect.tst.ts
- pnpm test packages/effect/test/Layer.test.ts
- pnpm check:tsgo
- pnpm docgen