### PR TITLE
add @effect/sql-pglite package

### DIFF
--- a/.changeset/add-sql-pglite.md
+++ b/.changeset/add-sql-pglite.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pglite": minor
+---
+
+Add `@effect/sql-pglite` package, wrapping `@electric-sql/pglite` with the Effect SQL client (Postgres dialect, Effect-managed transactions via savepoints, listen/notify, dumpDataDir/refreshArrayTypes, and a Migrator).

--- a/packages/sql/pglite/CHANGELOG.md
+++ b/packages/sql/pglite/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @effect/sql-pglite

--- a/packages/sql/pglite/LICENSE
+++ b/packages/sql/pglite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sql/pglite/README.md
+++ b/packages/sql/pglite/README.md
@@ -1,0 +1,7 @@
+# `@effect/sql-pglite`
+
+An `@effect/sql` implementation using the `@electric-sql/pglite` library.
+
+## Documentation
+
+- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/sql-pglite).

--- a/packages/sql/pglite/docgen.json
+++ b/packages/sql/pglite/docgen.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../node_modules/@effect/docgen/schema.json",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/pglite/src/",
+  "exclude": ["src/internal/**/*.ts"],
+  "tscExecutable": "tsgo",
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rewriteRelativeImportExtensions": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "effect": ["../../../effect/src/index.js"],
+      "effect/*": ["../../../effect/src/*.js"]
+    }
+  }
+}

