### PR TITLE
fix node request body caching

### DIFF
--- a/.changeset/fix-node-request-body-caching.md
+++ b/.changeset/fix-node-request-body-caching.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Fix Node HTTP server request body caching so `text`, `json`, and `arrayBuffer` can all be read from the same request body without consuming the stream more than once.

--- a/packages/platform-node/src/NodeHttpIncomingMessage.ts
+++ b/packages/platform-node/src/NodeHttpIncomingMessage.ts
@@ -47,22 +47,26 @@ export abstract class NodeHttpIncomingMessage<E> extends Inspectable.Class
     return this.remoteAddressOverride ?? Option.fromNullishOr(this.source.socket.remoteAddress)
   }
 
-  private textEffect: Effect.Effect<string, E> | undefined
-  get text(): Effect.Effect<string, E> {
-    if (this.textEffect) {
-      return this.textEffect
+  private bytesEffect: Effect.Effect<Uint8Array, E> | undefined
+  private get bytes(): Effect.Effect<Uint8Array, E> {
+    if (this.bytesEffect) {
+      return this.bytesEffect
     }
-    this.textEffect = Effect.runSync(Effect.cached(
+    this.bytesEffect = Effect.runSync(Effect.cached(
       Effect.flatMap(
         IncomingMessage.MaxBodySize.asEffect(),
         (maxBodySize) =>
-          NodeStream.toString(() => this.source, {
+          NodeStream.toUint8Array(() => this.source, {
             onError: this.onError,
             maxBytes: maxBodySize
           })
       )
     ))
-    return this.textEffect
+    return this.bytesEffect
+  }
+
+  get text(): Effect.Effect<string, E> {
+    return Effect.map(this.bytes, (bytes) => textDecoder.decode(bytes))
   }
 
   get textUnsafe(): string {
@@ -97,11 +101,8 @@ export abstract class NodeHttpIncomingMessage<E> extends Inspectable.Class
   }
 
   get arrayBuffer(): Effect.Effect<ArrayBuffer, E> {
-    return Effect.withFiber((fiber) =>
-      NodeStream.toArrayBuffer(() => this.source, {
-        onError: this.onError,
-        maxBytes: fiber.getRef(IncomingMessage.MaxBodySize)
-      })
-    )
+    return Effect.map(this.bytes, (bytes) => bytes.slice().buffer)
   }
 }
+
+const textDecoder = new TextDecoder()

--- a/packages/platform-node/test/NodeHttpServer.test.ts
+++ b/packages/platform-node/test/NodeHttpServer.test.ts
@@ -275,6 +275,34 @@ describe("HttpServer", () => {
       expect(todo).toEqual({ id: 1, title: "test" })
     }).pipe(Effect.provide(NodeHttpServer.layerTest)))
 
+  it.effect("request body accessors can be read multiple times", () =>
+    Effect.gen(function*() {
+      yield* HttpRouter.add(
+        "POST",
+        "/repro",
+        Effect.gen(function*() {
+          const request = yield* HttpServerRequest.HttpServerRequest
+          const arrayBuffer = yield* request.arrayBuffer
+          const text = yield* request.text
+
+          expect(new TextDecoder().decode(new Uint8Array(arrayBuffer))).toEqual("{\"ok\":true,\"msg\":\"hi\"}")
+          expect(text).toEqual("{\"ok\":true,\"msg\":\"hi\"}")
+
+          return HttpServerResponse.empty()
+        })
+      ).pipe(
+        HttpRouter.serve,
+        Layer.build
+      )
+
+      const response = yield* HttpClientRequest.post("/repro").pipe(
+        HttpClientRequest.bodyJsonUnsafe({ ok: true, msg: "hi" }),
+        HttpClient.execute
+      )
+
+      expect(response.status).toEqual(204)
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)))
+
   it.effect("schemaBodyUrlParams error", () =>
     Effect.gen(function*() {
       yield* HttpRouter.add(


### PR DESCRIPTION
## Summary
- cache Node HTTP server request bytes once and derive `text` and `arrayBuffer` from the same body
- add a regression test covering repeated reads of the same request body
- include a patch changeset for `@effect/platform-node`

Closes #2096 