### PR TITLE
fix(ai-openai): accept "in_memory" for prompt_cache_retention in response schemas

### DIFF
--- a/.changeset/fix-openai-prompt-cache-retention-in-memory.md
+++ b/.changeset/fix-openai-prompt-cache-retention-in-memory.md
@@ -1,0 +1,7 @@
+---
+"@effect/ai-openai": patch
+---
+
+Accept `"in_memory"` (underscore) as a valid `prompt_cache_retention` value in generated response schemas.
+
+OpenAI's live API returns `"in_memory"` in `Response` / `ChatCompletion` / related payloads, but the OpenAPI spec published by OpenAI only documents `"in-memory"` (hyphen). Strict decoding of real responses therefore fails with `InvalidOutputError` at `["prompt_cache_retention"]`. The generated schemas now accept `"in-memory" | "24h" | "in_memory"` so responses decode successfully; the spec-documented hyphen form is still preserved for requests.

--- a/packages/ai/openai/codegen.yaml
+++ b/packages/ai/openai/codegen.yaml
@@ -35,3 +35,10 @@ replacements:
     to: "Schema.Record(Schema.String, Schema.Json)"
   - from: "{ readonly [x: string]: unknown }"
     to: "{ readonly [x: string]: Schema.Json }"
+  # OpenAI's API returns `in_memory` (underscore) for `prompt_cache_retention` even
+  # though the OpenAPI spec only documents `in-memory` (hyphen). Accept both so
+  # responses parse successfully. See https://community.openai.com/... for context.
+  - from: 'Schema.Literals(["in-memory", "24h"])'
+    to: 'Schema.Literals(["in-memory", "24h", "in_memory"])'
+  - from: '"in-memory" | "24h"'
+    to: '"in-memory" | "24h" | "in_memory"'

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -19599,7 +19599,7 @@ export type CreateChatCompletionRequest = {
   readonly "safety_identifier"?: string | null
   readonly "prompt_cache_key"?: string | null
   readonly "service_tier"?: ServiceTier
-  readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+  readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
   readonly "messages": ReadonlyArray<ChatCompletionRequestMessage>
   readonly "model":
     | string
@@ -19764,7 +19764,7 @@ export const CreateChatCompletionRequest = Schema.Struct({
   "service_tier": Schema.optionalKey(ServiceTier),
   "prompt_cache_retention": Schema.optionalKey(
     Schema.Union([
-      Schema.Literals(["in-memory", "24h"]).annotate({
+      Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
         "description":
           "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
       }),
@@ -21553,7 +21553,7 @@ export type Response = {
   readonly "safety_identifier"?: string | null
   readonly "prompt_cache_key"?: string | null
   readonly "service_tier"?: ServiceTier
-  readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+  readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
   readonly "previous_response_id"?: string | null
   readonly "model":
     | ModelIdsShared
@@ -21654,7 +21654,7 @@ export const Response = Schema.Struct({
   "service_tier": Schema.optionalKey(ServiceTier),
   "prompt_cache_retention": Schema.optionalKey(
     Schema.Union([
-      Schema.Literals(["in-memory", "24h"]).annotate({
+      Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
         "description":
           "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
       }),
@@ -21823,7 +21823,7 @@ export type ResponseCompletedEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -21930,7 +21930,7 @@ export const ResponseCompletedEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -22104,7 +22104,7 @@ export type ResponseCreatedEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -22211,7 +22211,7 @@ export const ResponseCreatedEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -22386,7 +22386,7 @@ export type ResponseFailedEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -22495,7 +22495,7 @@ export const ResponseFailedEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -22666,7 +22666,7 @@ export type ResponseInProgressEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -22773,7 +22773,7 @@ export const ResponseInProgressEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -22947,7 +22947,7 @@ export type ResponseIncompleteEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -23054,7 +23054,7 @@ export const ResponseIncompleteEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -23228,7 +23228,7 @@ export type ResponseQueuedEvent = {
     readonly "safety_identifier"?: string | null
     readonly "prompt_cache_key"?: string | null
     readonly "service_tier"?: ServiceTier
-    readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+    readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
     readonly "previous_response_id"?: string | null
     readonly "model":
       | ModelIdsShared
@@ -23335,7 +23335,7 @@ export const ResponseQueuedEvent = Schema.Struct({
     "service_tier": Schema.optionalKey(ServiceTier),
     "prompt_cache_retention": Schema.optionalKey(
       Schema.Union([
-        Schema.Literals(["in-memory", "24h"]).annotate({
+        Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
           "description":
             "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
         }),
@@ -23629,7 +23629,7 @@ export type CreateResponse = {
   readonly "safety_identifier"?: string | null
   readonly "prompt_cache_key"?: string | null
   readonly "service_tier"?: ServiceTier
-  readonly "prompt_cache_retention"?: "in-memory" | "24h" | null
+  readonly "prompt_cache_retention"?: "in-memory" | "24h" | "in_memory" | null
   readonly "previous_response_id"?: string | null
   readonly "model"?:
     | ModelIdsShared
@@ -23718,7 +23718,7 @@ export const CreateResponse = Schema.Struct({
   "service_tier": Schema.optionalKey(ServiceTier),
   "prompt_cache_retention": Schema.optionalKey(
     Schema.Union([
-      Schema.Literals(["in-memory", "24h"]).annotate({
+      Schema.Literals(["in-memory", "24h", "in_memory"]).annotate({
         "description":
           "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
       }),

--- a/packages/ai/openai/test/OpenAiClient.test.ts
+++ b/packages/ai/openai/test/OpenAiClient.test.ts
@@ -541,6 +541,49 @@ describe("OpenAiClient", () => {
       }))
   })
 
+  describe("createResponse", () => {
+    // OpenAI's API returns `in_memory` (underscore) for `prompt_cache_retention`
+    // even though the OpenAPI spec only documents `in-memory` (hyphen). The
+    // generated schema accepts both so responses decode successfully.
+    it.effect("accepts prompt_cache_retention=\"in_memory\" in response body", () =>
+      Effect.gen(function*() {
+        const mockClient = makeMockHttpClient((request) =>
+          Effect.succeed(makeMockResponse({
+            status: 200,
+            body: makeResponseBody({ prompt_cache_retention: "in_memory" }),
+            request
+          }))
+        )
+
+        const client = yield* OpenAiClient.make({
+          apiKey: Redacted.make("test-key")
+        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
+
+        const [body] = yield* client.createResponse({ model: "gpt-4o", input: "test" })
+
+        assert.strictEqual(body.prompt_cache_retention, "in_memory")
+      }))
+
+    it.effect("accepts prompt_cache_retention=\"in-memory\" in response body", () =>
+      Effect.gen(function*() {
+        const mockClient = makeMockHttpClient((request) =>
+          Effect.succeed(makeMockResponse({
+            status: 200,
+            body: makeResponseBody({ prompt_cache_retention: "in-memory" }),
+            request
+          }))
+        )
+
+        const client = yield* OpenAiClient.make({
+          apiKey: Redacted.make("test-key")
+        }).pipe(Effect.provide(Layer.succeed(HttpClient.HttpClient, mockClient)))
+
+        const [body] = yield* client.createResponse({ model: "gpt-4o", input: "test" })
+
+        assert.strictEqual(body.prompt_cache_retention, "in-memory")
+      }))
+  })
+
   describe("createResponseStream", () => {
     it.effect("accepts keepalive stream events", () => {
       const mockClient = makeMockHttpClient((request) =>


### PR DESCRIPTION
## Summary

- OpenAI's live API returns `prompt_cache_retention: "in_memory"` (underscore), but the OpenAPI spec only documents `"in-memory"` (hyphen). Every real response that includes this field fails strict decoding with `InvalidOutputError` at `["prompt_cache_retention"]`, breaking `createResponse`, `createChatCompletion`, and all response-stream events that carry the nested `Response` payload.
- Generated schemas (`CreateChatCompletionRequest`, `Response`, `CreateResponse`, `ResponseCompleted/Created/Failed/InProgress/Incomplete/QueuedEvent`) now accept `"in-memory" | "24h" | "in_memory"` so responses decode cleanly. The spec-documented hyphen form is preserved for requests.
- `codegen.yaml` gains a `replacements` rule so future regenerations from the Stainless spec keep the fix.

## Repro (before the fix)

Minimal `createResponse` mock with `prompt_cache_retention: "in_memory"` (what OpenAI actually returns today):

```
[classify-task] Classification failed
  [classifyTask] {"description":"Expected \"in-memory\" | \"24h\", got \"in_memory\"
  at [\"prompt_cache_retention\"]","_tag":"InvalidOutputError",...}
```

## Test plan

- [x] `pnpm --filter @effect/ai-openai test OpenAiClient` — 24/24 passing (2 new tests added covering both `"in_memory"` and `"in-memory"` in a decoded `Response` body).
- [x] `pnpm check:tsgo` — passes.
- [x] `pnpm lint-fix` — clean.
- [x] Changeset added (`.changeset/fix-openai-prompt-cache-retention-in-memory.md`, patch bump for `@effect/ai-openai`).