### PR TITLE
feat(workflow): added support for customizing workflow executionId generation (#1987)

### DIFF
--- a/.changeset/khaki-bikes-shake.md
+++ b/.changeset/khaki-bikes-shake.md
@@ -1,0 +1,5 @@
+---
+"effect": major
+---
+
+Added support for customizing workflow executionId generation

--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -267,6 +267,55 @@ const InstanceTag = ServiceMap.Service<
   "effect/workflow/WorkflowEngine/WorkflowInstance" satisfies typeof WorkflowInstance.key
 )
 
+export interface MakeWorkflowExecutionId<
+  TName = string,
+  TPayloadSchema extends Schema.Struct.Fields | AnyStructSchema = Schema.Struct.Fields | AnyStructSchema,
+> {
+  <
+    Name extends TName,
+    PayloadSchema extends TPayloadSchema,
+    Payload extends (
+      PayloadSchema extends Schema.Struct.Fields ? Schema.Struct<PayloadSchema> : PayloadSchema
+    ),
+  >(
+    options: {
+      name: Name,
+      payload: PayloadSchema,
+      idempotencyKey: (payload: Payload['Type']) => string,
+      annotations?: ServiceMap.ServiceMap<never>,
+    },
+    payload: Payload['~type.make.in']
+  ): Effect.Effect<string, never, never>
+}
+
+const makeWorkflowExecutionId: MakeWorkflowExecutionId = (
+  (options, payload) => makeHashDigest(`${options.name}-${options.idempotencyKey(payload)}`)
+);
+
+/**
+ * @since 4.0.0
+ */
+export const executionId: (
+  & (
+    <
+      Payload extends AnyStructSchema
+    >(
+      workflow: Workflow<any, Payload, any, any>,
+      payload: Payload["Type"]
+    ) => Effect.Effect<string, never, never>
+  )
+  & MakeWorkflowExecutionId
+) = (workflowOrWorkflowOptions: any, payload: any) => {
+  // Use Workflow's executionId if a workflow is provided.
+  if (Predicate.hasProperty(workflowOrWorkflowOptions, TypeId)) {
+    const workflow = workflowOrWorkflowOptions as Workflow<any, any, any, any>;
+    return workflow.executionId(payload)
+  }
+  // Generate an executionId for a workflow options object and payload.
+  const options = workflowOrWorkflowOptions as any;
+  return makeWorkflowExecutionId(options, payload)
+}
+
 /**
  * @since 4.0.0
  * @category Constructors
@@ -287,13 +336,18 @@ export const make = <
   readonly error?: Error
   readonly suspendedRetrySchedule?: Schedule.Schedule<any, unknown> | undefined
   readonly annotations?: ServiceMap.ServiceMap<never>
+  readonly executionId?: MakeWorkflowExecutionId<Name, (
+    Payload extends Schema.Struct.Fields ? Schema.Struct<Payload> : Payload
+  )>
 }): Workflow<
   Name,
   Payload extends Schema.Struct.Fields ? Schema.Struct<Payload> : Payload,
   Success,
   Error
 > => {
-  const makeExecutionId = (payload: any) => makeHashDigest(`${options.name}-${options.idempotencyKey(payload)}`)
+  const makeExecutionId = (payload: any) => (
+    options.executionId ?? executionId
+  )(options as any, payload)
   const self: Workflow<Name, any, Success, Error> = {
     [TypeId]: TypeId,
     name: options.name,

--- a/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
+++ b/packages/effect/test/unstable/workflow/WorkflowEngine.test.ts
@@ -7,7 +7,14 @@ describe("WorkflowEngine", () => {
     name: "WorkflowEngine/IncrementWorkflow",
     payload: { value: Schema.Number },
     success: Schema.Number,
-    idempotencyKey: ({ value }) => String(value)
+    idempotencyKey: ({ value }) => String(value),
+    executionId: (options, payload) => Effect.gen(function* () {
+      const baseExecutionId = yield* Workflow.executionId(options, payload);
+      return [
+        options.name,
+        baseExecutionId,
+      ].join("/")
+    })
   })
 
   const IncrementWorkflowLayer = IncrementWorkflow.toLayer(({ value }) => Effect.succeed(value + 1))
@@ -33,6 +40,22 @@ describe("WorkflowEngine", () => {
       const discardedExecutionId = yield* IncrementWorkflow.execute({ value: 1 }, { discard: true })
 
       assert.strictEqual(discardedExecutionId, executionId)
+    }).pipe(
+      Effect.provide(IncrementWorkflowLayer.pipe(
+        Layer.provideMerge(WorkflowEngine.layerMemory)
+      ))
+    ))
+
+  it.effect("executionId uses makeWorkflowExecutionId from workflow options", () =>
+    Effect.gen(function*() {
+      const executionId = yield* IncrementWorkflow.executionId({ value: 1 });
+      const executionIdFromUtilityFunction = yield* Workflow.executionId(IncrementWorkflow, { value: 1 })
+      const expectedExecutionIdPrefix = [
+        IncrementWorkflow.name,
+      ].join("/");
+
+      assert.isTrue(executionId.startsWith(expectedExecutionIdPrefix))
+      assert.strictEqual(executionId, executionIdFromUtilityFunction)
     }).pipe(
       Effect.provide(IncrementWorkflowLayer.pipe(
         Layer.provideMerge(WorkflowEngine.layerMemory)


### PR DESCRIPTION


<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

- Adds `executionId` option to `Workflow.make` to override internal `Workflow.make` function `makeExecutionId`
- Adds `executionId` utility function to `Workflow.ts` to perform two functions:
  - Perform the default executionId generation for a given `Workflow.make` options object
  - Retrieve the execution ID for a given workflow and payload
    - We needed to expose the default generation for the convenience of overriding
    - It felt obtrusive exporting a `makeWorkflowExecutionId` function so I made the `executionId` function dual-purpose so it was worthy being a top-level export. Simply remaps to `workflow.executionId(payload)` when provided a `Workflow` instance.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes Effect-TS/effect-smol#1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes Effect-TS/effect#6367