--- a/packages/sql/pglite/package.json
+++ b/packages/sql/pglite/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@effect/sql-pglite",
+  "version": "4.0.0-beta.52",
+  "type": "module",
+  "license": "MIT",
+  "description": "A PGlite toolkit for Effect",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect-smol.git",
+    "directory": "packages/sql/pglite"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect-smol/issues"
+  },
+  "tags": [
+    "typescript",
+    "sql",
+    "pglite",
+    "postgres",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "sql",
+    "pglite",
+    "postgres",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "codegen": "effect-utils codegen",
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "build:tsgo": "tsgo -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "devDependencies": {
+    "effect": "workspace:^"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^"
+  },
+  "dependencies": {
+    "@electric-sql/pglite": "^0.4.4"
+  }
+}

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -1,0 +1,434 @@
+/**
+ * @since 1.0.0
+ */
+import { PGlite, type PGliteInterface, type PGliteOptions } from "@electric-sql/pglite"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Queue from "effect/Queue"
+import * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import * as Stream from "effect/Stream"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Client from "effect/unstable/sql/SqlClient"
+import type { Connection } from "effect/unstable/sql/SqlConnection"
+import {
+  AuthenticationError,
+  AuthorizationError,
+  ConnectionError,
+  ConstraintError,
+  DeadlockError,
+  LockTimeoutError,
+  SerializationError,
+  SqlError,
+  SqlSyntaxError,
+  StatementTimeoutError,
+  UnknownError
+} from "effect/unstable/sql/SqlError"
+import type { Custom, Fragment } from "effect/unstable/sql/Statement"
+import * as Statement from "effect/unstable/sql/Statement"
+
+/**
+ * @category type ids
+ * @since 1.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-pglite/PgliteClient"
+
+/**
+ * @category type ids
+ * @since 1.0.0
+ */
+export type TypeId = "~@effect/sql-pglite/PgliteClient"
+
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export interface PgliteClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId
+  readonly config: PgliteClientConfig
+  readonly pglite: PGliteInterface
+  readonly json: (_: unknown) => Fragment
+  readonly listen: (channel: string) => Stream.Stream<string, SqlError>
+  readonly notify: (channel: string, payload: string) => Effect.Effect<void, SqlError>
+  readonly dumpDataDir: (compression?: "none" | "gzip" | "auto") => Effect.Effect<File | Blob, SqlError>
+  readonly refreshArrayTypes: Effect.Effect<void, SqlError>
+}
+
+/**
+ * @category tags
+ * @since 1.0.0
+ */
+export const PgliteClient = Context.Service<PgliteClient>("@effect/sql-pglite/PgliteClient")
+
+const PgliteTransaction = Context.Service<readonly [PgliteConnection, counter: number]>(
+  "@effect/sql-pglite/PgliteClient/PgliteTransaction"
+)
+
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export type PgliteClientConfig = PgliteClientConfig.Create | PgliteClientConfig.Live
+
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export declare namespace PgliteClientConfig {
+  /**
+   * @category models
+   * @since 1.0.0
+   */
+  export interface Base {
+    readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly transformResultNames?: ((str: string) => string) | undefined
+    readonly transformQueryNames?: ((str: string) => string) | undefined
+    readonly transformJson?: boolean | undefined
+  }
+
+  /**
+   * @category models
+   * @since 1.0.0
+   */
+  export interface Create extends Base, PGliteOptions {}
+
+  /**
+   * @category models
+   * @since 1.0.0
+   */
+  export interface Live extends Base {
+    readonly liveClient: PGliteInterface
+  }
+
+  /**
+   * @category models
+   * @since 1.0.0
+   */
+  export interface ConfigBase extends Base {
+    readonly dataDir?: string | undefined
+    readonly username?: string | undefined
+    readonly database?: string | undefined
+    readonly relaxedDurability?: boolean | undefined
+  }
+}
+
+interface PgliteConnection extends Connection {}
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const make = (
+  options: PgliteClientConfig
+): Effect.Effect<PgliteClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const pglite: PGliteInterface = "liveClient" in options
+      ? options.liveClient
+      : yield* Effect.acquireRelease(
+        Effect.tryPromise({
+          try: async () => {
+            const pg = new PGlite(options as PGliteOptions)
+            await pg.waitReady
+            return pg as PGliteInterface
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "PgliteClient: Failed to connect", "connect") })
+        }),
+        (pg) => Effect.promise(() => pg.close()).pipe(Effect.timeoutOption(1000))
+      )
+
+    return yield* fromClient({ ...options, liveClient: pglite })
+  })
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const fromClient = (
+  options:
+    & PgliteClientConfig.Base
+    & {
+      readonly liveClient: PGliteInterface
+    }
+): Effect.Effect<PgliteClient, never, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const pglite = options.liveClient
+    const compiler = makeCompiler(options.transformQueryNames, options.transformJson)
+    const transformRows = options.transformResultNames
+      ? Statement.defaultTransforms(options.transformResultNames, options.transformJson).array
+      : undefined
+
+    const spanAttributes: Array<[string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "postgresql"]
+    ]
+
+    class PgliteConnectionImpl implements PgliteConnection {
+      private run(sql: string, params: ReadonlyArray<unknown>) {
+        return Effect.map(
+          Effect.tryPromise({
+            try: () => pglite.query<any>(sql, params as Array<any>),
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          }),
+          (result) => result.rows
+        )
+      }
+      execute(
+        sql: string,
+        params: ReadonlyArray<unknown>,
+        transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+      ) {
+        return transformRows
+          ? Effect.map(this.run(sql, params), transformRows)
+          : this.run(sql, params)
+      }
+      executeRaw(sql: string, params: ReadonlyArray<unknown>) {
+        return Effect.tryPromise({
+          try: () => pglite.query<any>(sql, params as Array<any>),
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
+      }
+      executeValues(sql: string, params: ReadonlyArray<unknown>) {
+        return Effect.map(
+          Effect.tryPromise({
+            try: () => pglite.query<any>(sql, params as Array<any>, { rowMode: "array" }),
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          }),
+          (result) => result.rows as ReadonlyArray<ReadonlyArray<any>>
+        )
+      }
+      executeUnprepared(
+        sql: string,
+        params: ReadonlyArray<unknown>,
+        transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+      ) {
+        return this.execute(sql, params, transformRows)
+      }
+      executeStream() {
+        return Stream.die("executeStream not implemented")
+      }
+    }
+
+    const connection: PgliteConnection = new PgliteConnectionImpl()
+    const semaphore = yield* Semaphore.make(1)
+
+    const transactionAcquirer: Effect.Effect<readonly [Scope.Closeable, PgliteConnection], SqlError> = Effect
+      .uninterruptibleMask(Effect.fnUntraced(function*(restore) {
+        const scope = Scope.makeUnsafe()
+        yield* restore(semaphore.take(1))
+        yield* Scope.addFinalizer(scope, semaphore.release(1))
+        return [scope, connection] as const
+      }))
+
+    const withTransaction = Client.makeWithTransaction({
+      transactionService: PgliteTransaction,
+      spanAttributes,
+      acquireConnection: transactionAcquirer,
+      begin: (conn) => conn.executeRaw("BEGIN", []).pipe(Effect.asVoid),
+      savepoint: (conn, id) => conn.executeRaw(`SAVEPOINT effect_sql_${id}`, []).pipe(Effect.asVoid),
+      commit: (conn) => conn.executeRaw("COMMIT", []).pipe(Effect.asVoid),
+      rollback: (conn) => conn.executeRaw("ROLLBACK", []).pipe(Effect.asVoid),
+      rollbackSavepoint: (conn, id) => conn.executeRaw(`ROLLBACK TO SAVEPOINT effect_sql_${id}`, []).pipe(Effect.asVoid)
+    })
+
+    const acquirer = Effect.flatMap(
+      Effect.serviceOption(PgliteTransaction),
+      Option.match({
+        onNone: () => semaphore.withPermits(1)(Effect.succeed(connection)),
+        onSome: ([conn]) => Effect.succeed(conn)
+      })
+    )
+
+    const config: PgliteClientConfig = options as PgliteClientConfig
+
+    return Object.assign(
+      yield* Client.make({
+        acquirer,
+        compiler,
+        spanAttributes,
+        transformRows
+      }),
+      {
+        [TypeId]: TypeId as TypeId,
+        config,
+        withTransaction,
+        pglite,
+        json: (_: unknown) => Statement.fragment([PgJson(_)]),
+        listen: (channel: string) =>
+          Stream.callback<string, SqlError>(Effect.fnUntraced(function*(queue) {
+            const unlisten = yield* Effect.tryPromise({
+              try: () =>
+                pglite.listen(channel, (payload) => {
+                  Queue.offerUnsafe(queue, payload)
+                }),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to listen", "listen") })
+            })
+            yield* Effect.addFinalizer(() => Effect.promise(() => unlisten()))
+          })),
+        notify: (channel: string, payload: string) =>
+          Effect.tryPromise({
+            try: () => pglite.query("SELECT pg_notify($1, $2)", [channel, payload]),
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to notify", "notify") })
+          }).pipe(Effect.asVoid),
+        dumpDataDir: (compression?: "none" | "gzip" | "auto") =>
+          Effect.tryPromise({
+            try: () => pglite.dumpDataDir(compression),
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to dump data dir", "dumpDataDir") })
+          }),
+        refreshArrayTypes: Effect.tryPromise({
+          try: () => pglite.refreshArrayTypes(),
+          catch: (cause) =>
+            new SqlError({ reason: classifyError(cause, "Failed to refresh array types", "refreshArrayTypes") })
+        })
+      }
+    )
+  })
+
+/**
+ * @category layers
+ * @since 1.0.0
+ */
+export const layerFrom = <E, R>(
+  acquire: Effect.Effect<PgliteClient, E, R>
+): Layer.Layer<PgliteClient | Client.SqlClient, E, Exclude<R, Scope.Scope | Reactivity.Reactivity>> =>
+  Layer.effectContext(
+    Effect.map(acquire, (client) =>
+      Context.make(PgliteClient, client).pipe(
+        Context.add(Client.SqlClient, client)
+      ))
+  ).pipe(Layer.provide(Reactivity.layer)) as any
+
+/**
+ * @category layers
+ * @since 1.0.0
+ */
+export const layerConfig: (
+  config: Config.Wrap<PgliteClientConfig.ConfigBase>
+) => Layer.Layer<PgliteClient | Client.SqlClient, Config.ConfigError | SqlError> = (
+  config: Config.Wrap<PgliteClientConfig.ConfigBase>
+): Layer.Layer<PgliteClient | Client.SqlClient, Config.ConfigError | SqlError> =>
+  layerFrom(Effect.flatMap(
+    Config.unwrap(config).asEffect(),
+    (resolved) => make(resolved as PgliteClientConfig)
+  ))
+
+/**
+ * @category layers
+ * @since 1.0.0
+ */
+export const layer = (
+  config: PgliteClientConfig
+): Layer.Layer<PgliteClient | Client.SqlClient, SqlError> => layerFrom(make(config))
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const makeCompiler = (
+  transform?: (_: string) => string,
+  transformJson = true
+): Statement.Compiler => {
+  const transformValue = transformJson && transform
+    ? Statement.defaultTransforms(transform).value
+    : undefined
+
+  return Statement.makeCompiler<PgCustom>({
+    dialect: "pg",
+    placeholder(_) {
+      return `$${_}`
+    },
+    onIdentifier: transform ?
+      function(value, withoutTransform) {
+        return withoutTransform ? escape(value) : escape(transform(value))
+      } :
+      escape,
+    onRecordUpdate(placeholders, valueAlias, valueColumns, values, returning) {
+      return [
+        `(values ${placeholders}) AS ${valueAlias}${valueColumns}${returning ? ` RETURNING ${returning[0]}` : ""}`,
+        returning ?
+          values.flat().concat(returning[1]) :
+          values.flat()
+      ]
+    },
+    onCustom(type, placeholder, withoutTransform) {
+      switch (type.kind) {
+        case "PgJson": {
+          return [
+            placeholder(undefined),
+            [
+              withoutTransform || transformValue === undefined
+                ? type.paramA
+                : transformValue(type.paramA)
+            ]
+          ]
+        }
+      }
+    }
+  })
+}
+
+const escape = Statement.defaultEscape("\"")
+
+/**
+ * @category custom types
+ * @since 1.0.0
+ */
+export type PgCustom = PgJson
+
+/**
+ * @category custom types
+ * @since 1.0.0
+ */
+interface PgJson extends Custom<"PgJson", unknown> {}
+const PgJson = Statement.custom<PgJson>("PgJson")
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+
+const pgCodeFromCause = (cause: unknown): string | undefined => {
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return undefined
+  }
+  const code = (cause as { code: unknown }).code
+  return typeof code === "string" ? code : undefined
+}
+
+const classifyError = (
+  cause: unknown,
+  message: string,
+  operation: string
+) => {
+  const props = { cause, message, operation }
+  const code = pgCodeFromCause(cause)
+  if (code !== undefined) {
+    if (code.startsWith("08")) {
+      return new ConnectionError(props)
+    }
+    if (code.startsWith("28")) {
+      return new AuthenticationError(props)
+    }
+    if (code === "42501") {
+      return new AuthorizationError(props)
+    }
+    if (code.startsWith("42")) {
+      return new SqlSyntaxError(props)
+    }
+    if (code.startsWith("23")) {
+      return new ConstraintError(props)
+    }
+    if (code === "40P01") {
+      return new DeadlockError(props)
+    }
+    if (code === "40001") {
+      return new SerializationError(props)
+    }
+    if (code === "55P03") {
+      return new LockTimeoutError(props)
+    }
+    if (code === "57014") {
+      return new StatementTimeoutError(props)
+    }
+  }
+  return new UnknownError(props)
+}

