### PR TITLE
AtomHttpApi include middleware errors in queries and mutations

### DIFF
--- a/.changeset/eff-783-atom-http-api-errors.md
+++ b/.changeset/eff-783-atom-http-api-errors.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `AtomHttpApi` query and mutation error inference to include endpoint middleware and client middleware errors, matching `HttpApiClient` behavior (including response-only mutation mode).

--- a/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
+++ b/packages/effect/src/unstable/reactivity/AtomHttpApi.ts
@@ -16,6 +16,7 @@ import type * as HttpApi from "../httpapi/HttpApi.ts"
 import * as HttpApiClient from "../httpapi/HttpApiClient.ts"
 import * as HttpApiEndpoint from "../httpapi/HttpApiEndpoint.ts"
 import type * as HttpApiGroup from "../httpapi/HttpApiGroup.ts"
+import type * as HttpApiMiddleware from "../httpapi/HttpApiMiddleware.ts"
 import * as AsyncResult from "./AsyncResult.ts"
 import * as Atom from "./Atom.ts"
 import * as Reactivity from "./Reactivity.ts"
@@ -57,7 +58,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
       infer _Headers,
       infer _Success,
       infer _Error,
-      infer _R,
+      infer _Middleware,
       infer _RE
     >
   ] ? Atom.AtomResultFn<
@@ -67,7 +68,7 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
         }
       >,
       ResponseByMode<_Success["Type"], ResponseMode>,
-      _Error["Type"]
+      ErrorByMode<_Error, _Middleware, ResponseMode>
     >
     : never
 
@@ -119,13 +120,13 @@ export interface AtomHttpApiClient<Self, Id extends string, Groups extends HttpA
       infer _Headers,
       infer _Success,
       infer _Error,
-      infer _R,
+      infer _Middleware,
       infer _RE
     >
   ] ? Atom.Atom<
       AsyncResult.AsyncResult<
         ResponseByMode<_Success["Type"], ResponseMode>,
-        _Error["Type"]
+        ErrorByMode<_Error, _Middleware, ResponseMode>
       >
     >
     : never
@@ -316,3 +317,12 @@ type ResponseByMode<Success, ResponseMode extends HttpApiEndpoint.ClientResponse
   ["decoded-and-response"] ? [Success, HttpClientResponse]
   : [ResponseMode] extends ["response-only"] ? HttpClientResponse
   : Success
+
+type ErrorByMode<
+  Error extends Schema.Top,
+  Middleware,
+  ResponseMode extends HttpApiEndpoint.ClientResponseMode
+> =
+  | HttpApiMiddleware.Error<Middleware>
+  | HttpApiMiddleware.ClientError<Middleware>
+  | ([ResponseMode] extends ["response-only"] ? never : Error["Type"])

--- a/packages/effect/typetest/unstable/reactivity/AtomHttpApi.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AtomHttpApi.tst.ts
@@ -1,0 +1,63 @@
+import { Effect, Layer, Schema } from "effect"
+import { HttpClient } from "effect/unstable/http"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware } from "effect/unstable/httpapi"
+import { type Atom, AtomHttpApi } from "effect/unstable/reactivity"
+import { describe, expect, it } from "tstyche"
+
+class EndpointError extends Schema.ErrorClass<EndpointError>("EndpointError")({
+  _tag: Schema.tag("EndpointError")
+}) {}
+
+class MiddlewareError extends Schema.ErrorClass<MiddlewareError>("MiddlewareError")({
+  _tag: Schema.tag("MiddlewareError")
+}) {}
+
+class MiddlewareClientError extends Schema.ErrorClass<MiddlewareClientError>("MiddlewareClientError")({
+  _tag: Schema.tag("MiddlewareClientError")
+}) {}
+
+class TestMiddleware extends HttpApiMiddleware.Service<TestMiddleware, {
+  clientError: MiddlewareClientError
+}>()("TestMiddleware", {
+  error: MiddlewareError,
+  requiredForClient: true
+}) {}
+
+const Api = HttpApi.make("Api").add(
+  HttpApiGroup.make("group").add(
+    HttpApiEndpoint.get("get", "/get", {
+      success: Schema.String,
+      error: EndpointError
+    }).middleware(TestMiddleware)
+  )
+)
+
+const Client = AtomHttpApi.Service()("Client", {
+  api: Api,
+  httpClient: Layer.succeed(HttpClient.HttpClient, HttpClient.make(() => Effect.die("not used")))
+})
+
+describe("AtomHttpApi", () => {
+  it("should include middleware errors in query and mutation atoms", () => {
+    const mutation = Client.mutation("group", "get")
+    const query = Client.query("group", "get", {})
+
+    expect<Atom.Failure<typeof mutation>>().type.toBe<
+      EndpointError | MiddlewareError | MiddlewareClientError
+    >()
+
+    expect<Atom.Failure<typeof query>>().type.toBe<
+      EndpointError | MiddlewareError | MiddlewareClientError
+    >()
+  })
+
+  it("should mirror HttpApiClient response-only error behavior", () => {
+    const mutation = Client.mutation("group", "get", {
+      responseMode: "response-only"
+    })
+
+    expect<Atom.Failure<typeof mutation>>().type.toBe<
+      MiddlewareError | MiddlewareClientError
+    >()
+  })
+})


### PR DESCRIPTION
## Summary
- update `AtomHttpApi` type signatures so query / mutation errors include endpoint middleware errors and client middleware errors
- preserve HttpApiClient response-mode behavior in types by excluding endpoint errors for mutation `response-only` mode
- add a new tstyche typetest for `AtomHttpApi` error inference, plus a changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/reactivity/AtomHttpApi.test.ts
- pnpm test-types packages/effect/typetest/unstable/reactivity/AtomHttpApi.tst.ts
- pnpm check:tsgo