### PR TITLE
fix: fix `isNullish()` type predicate

### DIFF
--- a/.changeset/rich-dots-push.md
+++ b/.changeset/rich-dots-push.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+fix `isNullish()` type predicate

--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -879,7 +879,7 @@ export function isNotNull<A>(input: A): input is Exclude<A, null> {
  * @since 4.0.0
  */
 export function isNullish<A>(input: A): input is A & (null | undefined) {
-  return input == null
+  return input === null || input === undefined
 }
 
 /**

--- a/packages/effect/src/Predicate.ts
+++ b/packages/effect/src/Predicate.ts
@@ -878,8 +878,8 @@ export function isNotNull<A>(input: A): input is Exclude<A, null> {
  * @category guards
  * @since 4.0.0
  */
-export function isNullish<A>(input: A): input is Extract<A, null | undefined> {
-  return input === null || input === undefined
+export function isNullish<A>(input: A): input is A & (null | undefined) {
+  return input == null
 }
 
 /**

--- a/packages/effect/typetest/Predicate.tst.ts
+++ b/packages/effect/typetest/Predicate.tst.ts
@@ -65,7 +65,7 @@ describe("Predicate", () => {
     expect(numberOrNullOrUndefined.filter(Predicate.isNullish)).type.toBe<Array<null | undefined>>()
 
     if (Predicate.isNullish(u)) {
-      expect.skip(u).type.toBe<null | undefined>()
+      expect(u).type.toBe<null | undefined>()
     }
   })
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR is fixes `isNullish()` type predicate. I replaced `input is Extract<A, null | undefined>` with `input is A & (null | undefined)`. This works similar to `isNotNullish()` predicated where `NonNullable` utility is used which is implements as `T & {}`.

The intersection keeps only the overlapping parts of the type. This is `null | undefined` in `isNullish()` predicate; or `{}` (non nullish type) in `isNotNullish()` predicate.