--- a/packages/sql/pglite/src/PgliteMigrator.ts
+++ b/packages/sql/pglite/src/PgliteMigrator.ts
@@ -1,0 +1,33 @@
+/**
+ * @since 1.0.0
+ */
+import type * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Migrator from "effect/unstable/sql/Migrator"
+import type * as Client from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+
+/**
+ * @since 1.0.0
+ */
+export * from "effect/unstable/sql/Migrator"
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const run: <R2 = never>(
+  options: Migrator.MigratorOptions<R2>
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R2
+> = Migrator.make({})
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const layer = <R>(
+  options: Migrator.MigratorOptions<R>
+): Layer.Layer<never, Migrator.MigrationError | SqlError, Client.SqlClient | R> => Layer.effectDiscard(run(options))

--- a/packages/sql/pglite/src/index.ts
+++ b/packages/sql/pglite/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @since 1.0.0
+ */
+
+// @barrel: Auto-generated exports. Do not edit manually.
+
+/**
+ * @since 1.0.0
+ */
+export * as PgliteClient from "./PgliteClient.ts"
+
+/**
+ * @since 1.0.0
+ */
+export * as PgliteMigrator from "./PgliteMigrator.ts"

--- a/packages/sql/pglite/test/Client.test.ts
+++ b/packages/sql/pglite/test/Client.test.ts
@@ -1,0 +1,133 @@
+import { PgliteClient } from "@effect/sql-pglite"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+
+const ClientLayer = PgliteClient.layer({})
+
+const Migrations = Layer.effectDiscard(
+  PgliteClient.PgliteClient.asEffect().pipe(
+    Effect.andThen((sql) =>
+      Effect.acquireRelease(
+        sql`CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT)`,
+        () => sql`DROP TABLE test`.pipe(Effect.ignore)
+      )
+    )
+  )
+)
+
+describe("PgliteClient", () => {
+  layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("basic insert/select", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        yield* sql`INSERT INTO test (name) VALUES ('hello')`
+        const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM test`
+        assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+        const values = yield* sql`SELECT * FROM test`.values
+        assert.deepStrictEqual(values, [[1, "hello"]])
+      }).pipe(Effect.provide(Migrations)))
+
+    it.effect("insert helper", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const [query, params] = sql`INSERT INTO people ${sql.insert({ name: "Tim", age: 10 })}`.compile()
+        assert.strictEqual(query, `INSERT INTO people ("name","age") VALUES ($1,$2)`)
+        assert.deepStrictEqual(params, ["Tim", 10])
+      }))
+
+    it.effect("update helper", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const [query, params] = sql`UPDATE people SET ${sql.update({ name: "Tim" })}`.compile()
+        assert.strictEqual(query, `UPDATE people SET "name" = $1`)
+        assert.deepStrictEqual(params, ["Tim"])
+      }))
+
+    it.effect("updateValues helper", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const [query, params] = sql`UPDATE people SET name = data.name FROM ${
+          sql.updateValues([{ name: "Tim" }, { name: "John" }], "data")
+        }`.compile()
+        assert.strictEqual(
+          query,
+          `UPDATE people SET name = data.name FROM (values ($1),($2)) AS data("name")`
+        )
+        assert.deepStrictEqual(params, ["Tim", "John"])
+      }))
+
+    it.effect("in helper", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const [query, params] = sql`SELECT * FROM ${sql("people")} WHERE id IN ${sql.in([1, 2, "x"])}`.compile()
+        assert.strictEqual(query, `SELECT * FROM "people" WHERE id IN ($1,$2,$3)`)
+        assert.deepStrictEqual(params, [1, 2, "x"])
+      }))
+
+    it.effect("and helper", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const now = new Date()
+        const [query, params] = sql`SELECT * FROM ${sql("people")} WHERE ${
+          sql.and([sql.in("name", ["Tim", "John"]), sql`created_at < ${now}`])
+        }`.compile()
+        assert.strictEqual(query, `SELECT * FROM "people" WHERE ("name" IN ($1,$2) AND created_at < $3)`)
+        assert.deepStrictEqual(params, ["Tim", "John", now])
+      }))
+
+    it.effect("identifier transform", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const compiler = PgliteClient.makeCompiler((s) => s.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`))
+        const [query] = compiler.compile(sql`SELECT * FROM ${sql("peopleTest")}`, false)
+        assert.strictEqual(query, `SELECT * FROM "people_test"`)
+      }))
+
+    it.effect("json fragment", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const rows = yield* sql<{ json: unknown }>`SELECT ${sql.json({ a: 1 })}::jsonb AS json`
+        assert.deepStrictEqual(rows[0].json, { a: 1 })
+      }))
+
+    it.effect("listen + notify", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const fiber = yield* sql.listen("ch1").pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+        yield* TestClock.adjust("250 millis")
+        yield* sql.notify("ch1", "hello")
+        const payloads = yield* Fiber.join(fiber)
+        assert.deepStrictEqual(payloads, ["hello"])
+      }), { timeout: 15_000 })
+
+    it.effect("provider extras", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        yield* sql.refreshArrayTypes
+        const dump = yield* sql.dumpDataDir("none")
+        assert.isAbove((dump as Blob).size, 0)
+      }))
+  })
+
+  describe("fromClient", () => {
+    layer(
+      Layer.unwrap(
+        Effect.gen(function*() {
+          const { PGlite } = yield* Effect.promise(() => import("@electric-sql/pglite"))
+          const pg = new PGlite()
+          yield* Effect.promise(() => pg.waitReady)
+          return PgliteClient.layerFrom(PgliteClient.fromClient({ liveClient: pg }))
+        })
+      ),
+      { timeout: "30 seconds" }
+    )((it) => {
+      it.effect("works", () =>
+        Effect.gen(function*() {
+          const sql = yield* PgliteClient.PgliteClient
+          const rows = yield* sql<{ value: number }>`SELECT 1 AS value`
+          assert.deepStrictEqual(rows, [{ value: 1 }])
+        }))
+    })
+  })
+})

