### PR TITLE
chore: update tstyche to v7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rollup-plugin-visualizer": "^7.0.1",
     "terser": "^5.46.1",
     "ts-patch": "^3.3.0",
-    "tstyche": "^7.0.0",
+    "tstyche": "^7.1.0",
     "typescript": "^6.0.2",
     "vite": "^7.3.2",
     "vite-tsconfig-paths": "^6.1.1",

--- a/packages/effect/typetest/Struct.tst.ts
+++ b/packages/effect/typetest/Struct.tst.ts
@@ -1,6 +1,6 @@
 import { hole, Number, pipe, Schema, String as Str, Struct } from "effect"
 import type { Reducer } from "effect"
-import { describe, expect, it, when } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 const aSym = Symbol.for("a")
 const bSym = Symbol.for("b")
@@ -51,10 +51,18 @@ describe("Struct", () => {
 
   describe("get", () => {
     it("errors", () => {
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.get).type.not.toBeCallableWith("b"))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Argument of type '"b"' is not assignable to parameter of type '"a" | unique symbol | 1'
+        Struct.get("b")
+      )
       expect(Struct.get).type.not.toBeCallableWith(mixedKeys, "b")
 
-      when(pipe).isCalledWith(optionalMixedKeys, expect(Struct.get).type.not.toBeCallableWith("b"))
+      pipe(
+        optionalMixedKeys,
+        // @ts-expect-error Argument of type '"b"' is not assignable to parameter of type '"a" | unique symbol | 1'
+        Struct.get("b")
+      )
       expect(Struct.get).type.not.toBeCallableWith(optionalMixedKeys, "b")
     })
 
@@ -90,13 +98,25 @@ describe("Struct", () => {
 
   describe("pick", () => {
     it("errors when picking a non-existent key", () => {
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.pick).type.not.toBeCallableWith(["d"]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type '"d"' is not assignable to type '"a" | unique symbol | 1'
+        Struct.pick(["d"])
+      )
       expect(Struct.pick).type.not.toBeCallableWith(mixedKeys, ["d"])
 
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.pick).type.not.toBeCallableWith([dSym]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type 'unique symbol' is not assignable to type '"a" | unique symbol | 1'
+        Struct.pick([dSym])
+      )
       expect(Struct.pick).type.not.toBeCallableWith(mixedKeys, [dSym])
 
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.pick).type.not.toBeCallableWith([4]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type '4' is not assignable to type '"a" | unique symbol | 1'
+        Struct.pick([4])
+      )
       expect(Struct.pick).type.not.toBeCallableWith(mixedKeys, [4])
     })
 
@@ -122,13 +142,25 @@ describe("Struct", () => {
 
   describe("omit", () => {
     it("errors when omitting a non-existent key", () => {
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.omit).type.not.toBeCallableWith(["d"]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type '"d"' is not assignable to type '"a" | unique symbol | 1'
+        Struct.omit(["d"])
+      )
       expect(Struct.omit).type.not.toBeCallableWith(mixedKeys, ["d"])
 
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.omit).type.not.toBeCallableWith([dSym]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type 'unique symbol' is not assignable to type '"a" | unique symbol | 1'
+        Struct.omit([dSym])
+      )
       expect(Struct.omit).type.not.toBeCallableWith(mixedKeys, [dSym])
 
-      when(pipe).isCalledWith(mixedKeys, expect(Struct.omit).type.not.toBeCallableWith([4]))
+      pipe(
+        mixedKeys,
+        // @ts-expect-error Type '4' is not assignable to type '"a" | unique symbol | 1'
+        Struct.omit([4])
+      )
       expect(Struct.omit).type.not.toBeCallableWith(mixedKeys, [4])
     })
 
@@ -158,9 +190,10 @@ describe("Struct", () => {
         { a: "a", b: 1 },
         { a: (n: number) => n }
       )
-      when(pipe).isCalledWith(
+      pipe(
         { a: "a", b: 1 },
-        expect(Struct.evolve).type.not.toBeCallableWith({ a: (n: number) => n })
+        // @ts-expect-error Type '(n: number) => number' is not assignable to type '(a: string) => unknown'
+        Struct.evolve({ a: (n: number) => n })
       )
     })
 

--- a/packages/effect/typetest/Tuple.tst.ts
+++ b/packages/effect/typetest/Tuple.tst.ts
@@ -1,6 +1,6 @@
 import { Number, pipe, Schema, String as Str, Tuple } from "effect"
 import type { Reducer } from "effect"
-import { describe, expect, it, when } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 const tuple = ["a", 2, true] as [string, number, boolean]
 
@@ -9,10 +9,18 @@ const optionalTuple = ["a", 2, true] as [string?, number?, boolean?]
 describe("Tuple", () => {
   describe("get", () => {
     it("errors", () => {
-      when(pipe).isCalledWith(tuple, expect(Tuple.get).type.not.toBeCallableWith(4))
+      pipe(
+        tuple,
+        // @ts-expect-error Argument of type '4' is not assignable
+        Tuple.get(4)
+      )
       expect(Tuple.get).type.not.toBeCallableWith(tuple, 4)
 
-      when(pipe).isCalledWith(optionalTuple, expect(Tuple.get).type.not.toBeCallableWith(0))
+      pipe(
+        optionalTuple,
+        // @ts-expect-error Argument of type '0' is not assignable
+        Tuple.get(0)
+      )
       expect(Tuple.get).type.not.toBeCallableWith(optionalTuple, 0)
     })
 
@@ -31,7 +39,11 @@ describe("Tuple", () => {
 
   describe("pick", () => {
     it("errors", () => {
-      when(pipe).isCalledWith(tuple, expect(Tuple.pick).type.not.toBeCallableWith([4]))
+      pipe(
+        tuple,
+        // @ts-expect-error Type '4' is not assignable
+        Tuple.pick([4])
+      )
       expect(Tuple.pick).type.not.toBeCallableWith(tuple, [4])
     })
 
@@ -46,7 +58,11 @@ describe("Tuple", () => {
 
   describe("omit", () => {
     it("errors", () => {
-      when(pipe).isCalledWith(tuple, expect(Tuple.omit).type.not.toBeCallableWith([4]))
+      pipe(
+        tuple,
+        // @ts-expect-error Type '4' is not assignable
+        Tuple.omit([4])
+      )
       expect(Tuple.omit).type.not.toBeCallableWith(tuple, [4])
     })
 
@@ -93,7 +109,11 @@ describe("Tuple", () => {
 
   describe("renameIndices", () => {
     it("errors", () => {
-      when(pipe).isCalledWith(tuple, expect(Tuple.renameIndices).type.not.toBeCallableWith(["4", "0"]))
+      pipe(
+        tuple,
+        // @ts-expect-error Type '"4"' is not assignable
+        Tuple.renameIndices(["4", "0"])
+      )
       expect(Tuple.renameIndices).type.not.toBeCallableWith(tuple, ["4", "0"])
     })
 

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -971,11 +971,10 @@ describe("Schema", () => {
 
     it("E != T", () => {
       Schema.String.pipe(Schema.decodeTo(
-          Schema.Number,
-          // @ts-expect-error Argument of type 'Transformation<never, never, never, never>' is not assignable
-          SchemaTransformation.passthrough()
-        )
-      )
+        Schema.Number,
+        // @ts-expect-error Argument of type 'Transformation<never, never, never, never>' is not assignable
+        SchemaTransformation.passthrough()
+      ))
 
       Schema.String.pipe(
         Schema.decodeTo(

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -13,7 +13,7 @@ import {
   Tuple
 } from "effect"
 import { immerable, produce } from "immer"
-import { describe, expect, it, when } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 type Make<In, Out> = (input: In, options?: Schema.MakeOptions | undefined) => Out
 type MakeEffect<In, Out> = (
@@ -970,9 +970,9 @@ describe("Schema", () => {
     })
 
     it("E != T", () => {
-      when(Schema.String.pipe).isCalledWith(
-        expect(Schema.decodeTo).type.not.toBeCallableWith(
+      Schema.String.pipe(Schema.decodeTo(
           Schema.Number,
+          // @ts-expect-error Argument of type 'Transformation<never, never, never, never>' is not assignable
           SchemaTransformation.passthrough()
         )
       )
@@ -1276,12 +1276,12 @@ describe("Schema", () => {
         const fABranded = (a: ABranded) => a
 
         fABranded(ABranded.make({ a: "a" }))
-        when(fABranded).isCalledWith(expect(BBranded.make).type.not.toBeCallableWith({ a: "a" }))
+        expect(fABranded).type.not.toBeCallableWith(BBranded.make({ a: "a" }))
 
         const fBBranded = (a: BBranded) => a
 
         fBBranded(BBranded.make({ a: "a" }))
-        when(fBBranded).isCalledWith(expect(ABranded.make).type.not.toBeCallableWith({ a: "a" }))
+        expect(fBBranded).type.not.toBeCallableWith(ABranded.make({ a: "a" }))
       })
 
       it("branded (Brand module)", () => {
@@ -1295,12 +1295,12 @@ describe("Schema", () => {
         const fABranded = (a: ABranded) => a
 
         fABranded(ABranded.make({ a: "a" }))
-        when(fABranded).isCalledWith(expect(BBranded.make).type.not.toBeCallableWith({ a: "a" }))
+        expect(fABranded).type.not.toBeCallableWith(BBranded.make({ a: "a" }))
 
         const fBBranded = (a: BBranded) => a
 
         fBBranded(BBranded.make({ a: "a" }))
-        when(fBBranded).isCalledWith(expect(ABranded.make).type.not.toBeCallableWith({ a: "a" }))
+        expect(fBBranded).type.not.toBeCallableWith(ABranded.make({ a: "a" }))
       })
 
       it("extend & static members", () => {
@@ -1329,12 +1329,12 @@ describe("Schema", () => {
         const f1 = (e1: E1) => e1
 
         f1(E1.make({ a: "a", b: "b" }))
-        when(f1).isCalledWith(expect(E2.make).type.not.toBeCallableWith({ a: "a", b: "b" }))
+        expect(f1).type.not.toBeCallableWith(E2.make({ a: "a", b: "b" }))
 
         const f2 = (e2: E2) => e2
 
         f2(E2.make({ a: "a", b: "b" }))
-        when(f2).isCalledWith(expect(E1.make).type.not.toBeCallableWith({ a: "a", b: "b" }))
+        expect(f2).type.not.toBeCallableWith(E1.make({ a: "a", b: "b" }))
       })
     })
 
@@ -1681,7 +1681,7 @@ describe("Schema", () => {
     it("should not be callable with a schema with wrong type", () => {
       type Int = number & Brand.Brand<"Int">
       const Int = Brand.check<Int>(Schema.isInt())
-      when(Schema.String.pipe).isCalledWith(expect(Schema.fromBrand).type.not.toBeCallableWith("Int", Int))
+      expect(Schema.String.pipe).type.not.toBeCallableWith(Schema.fromBrand("Int", Int))
     })
 
     it("single brand", () => {

--- a/packages/effect/typetest/schema/Struct.tst.ts
+++ b/packages/effect/typetest/schema/Struct.tst.ts
@@ -1,6 +1,6 @@
 import { flow, Schema, String as Str, Struct } from "effect"
 import type { Brand, SchemaAST } from "effect"
-import { describe, expect, it, when } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 describe("Struct", () => {
   it("ast type", () => {
@@ -598,12 +598,12 @@ describe("Struct", () => {
       const fABranded = (a: ABranded) => a
 
       fABranded(ABranded.make({ a: "a" }))
-      when(fABranded).isCalledWith(expect(BBranded.make).type.not.toBeCallableWith({ a: "a" }))
+      expect(fABranded).type.not.toBeCallableWith(BBranded.make({ a: "a" }))
 
       const fBBranded = (a: BBranded) => a
 
       fBBranded(BBranded.make({ a: "a" }))
-      when(fBBranded).isCalledWith(expect(ABranded.make).type.not.toBeCallableWith({ a: "a" }))
+      expect(fBBranded).type.not.toBeCallableWith(ABranded.make({ a: "a" }))
     })
 
     it("branded (Brand module)", () => {
@@ -617,12 +617,12 @@ describe("Struct", () => {
       const fABranded = (a: ABranded) => a
 
       fABranded(ABranded.make({ a: "a" }))
-      when(fABranded).isCalledWith(expect(BBranded.make).type.not.toBeCallableWith({ a: "a" }))
+      expect(fABranded).type.not.toBeCallableWith(BBranded.make({ a: "a" }))
 
       const fBBranded = (a: BBranded) => a
 
       fBBranded(BBranded.make({ a: "a" }))
-      when(fBBranded).isCalledWith(expect(ABranded.make).type.not.toBeCallableWith({ a: "a" }))
+      expect(fBBranded).type.not.toBeCallableWith(ABranded.make({ a: "a" }))
     })
   })
 

--- a/packages/effect/typetest/unstable/cli/Command.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Command.tst.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli"
-import { describe, expect, it, when } from "tstyche"
+import { describe, expect, it } from "tstyche"
 
 describe("Command", () => {
   describe("withSharedFlags", () => {
@@ -74,8 +74,9 @@ describe("Command", () => {
     })
 
     it("accepts only flags", () => {
-      when(Command.make("root").pipe).isCalledWith(
-        expect(Command.withSharedFlags).type.not.toBeCallableWith({ file: Argument.string("file") })
+      Command.make("root").pipe(
+        // @ts-expect-error Type 'Argument<string>' is not assignable
+        Command.withSharedFlags({ file: Argument.string("file") })
       )
     })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       tstyche:
-        specifier: ^7.0.0
-        version: 7.0.0(typescript@6.0.2)
+        specifier: ^7.1.0
+        version: 7.1.0(typescript@6.0.2)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -5997,8 +5997,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tstyche@7.0.0:
-    resolution: {integrity: sha512-dWuDvU8b0mfgMMZfYz8qPo3My/UVgcG05Q8PBr3NbCWv+lHD7RqrOn9EBIZM59MmubP1/txVard0D/7ScFXddg==}
+  tstyche@7.1.0:
+    resolution: {integrity: sha512-Ar03KIab85QcPzMRIBrLGqpaKYsnNTbEhhC+wsEGrerSaaLfBDNFDcLtoxEMJHAO/ssjeApAFkjRKUjfxUx4EQ==}
     engines: {node: '>=22.12'}
     hasBin: true
     peerDependencies:
@@ -11961,7 +11961,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tstyche@7.0.0(typescript@6.0.2):
+  tstyche@7.1.0(typescript@6.0.2):
     optionalDependencies:
       typescript: 6.0.2
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR updates `tstyche` to v7.1.0. This release removes the experimental `when()` helper, which was undocumented and unfinished.

I initially hoped it would help avoid `// @ts-expect-error` in complex cases, but it actually made those test cases harder to read. Using `// @ts-expect-error` is sufficient and much clearer for readers.

As you'll notice in this PR, `.not.toBeCallableWith()` can be used instead in some cases, which is another reason to remove `when()` as redundant.