### PR TITLE
fix(rpc): add makeMsgPack for configurable msgpackr options

### DIFF
--- a/.changeset/add-make-msgpack.md
+++ b/.changeset/add-make-msgpack.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `RpcSerialization.makeMsgPack` for creating MessagePack serialization with custom msgpackr options. On Cloudflare Workers with `allow_eval_during_startup` (default for `compatibility_date >= 2025-06-01`), pass `{ useRecords: false }` to prevent msgpackr's JIT code generation via `new Function()`, which is blocked during request handling. Also fixes silent error swallowing in the `msgPack` decode path — non-incomplete errors are now rethrown instead of returning `[]`.

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -400,47 +400,67 @@ interface JsonRpcResponse {
 type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse
 
 /**
+ * Create a MessagePack serialization with custom msgpackr options.
+ *
+ * On Cloudflare Workers with `allow_eval_during_startup` (default for
+ * `compatibility_date >= 2025-06-01`), pass `{ useRecords: false }` to
+ * prevent msgpackr's JIT code generation via `new Function()`, which is
+ * blocked during request handling.
+ *
+ * @since 4.0.0
+ * @category serialization
+ * @example
+ * ```ts
+ * import { Layer } from "effect"
+ * import { RpcSerialization } from "effect/unstable/rpc"
+ *
+ * // Cloudflare Workers
+ * Layer.succeed(RpcSerialization)(
+ *   RpcSerialization.makeMsgPack({ useRecords: false })
+ * )
+ * ```
+ */
+export const makeMsgPack = (options: Msgpackr.Options): RpcSerialization["Service"] =>
+  RpcSerialization.of({
+    contentType: "application/msgpack",
+    includesFraming: true,
+    makeUnsafe: () => {
+      const unpackr = new Msgpackr.Unpackr(options)
+      const packr = new Msgpackr.Packr(options)
+      const encoder = new TextEncoder()
+      let incomplete: Uint8Array | undefined = undefined
+      return {
+        decode: (bytes) => {
+          let buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes
+          if (incomplete !== undefined) {
+            const prev = buf
+            bytes = new Uint8Array(incomplete.length + buf.length)
+            bytes.set(incomplete)
+            bytes.set(prev, incomplete.length)
+            buf = bytes
+            incomplete = undefined
+          }
+          try {
+            return unpackr.unpackMultiple(buf)
+          } catch (error_) {
+            const error = error_ as any
+            if (error.incomplete) {
+              incomplete = buf.subarray(error.lastPosition)
+              return error.values ?? []
+            }
+            throw error_
+          }
+        },
+        encode: (response) => packr.pack(response)
+      }
+    }
+  })
+
+/**
  * @since 4.0.0
  * @category serialization
  */
-export const msgPack: RpcSerialization["Service"] = RpcSerialization.of({
-  contentType: "application/msgpack",
-  includesFraming: true,
-  makeUnsafe: () => {
-    const unpackr = new Msgpackr.Unpackr({
-      useRecords: true
-    })
-    const packr = new Msgpackr.Packr({
-      useRecords: true
-    })
-    const encoder = new TextEncoder()
-    let incomplete: Uint8Array | undefined = undefined
-    return {
-      decode: (bytes) => {
-        let buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes
-        if (incomplete !== undefined) {
-          const prev = buf
-          bytes = new Uint8Array(incomplete.length + buf.length)
-          bytes.set(incomplete)
-          bytes.set(prev, incomplete.length)
-          buf = bytes
-          incomplete = undefined
-        }
-        try {
-          return unpackr.unpackMultiple(buf)
-        } catch (error_) {
-          const error = error_ as any
-          if (error.incomplete) {
-            incomplete = buf.subarray(error.lastPosition)
-            return error.values ?? []
-          }
-          return []
-        }
-      },
-      encode: (response) => packr.pack(response)
-    }
-  }
-})
+export const msgPack: RpcSerialization["Service"] = makeMsgPack({ useRecords: true })
 
 /**
  * A rpc serialization layer that uses JSON for serialization.
@@ -490,6 +510,11 @@ export const layerNdJsonRpc = (options?: {
  *
  * MessagePack has a more compact binary format compared to JSON and NDJSON. It
  * also has better support for binary data.
+ *
+ * On Cloudflare Workers with `allow_eval_during_startup` (default for
+ * `compatibility_date >= 2025-06-01`), use {@link makeMsgPack} with
+ * `{ useRecords: false }` to prevent msgpackr's JIT code generation via
+ * `new Function()`, which is blocked during request handling.
  *
  * @since 4.0.0
  * @category serialization

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -402,25 +402,10 @@ type JsonRpcMessage = JsonRpcRequest | JsonRpcResponse
 /**
  * Create a MessagePack serialization with custom msgpackr options.
  *
- * On Cloudflare Workers with `allow_eval_during_startup` (default for
- * `compatibility_date >= 2025-06-01`), pass `{ useRecords: false }` to
- * prevent msgpackr's JIT code generation via `new Function()`, which is
- * blocked during request handling.
- *
  * @since 4.0.0
  * @category serialization
- * @example
- * ```ts
- * import { Layer } from "effect"
- * import { RpcSerialization } from "effect/unstable/rpc"
- *
- * // Cloudflare Workers
- * Layer.succeed(RpcSerialization)(
- *   RpcSerialization.makeMsgPack({ useRecords: false })
- * )
- * ```
  */
-export const makeMsgPack = (options: Msgpackr.Options): RpcSerialization["Service"] =>
+export const makeMsgPack = (options?: Msgpackr.Options | undefined): RpcSerialization["Service"] =>
   RpcSerialization.of({
     contentType: "application/msgpack",
     includesFraming: true,
@@ -430,7 +415,7 @@ export const makeMsgPack = (options: Msgpackr.Options): RpcSerialization["Servic
       const encoder = new TextEncoder()
       let incomplete: Uint8Array | undefined = undefined
       return {
-        decode: (bytes) => {
+        decode(bytes) {
           let buf = typeof bytes === "string" ? encoder.encode(bytes) : bytes
           if (incomplete !== undefined) {
             const prev = buf
@@ -510,11 +495,6 @@ export const layerNdJsonRpc = (options?: {
  *
  * MessagePack has a more compact binary format compared to JSON and NDJSON. It
  * also has better support for binary data.
- *
- * On Cloudflare Workers with `allow_eval_during_startup` (default for
- * `compatibility_date >= 2025-06-01`), use {@link makeMsgPack} with
- * `{ useRecords: false }` to prevent msgpackr's JIT code generation via
- * `new Function()`, which is blocked during request handling.
  *
  * @since 4.0.0
  * @category serialization

--- a/packages/effect/test/rpc/RpcSerialization.test.ts
+++ b/packages/effect/test/rpc/RpcSerialization.test.ts
@@ -132,4 +132,40 @@ describe("RpcSerialization", () => {
       "{\"jsonrpc\":\"2.0\",\"method\":\"users.get\",\"params\":null,\"id\":\"\",\"headers\":[]}"
     )
   })
+
+  it("msgPack encodes and decodes a payload", () => {
+    const parser = RpcSerialization.msgPack.makeUnsafe()
+    const payload = { _tag: "Request", id: 1, method: "echo" }
+    const encoded = parser.encode(payload)
+    const decoded = parser.decode(encoded as Uint8Array)
+    assert.strictEqual(decoded.length, 1)
+    assert.deepStrictEqual(decoded[0], payload)
+  })
+
+  it("makeMsgPack with useRecords false encodes and decodes a payload", () => {
+    const parser = RpcSerialization.makeMsgPack({ useRecords: false }).makeUnsafe()
+    const payload = { _tag: "Request", id: 1, method: "echo" }
+    const encoded = parser.encode(payload)
+    const decoded = parser.decode(encoded as Uint8Array)
+    assert.strictEqual(decoded.length, 1)
+    assert.deepStrictEqual(decoded[0], payload)
+  })
+
+  it("makeMsgPack with useRecords false handles nested objects with repeated structures", () => {
+    const parser = RpcSerialization.makeMsgPack({ useRecords: false }).makeUnsafe()
+    const payload = {
+      _tag: "Chunk",
+      requestId: "1",
+      values: [
+        responseExitSuccess("1", { _tag: "Ok", data: "a" }),
+        responseExitSuccess("2", { _tag: "Ok", data: "b" }),
+        responseExitSuccess("3", { _tag: "Ok", data: "c" }),
+        responseExitSuccess("4", { _tag: "Ok", data: "d" })
+      ]
+    }
+    const encoded = parser.encode(payload)
+    const decoded = parser.decode(encoded as Uint8Array)
+    assert.strictEqual(decoded.length, 1)
+    assert.deepStrictEqual(decoded[0], payload)
+  })
 })


### PR DESCRIPTION
## Problem

`RpcSerialization.msgPack` silently fails on Cloudflare Workers when decoding messages with 3+ same-structure objects. The `Packr`/`Unpackr` are constructed with `useRecords: true`, which enables msgpackr's record path. When the JIT threshold is reached, msgpackr calls `new Function()` — blocked by CF Workers during request handling — and the `catch { return [] }` in the decode path silently swallows the resulting `EvalError`.

## Solution

Add `RpcSerialization.makeMsgPack(options)` factory accepting `msgpackr.Options`. CF Workers users pass `{ useRecords: false }`:

```ts
Layer.succeed(RpcSerialization)(
  RpcSerialization.makeMsgPack({ useRecords: false })
)
```

Existing `msgPack` / `layerMsgPack` exports are unchanged. Also rethrows non-incomplete decode errors instead of returning `[]`.

Same fix as v3: https://github.com/Effect-TS/effect/pull/6161
Reproduction: https://github.com/bohdanbirdie/repro-effect-rpc-msgpack-cf-workers