--- a/packages/sql/pglite/test/Migrator.test.ts
+++ b/packages/sql/pglite/test/Migrator.test.ts
@@ -1,0 +1,45 @@
+import { PgliteClient, PgliteMigrator } from "@effect/sql-pglite"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql/SqlClient"
+
+const ClientLayer = PgliteClient.layer({})
+
+const loader = Effect.succeed([
+  [
+    1,
+    "init",
+    Effect.succeed(Effect.gen(function*() {
+      const sql = yield* SqlClient
+      yield* sql`CREATE TABLE migrator_test (id SERIAL PRIMARY KEY, value TEXT)`
+    }))
+  ] as const,
+  [
+    2,
+    "insert",
+    Effect.succeed(Effect.gen(function*() {
+      const sql = yield* SqlClient
+      yield* sql`INSERT INTO migrator_test (value) VALUES ('hello')`
+    }))
+  ] as const
+])
+
+const MigratorLayer = PgliteMigrator.layer({ loader }).pipe(Layer.provide(ClientLayer))
+
+describe("PgliteMigrator", () => {
+  layer(Layer.merge(ClientLayer, MigratorLayer), { timeout: "30 seconds" })((it) => {
+    it.effect("runs migrations and records them", () =>
+      Effect.gen(function*() {
+        const sql = yield* PgliteClient.PgliteClient
+        const rows = yield* sql<{ value: string }>`SELECT value FROM migrator_test`
+        assert.deepStrictEqual(rows, [{ value: "hello" }])
+        const migrations = yield* sql<
+          { migration_id: number; name: string }
+        >`SELECT migration_id, name FROM effect_sql_migrations ORDER BY migration_id`
+        assert.deepStrictEqual(
+          migrations.map((m) => [m.migration_id, m.name]),
+          [[1, "init"], [2, "insert"]]
+        )
+      }))
+  })
+})

