### PR TITLE
Underline active labels in CLI multi-select prompts

### DIFF
--- a/.changeset/tiny-buckets-wave.md
+++ b/.changeset/tiny-buckets-wave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Underline the active label in CLI multi-select prompts and add a scratchpad example for manual verification.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -2303,6 +2303,17 @@ const renderChoiceDescription = <A>(
 
 const metaOptionsCount = 2
 
+const renderMultiSelectTitle = (
+  title: string,
+  isHighlighted: boolean,
+  renderOptions?: RenderOptions | undefined
+) => {
+  if (renderOptions?.plain === true || !isHighlighted) {
+    return title
+  }
+  return Ansi.annotate(title, Ansi.combine(Ansi.underlined, Ansi.cyanBright))
+}
+
 const renderMultiSelectChoices = <A>(
   state: MultiSelectState,
   options: SelectOptionsReq<A> & MultiSelectOptionsReq,
@@ -2338,9 +2349,7 @@ const renderMultiSelectChoices = <A>(
     }
     if (index < metaOptions.length) {
       // Meta options
-      const title = isHighlighted && renderOptions?.plain !== true
-        ? Ansi.annotate(choice.title, Ansi.cyanBright)
-        : choice.title
+      const title = renderMultiSelectTitle(choice.title, isHighlighted, renderOptions)
       documents.push(prefix + " " + title)
     } else {
       // Regular choices
@@ -2350,9 +2359,7 @@ const renderMultiSelectChoices = <A>(
       const annotatedCheckbox = isHighlighted && renderOptions?.plain !== true
         ? Ansi.annotate(checkbox, Ansi.cyanBright)
         : checkbox
-      const title = isHighlighted && renderOptions?.plain !== true
-        ? Ansi.annotate(choice.title, Ansi.cyanBright)
-        : choice.title
+      const title = renderMultiSelectTitle(choice.title, isHighlighted, renderOptions)
       const description = renderChoiceDescription(choice as SelectChoice<A>, isHighlighted, renderOptions)
       documents.push(prefix + " " + annotatedCheckbox + " " + title + " " + description)
     }

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, FileSystem, Layer, Path, Redacted } from "effect"
+import { Effect, Fiber, FileSystem, Layer, Path, Redacted } from "effect"
 import { TestConsole } from "effect/testing"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
@@ -43,6 +43,11 @@ const toFrames = (lines: ReadonlyArray<unknown>) =>
   lines
     .map((line) => stripAnsi(String(line)))
     .filter((line) => line.split(bell).join("").trim().length > 0)
+
+const toRawFrames = (lines: ReadonlyArray<unknown>) =>
+  lines
+    .map((line) => String(line))
+    .filter((line) => stripAnsi(line).split(bell).join("").trim().length > 0)
 
 const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((frame) => frame.includes(text))
 
@@ -430,4 +435,38 @@ describe("Prompt.file", () => {
       assert.isFalse(narrowedFrame?.includes("basket.txt"))
       assert.isTrue(expandedFrame?.includes("basket.txt"))
     }).pipe(Effect.provide(FilePromptLayer)))
+})
+
+describe("Prompt.multiSelect", () => {
+  it.effect("underlines the active label", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.multiSelect({
+        message: "Pick items",
+        choices: [
+          { title: "Alpha", value: "alpha" },
+          { title: "Beta", value: "beta" },
+          { title: "Gamma", value: "gamma" }
+        ]
+      })
+
+      const fiber = yield* Prompt.run(prompt).pipe(Effect.forkChild)
+
+      yield* Effect.yieldNow
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* MockTerminal.inputKey("down")
+      yield* Effect.yieldNow
+
+      const output = yield* TestConsole.logLines
+      const frames = toRawFrames(output)
+      const highlightedFrame = [...frames].reverse().find((frame) => frame.includes("Beta"))
+
+      assert.isTrue(highlightedFrame !== undefined)
+      assert.isTrue(highlightedFrame?.includes(`${escape}[4m${escape}[96mBeta${escape}[0m`))
+
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Fiber.join(fiber)
+      assert.deepStrictEqual(result, [])
+    }).pipe(Effect.provide(TestLayer)))
 })


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Improve the CLI multi-select prompt by making the active label easier to track during navigation.

This change updates the multi-select renderer to apply underlined cyan styling to the currently highlighted label, bringing its visual emphasis closer to the other prompt variants. It also adds a test that verifies the highlighted label rendering so the behavior is covered going forward.

## Related

- Related Issue #
- Closes #