### PR TITLE
fix SchemaAST.isJson rejecting DAGs as cycles, closes #2021

### DIFF
--- a/.changeset/fix-is-json-dag.md
+++ b/.changeset/fix-is-json-dag.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `SchemaAST.isJson` rejecting DAGs as cycles, closes #2021.
+
+The previous implementation marked every visited object in a single `seen` set and never removed it, so any value that referenced the same object through two different paths (a DAG, e.g. `{ x: shared, y: shared }`) was treated as a cycle and returned `false`. Cycle detection now tracks only the current recursion path (popping on exit) and memoizes fully validated subtrees, so DAGs are accepted while true cycles are still rejected.

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -3372,7 +3372,14 @@ export const resolveDescription: (ast: AST) => string | undefined = InternalAnno
  * @internal
  */
 export function isJson(u: unknown): u is Schema.Json {
-  const seen = new Set<unknown>()
+  // `onPath` is the current recursion stack: nodes between the root and the
+  // one being visited. A hit here means we looped back to an ancestor — a
+  // real cycle, not a DAG — so the value is not JSON.
+  const onPath = new Set<unknown>()
+  // `validated` memoizes subtrees we've already fully checked. Without it, a
+  // diamond-shaped DAG (same node reached through multiple parents) would be
+  // re-traversed once per parent, which is exponential in the nesting depth.
+  const validated = new Set<unknown>()
   return recur(u)
 
   function recur(u: unknown): boolean {
@@ -3385,14 +3392,23 @@ export function isJson(u: unknown): u is Schema.Json {
     if (typeof u !== "object" || u === undefined) {
       return false
     }
-    if (seen.has(u)) {
+    if (onPath.has(u)) {
       return false
     }
-    seen.add(u)
-    if (Array.isArray(u)) {
-      return u.every(recur)
+    if (validated.has(u)) {
+      return true
     }
-    return Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
+    onPath.add(u)
+    const ok = Array.isArray(u)
+      ? u.every(recur)
+      : Object.keys(u).every((key) => recur((u as Record<string, unknown>)[key]))
+    // Pop on exit so siblings reaching the same node via a different path
+    // don't see it as an ancestor (that would reject valid DAGs).
+    onPath.delete(u)
+    if (ok) {
+      validated.add(u)
+    }
+    return ok
   }
 }
 

--- a/packages/effect/test/schema/SchemaAST.test.ts
+++ b/packages/effect/test/schema/SchemaAST.test.ts
@@ -32,6 +32,13 @@ describe("SchemaAST", () => {
     const circular: Record<string, unknown> = {}
     circular.self = circular
     strictEqual(SchemaAST.isJson(circular), false)
+    // accepts DAGs
+    const shared = { a: 1 }
+    strictEqual(SchemaAST.isJson({ x: shared, y: shared }), true)
+    strictEqual(SchemaAST.isJson([shared, { nested: shared }]), true)
+    // Nested DAG
+    const deeper = { parent: { left: shared, right: shared } }
+    strictEqual(SchemaAST.isJson(deeper), true)
   })
 
   it("isStringTree", () => {


### PR DESCRIPTION
The previous implementation marked every visited object in a single `seen` set and never removed it, so any value that referenced the same object through two different paths (a DAG, e.g. `{ x: shared, y: shared }`) was treated as a cycle and returned `false`. Cycle detection now tracks only the current recursion path (popping on exit) and memoizes fully validated subtrees, so DAGs are accepted while true cycles are still rejected.
