### PR TITLE
EFF-782 Support common string literals in HttpApiSchema.status

### DIFF
--- a/.changeset/eff-782-httpapi-status-literals.md
+++ b/.changeset/eff-782-httpapi-status-literals.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add support for common HTTP status string literals in `HttpApiSchema.status` (for example, `HttpApiSchema.status("Created")` resolves to status code `201`).

--- a/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSchema.ts
@@ -78,17 +78,96 @@ export type ResponseEncoding = {
   readonly contentType: string
 }
 
+const statusCodeByLiteral = {
+  Continue: 100,
+  SwitchingProtocols: 101,
+  Processing: 102,
+  EarlyHints: 103,
+  OK: 200,
+  Ok: 200,
+  Created: 201,
+  Accepted: 202,
+  NonAuthoritativeInformation: 203,
+  NoContent: 204,
+  ResetContent: 205,
+  PartialContent: 206,
+  MultiStatus: 207,
+  AlreadyReported: 208,
+  ImUsed: 226,
+  MultipleChoices: 300,
+  MovedPermanently: 301,
+  Found: 302,
+  SeeOther: 303,
+  NotModified: 304,
+  TemporaryRedirect: 307,
+  PermanentRedirect: 308,
+  BadRequest: 400,
+  Unauthorized: 401,
+  PaymentRequired: 402,
+  Forbidden: 403,
+  NotFound: 404,
+  MethodNotAllowed: 405,
+  NotAcceptable: 406,
+  ProxyAuthenticationRequired: 407,
+  RequestTimeout: 408,
+  Conflict: 409,
+  Gone: 410,
+  LengthRequired: 411,
+  PreconditionFailed: 412,
+  PayloadTooLarge: 413,
+  UriTooLong: 414,
+  UnsupportedMediaType: 415,
+  RangeNotSatisfiable: 416,
+  ExpectationFailed: 417,
+  ImATeapot: 418,
+  MisdirectedRequest: 421,
+  UnprocessableEntity: 422,
+  Locked: 423,
+  FailedDependency: 424,
+  TooEarly: 425,
+  UpgradeRequired: 426,
+  PreconditionRequired: 428,
+  TooManyRequests: 429,
+  RequestHeaderFieldsTooLarge: 431,
+  UnavailableForLegalReasons: 451,
+  InternalServerError: 500,
+  NotImplemented: 501,
+  BadGateway: 502,
+  ServiceUnavailable: 503,
+  GatewayTimeout: 504,
+  HttpVersionNotSupported: 505,
+  VariantAlsoNegotiates: 506,
+  InsufficientStorage: 507,
+  LoopDetected: 508,
+  NotExtended: 510,
+  NetworkAuthenticationRequired: 511
+} as const
+
+/**
+ * Common HTTP status code literals accepted by {@link status}.
+ *
+ * @category status
+ * @since 4.0.0
+ */
+export type StatusLiteral = keyof typeof statusCodeByLiteral
+
 /**
  * A convenience function to set the HTTP status code of a schema.
  *
  * This is equivalent to calling `.annotate({ httpApiStatus: code })` on the schema.
  *
+ * You can pass either a numeric status code (for example, `201`) or a common
+ * literal name (for example, `"Created"`).
+ *
  * @category status
  * @since 4.0.0
  */
-export function status(code: number) {
+export function status(code: number): <S extends Schema.Top>(self: S) => S["Rebuild"]
+export function status(code: StatusLiteral): <S extends Schema.Top>(self: S) => S["Rebuild"]
+export function status(code: number | StatusLiteral) {
+  const statusCode = typeof code === "string" ? statusCodeByLiteral[code] : code
   return <S extends Schema.Top>(self: S): S["Rebuild"] => {
-    return self.annotate({ httpApiStatus: code })
+    return self.annotate({ httpApiStatus: statusCode })
   }
 }
 

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -102,7 +102,7 @@ describe("HttpApi", () => {
       class M extends HttpApiMiddleware.Service<M>()("Http/Logger", {
         error: Schema.String
           .pipe(
-            HttpApiSchema.status(405),
+            HttpApiSchema.status("MethodNotAllowed"),
             HttpApiSchema.asText()
           )
       }) {}
@@ -998,7 +998,7 @@ describe("HttpApi", () => {
           HttpApiGroup.make("group")
             .add(
               HttpApiEndpoint.get("a", "/a", {
-                error: Schema.Void.pipe(HttpApiSchema.status(403))
+                error: Schema.Void.pipe(HttpApiSchema.status("Forbidden"))
               }),
               HttpApiEndpoint.get("b", "/b", {
                 error: HttpApiSchema.NoContent,
@@ -1007,7 +1007,7 @@ describe("HttpApi", () => {
               HttpApiEndpoint.get("c", "/c", {
                 error: Schema.String.pipe(
                   HttpApiSchema.asNoContent({ decode: () => "c" }),
-                  HttpApiSchema.status(403)
+                  HttpApiSchema.status("Forbidden")
                 )
               }),
               HttpApiEndpoint.get("d", "/d", {
@@ -1432,7 +1432,7 @@ describe("HttpApi", () => {
             decode: (message) => new RateLimitError({ message })
           })
         ),
-        HttpApiSchema.status(429),
+        HttpApiSchema.status("TooManyRequests"),
         HttpApiSchema.asText()
       )
 

--- a/packages/platform-node/test/OpenApi.test.ts
+++ b/packages/platform-node/test/OpenApi.test.ts
@@ -885,6 +885,20 @@ describe("OpenAPI spec", () => {
           })
         })
 
+        it("status(\"Created\")", () => {
+          const Api = HttpApi.make("api")
+            .add(
+              HttpApiGroup.make("group")
+                .add(HttpApiEndpoint.get("a", "/a", {
+                  success: Schema.Void.pipe(HttpApiSchema.status("Created"))
+                }))
+            )
+          const spec = OpenApi.fromApi(Api)
+          assert.deepStrictEqual(spec.paths["/a"].get?.responses["201"], {
+            description: "<No Content>"
+          })
+        })
+
         it("Accepted", () => {
           const Api = HttpApi.make("api")
             .add(


### PR DESCRIPTION
## Summary
- add common HTTP status string literal support to `HttpApiSchema.status` by overloading it to accept `StatusLiteral` names as well as numeric codes
- map string literals (for example `"Created"`, `"Forbidden"`, `"TooManyRequests"`) to numeric status codes in `HttpApiSchema`
- add integration coverage in platform-node tests, including a dedicated OpenAPI assertion that `HttpApiSchema.status("Created")` produces response status `201`
- include a changeset for the `effect` package

## Validation
- `pnpm lint-fix`
- `pnpm test packages/platform-node/test/OpenApi.test.ts`
- `pnpm test packages/platform-node/test/HttpApi.test.ts`
- `pnpm check:tsgo`