--- a/packages/sql/pglite/test/SqlErrorClassification.test.ts
+++ b/packages/sql/pglite/test/SqlErrorClassification.test.ts
@@ -1,0 +1,56 @@
+import { PgliteClient } from "@effect/sql-pglite"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+
+const queryFailureReasonTag = (cause: unknown) =>
+  Effect.gen(function*() {
+    const stub = makeFailingClient(cause)
+    const client = yield* PgliteClient.fromClient({ liveClient: stub as any })
+    const error = yield* Effect.flip(client`SELECT 1`)
+    return error.reason._tag
+  }).pipe(
+    Effect.scoped,
+    Effect.provide(Reactivity.layer)
+  )
+
+const makeFailingClient = (cause: unknown) => ({
+  query: () => Promise.reject(cause),
+  exec: () => Promise.reject(cause),
+  listen: () => Promise.resolve(() => Promise.resolve()),
+  notify: () => Promise.resolve(),
+  dumpDataDir: () => Promise.reject(cause),
+  refreshArrayTypes: () => Promise.reject(cause),
+  close: () => Promise.resolve(),
+  waitReady: Promise.resolve(),
+  ready: true,
+  closed: false
+})
+
+describe("PgliteClient SqlError classification", () => {
+  it.effect("checks 42501 before generic 42*", () =>
+    Effect.gen(function*() {
+      const authorizationTag = yield* queryFailureReasonTag({ code: "42501" })
+      assert.strictEqual(authorizationTag, "AuthorizationError")
+
+      const syntaxTag = yield* queryFailureReasonTag({ code: "42P01" })
+      assert.strictEqual(syntaxTag, "SqlSyntaxError")
+    }))
+
+  it.effect("maps connection / constraint / deadlock", () =>
+    Effect.gen(function*() {
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "08006" }), "ConnectionError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "23505" }), "ConstraintError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "40P01" }), "DeadlockError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "40001" }), "SerializationError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "55P03" }), "LockTimeoutError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "57014" }), "StatementTimeoutError")
+      assert.strictEqual(yield* queryFailureReasonTag({ code: "28000" }), "AuthenticationError")
+    }))
+
+  it.effect("falls back to UnknownError for unmapped SQLSTATE", () =>
+    Effect.gen(function*() {
+      const tag = yield* queryFailureReasonTag({ code: "ZZZZZ" })
+      assert.strictEqual(tag, "UnknownError")
+    }))
+})

