### PR TITLE
fix: floor TestClock nanoseconds before BigInt conversion

### DIFF
--- a/.changeset/tidy-stars-drive.md
+++ b/.changeset/tidy-stars-drive.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `TestClock.currentTimeNanosUnsafe()` to floor fractional millisecond instants before converting them to `BigInt`.

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -235,7 +235,7 @@ export const make = Effect.fnUntraced(function*(
   }
 
   function currentTimeNanosUnsafe(): bigint {
-    return BigInt(currentTimestamp * 1000000)
+    return BigInt(Math.floor(currentTimestamp * 1000000))
   }
 
   const currentTimeMillis = Effect.sync(currentTimeMillisUnsafe)

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -53,4 +53,11 @@ describe("TestClock", () => {
       yield* TestClock.setTime(Duration.toMillis(Duration.hours(11)))
       assert.isTrue(elapsed)
     }))
+
+  it.effect("setTime - floors nanoseconds for fractional millisecond instants", () =>
+    Effect.gen(function*() {
+      const testClock = yield* TestClock.make()
+      yield* testClock.setTime(34199023438.000004)
+      assert.strictEqual(testClock.currentTimeNanosUnsafe(), 34199023438000004n)
+    }))
 })

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -57,7 +57,7 @@ describe("TestClock", () => {
   it.effect("setTime - floors nanoseconds for fractional millisecond instants", () =>
     Effect.gen(function*() {
       const testClock = yield* TestClock.make()
-      yield* testClock.setTime(34199023438.0000004)
-      assert.strictEqual(testClock.currentTimeNanosUnsafe(), 34199023438000000n)
+      yield* testClock.setTime(199023438.0000004)
+      assert.strictEqual(testClock.currentTimeNanosUnsafe(), 199023438000000n)
     }))
 })

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -57,7 +57,7 @@ describe("TestClock", () => {
   it.effect("setTime - floors nanoseconds for fractional millisecond instants", () =>
     Effect.gen(function*() {
       const testClock = yield* TestClock.make()
-      yield* testClock.setTime(34199023438.000004)
-      assert.strictEqual(testClock.currentTimeNanosUnsafe(), 34199023438000004n)
+      yield* testClock.setTime(34199023438.0000004)
+      assert.strictEqual(testClock.currentTimeNanosUnsafe(), 34199023438000000n)
     }))
 })


### PR DESCRIPTION
## Summary
- floor `TestClock.currentTimeNanosUnsafe()` before converting fractional millisecond instants to `BigInt`
- add a regression test covering a fractional `setTime(...)` timestamp
- add a patch changeset for `effect`

Port of: https://github.com/Effect-TS/effect/pull/6194