--- a/packages/sql/pglite/test/Transaction.test.ts
+++ b/packages/sql/pglite/test/Transaction.test.ts
@@ -1,0 +1,62 @@
+import { PgliteClient } from "@effect/sql-pglite"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect } from "effect"
+
+const ClientLayer = PgliteClient.layer({})
+
+const setup = (table: string) =>
+  Effect.gen(function*() {
+    const sql = yield* PgliteClient.PgliteClient
+    yield* sql.unsafe(`CREATE TABLE IF NOT EXISTS ${table} (id SERIAL PRIMARY KEY, name TEXT)`)
+    yield* sql.unsafe(`TRUNCATE TABLE ${table} RESTART IDENTITY`)
+    return sql
+  })
+
+describe("PgliteClient transactions", () => {
+  layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("withTransaction commit", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_commit")
+        yield* sql.withTransaction(sql.unsafe(`INSERT INTO tx_commit (name) VALUES ('hello')`))
+        const rows = yield* sql.unsafe<{ name: string }>(`SELECT name FROM tx_commit`)
+        assert.deepStrictEqual(rows, [{ name: "hello" }])
+      }))
+
+    it.effect("withTransaction rollback", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_rollback")
+        yield* sql.unsafe(`INSERT INTO tx_rollback (name) VALUES ('hello')`).pipe(
+          Effect.andThen(Effect.fail("boom")),
+          sql.withTransaction,
+          Effect.ignore
+        )
+        const rows = yield* sql.unsafe(`SELECT * FROM tx_rollback`)
+        assert.deepStrictEqual(rows, [])
+      }))
+
+    it.effect("nested transaction commits both", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_nested_commit")
+        const stmt = sql.unsafe(`INSERT INTO tx_nested_commit (name) VALUES ('hello')`)
+        yield* stmt.pipe(Effect.andThen(() => stmt.pipe(sql.withTransaction)), sql.withTransaction)
+        const rows = yield* sql.unsafe<{ total: number }>(
+          `SELECT count(*)::int AS total FROM tx_nested_commit`
+        )
+        assert.strictEqual(rows.at(0)?.total, 2)
+      }))
+
+    it.effect("nested transaction rollback via savepoint", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_nested_rollback")
+        const stmt = sql.unsafe(`INSERT INTO tx_nested_rollback (name) VALUES ('hello')`)
+        yield* stmt.pipe(
+          Effect.andThen(() => stmt.pipe(Effect.andThen(Effect.fail("boom")), sql.withTransaction, Effect.ignore)),
+          sql.withTransaction
+        )
+        const rows = yield* sql.unsafe<{ total: number }>(
+          `SELECT count(*)::int AS total FROM tx_nested_rollback`
+        )
+        assert.strictEqual(rows.at(0)?.total, 1)
+      }))
+  })
+})

--- a/packages/sql/pglite/tsconfig.json
+++ b/packages/sql/pglite/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" },
+    { "path": "../../platform-node" }
+  ]
+}

--- a/packages/sql/pglite/vitest.config.ts
+++ b/packages/sql/pglite/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,16 @@ importers:
         specifier: workspace:^
         version: link:../../effect
 
+  packages/sql/pglite:
+    dependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.4
+        version: 0.4.4
+    devDependencies:
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+
   packages/sql/sqlite-bun:
     devDependencies:
       '@effect/platform-bun':
@@ -1555,6 +1565,9 @@ packages:
 
   '@effect/wa-sqlite@0.2.1':
     resolution: {integrity: sha512-vMnGIHKWSIFnDf7+n7lP2vyXPzORJotkaRI8LKyJw3eNjsvFopHYVaaGSeMSSVTm/w45pC5T4JdLrD6nxSR4oQ==}
+
+  '@electric-sql/pglite@0.4.4':
+    resolution: {integrity: sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -7258,6 +7271,8 @@ snapshots:
       strip-color: 0.1.0
 
   '@effect/wa-sqlite@0.2.1': {}
+
+  '@electric-sql/pglite@0.4.4': {}
 
   '@emnapi/core@1.9.2':
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,6 +71,8 @@
       "@effect/sql-mysql2/*": ["./packages/sql/mysql2/src/*.ts"],
       "@effect/sql-pg": ["./packages/sql/pg/src/index.ts"],
       "@effect/sql-pg/*": ["./packages/sql/pg/src/*.ts"],
+      "@effect/sql-pglite": ["./packages/sql/pglite/src/index.ts"],
+      "@effect/sql-pglite/*": ["./packages/sql/pglite/src/*.ts"],
       "@effect/sql-sqlite-bun": ["./packages/sql/sqlite-bun/src/index.ts"],
       "@effect/sql-sqlite-bun/*": ["./packages/sql/sqlite-bun/src/*.ts"],
       "@effect/sql-sqlite-do": ["./packages/sql/sqlite-do/src/index.ts"],

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -23,6 +23,7 @@
     { "path": "packages/sql/mysql2" },
     { "path": "packages/sql/mssql" },
     { "path": "packages/sql/pg" },
+    { "path": "packages/sql/pglite" },
     { "path": "packages/sql/sqlite-bun" },
     { "path": "packages/sql/sqlite-do" },
     { "path": "packages/sql/sqlite-node" },


### PR DESCRIPTION
## Summary

New `@effect/sql-pglite` package wrapping [`@electric-sql/pglite`](https://github.com/electric-sql/pglite) with the Effect SQL client.

- Postgres dialect/compiler (mirrors `@effect/sql-pg`)
- Effect-managed transactions via `Client.makeWithTransaction` with savepoint-based nesting (mirrors `@effect/sql-libsql` single-client ownership pattern)
- `listen` / `notify` via pglite's in-process notification callbacks
- Passthrough for `dumpDataDir` and `refreshArrayTypes`
- `PgliteMigrator` mirroring `LibsqlMigrator`
- JSON fragment + error classification

## Tests

19 tests across 4 files (Client, Transaction, Migrator, SqlErrorClassification). All pass.