### PR TITLE
feat(reactivity): add `.exhaustive()` finalizer to AsyncResult builder

### DIFF
--- a/.changeset/asyncresult-exhaustive.md
+++ b/.changeset/asyncresult-exhaustive.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add an exhaustive finalizer to the AsyncResult builder.

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -612,57 +612,59 @@ export const builder = <A extends AsyncResult<any, any>>(self: A): Builder<
   never,
   A extends Success<infer _A, infer _E> ? _A : never,
   A extends Failure<infer _A, infer _E> ? _E : never,
-  A extends Initial<infer _A, infer _E> ? true : never
+  A extends Initial<infer _A, infer _E> ? true : never,
+  A extends Failure<infer _A, infer _E> ? unknown : never
 > => new BuilderImpl(self) as any
 
 /**
  * @since 4.0.0
  * @category Builder
  */
-export type Builder<Out, A, E, I> =
+export type Builder<Out, A, E, I, F> =
   & Pipeable
   & {
-    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I>
-    onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I>
+    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I, F>
+    onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I, F>
     orElse<B>(orElse: LazyArg<B>): Out | B
     orNull(): Out | null
     render(): [A | I] extends [never] ? Out : Out | null
   }
-  & ([A | E | I] extends [never] ? {
+  & ([A | E | I | F] extends [never] ? {
       exhaustive(): Out
     } :
     {})
   & ([I] extends [never] ? {} :
     {
-      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never>
-      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never>
+      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never, F>
+      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never, F>
     })
   & ([A] extends [never] ? {} :
     {
-      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I>
+      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I, F>
     })
+  & ([E | F] extends [never] ? {} : {
+    onFailure<B>(f: (cause: Cause.Cause<E>, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, never>
+  })
   & ([E] extends [never] ? {} : {
-    onFailure<B>(f: (cause: Cause.Cause<E>, result: Failure<A, E>) => B): Builder<Out | B, A, never, I>
-
-    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I>
+    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, F>
 
     onErrorIf<B extends E, C>(
       refinement: Refinement<E, B>,
       f: (error: B, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I>
+    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I, F>
     onErrorIf<C>(
       predicate: Predicate<E>,
       f: (error: E, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, E, I>
+    ): Builder<Out | C, A, E, I, F>
 
     onErrorTag<const Tags extends ReadonlyArray<Types.Tags<E>>, B>(
       tags: Tags,
       f: (error: Types.ExtractTag<E, Tags[number]>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I, F>
     onErrorTag<const Tag extends Types.Tags<E>, B>(
       tag: Tag,
       f: (error: Types.ExtractTag<E, Tag>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I, F>
   })
 
 class BuilderImpl<Out, A, E> {

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -620,51 +620,51 @@ export const builder = <A extends AsyncResult<any, any>>(self: A): Builder<
  * @since 4.0.0
  * @category Builder
  */
-export type Builder<Out, A, E, I, F> =
+export type Builder<Out, A, E, I, Defect> =
   & Pipeable
   & {
-    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I, F>
-    onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I, F>
+    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I, Defect>
+    onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I, never>
     orElse<B>(orElse: LazyArg<B>): Out | B
     orNull(): Out | null
     render(): [A | I] extends [never] ? Out : Out | null
   }
-  & ([A | E | I | F] extends [never] ? {
+  & ([A | E | I | Defect] extends [never] ? {
       exhaustive(): Out
     } :
     {})
   & ([I] extends [never] ? {} :
     {
-      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never, F>
-      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never, F>
+      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never, Defect>
+      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never, Defect>
     })
   & ([A] extends [never] ? {} :
     {
-      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I, F>
+      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I, Defect>
     })
-  & ([E | F] extends [never] ? {} : {
+  & ([E | Defect] extends [never] ? {} : {
     onFailure<B>(f: (cause: Cause.Cause<E>, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, never>
   })
   & ([E] extends [never] ? {} : {
-    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, F>
+    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, Defect>
 
     onErrorIf<B extends E, C>(
       refinement: Refinement<E, B>,
       f: (error: B, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I, F>
+    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I, Defect>
     onErrorIf<C>(
       predicate: Predicate<E>,
       f: (error: E, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, E, I, F>
+    ): Builder<Out | C, A, E, I, Defect>
 
     onErrorTag<const Tags extends ReadonlyArray<Types.Tags<E>>, B>(
       tags: Tags,
       f: (error: Types.ExtractTag<E, Tags[number]>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I, F>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I, Defect>
     onErrorTag<const Tag extends Types.Tags<E>, B>(
       tag: Tag,
       f: (error: Types.ExtractTag<E, Tag>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I, F>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I, Defect>
   })
 
 class BuilderImpl<Out, A, E> {

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -628,6 +628,10 @@ export type Builder<Out, A, E, I> =
     orNull(): Out | null
     render(): [A | I] extends [never] ? Out : Out | null
   }
+  & ([A | E | I] extends [never] ? {
+      exhaustive(): Out
+    } :
+    {})
   & ([I] extends [never] ? {} :
     {
       onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never>
@@ -760,6 +764,10 @@ class BuilderImpl<Out, A, E> {
       throw Cause.squash(this.result.cause)
     }
     return null
+  }
+
+  exhaustive(): Out {
+    return this.render() as Out
   }
 }
 

--- a/packages/effect/src/unstable/reactivity/AsyncResult.ts
+++ b/packages/effect/src/unstable/reactivity/AsyncResult.ts
@@ -613,59 +613,84 @@ export const builder = <A extends AsyncResult<any, any>>(self: A): Builder<
   A extends Success<infer _A, infer _E> ? _A : never,
   A extends Failure<infer _A, infer _E> ? _E : never,
   A extends Initial<infer _A, infer _E> ? true : never,
-  A extends Failure<infer _A, infer _E> ? unknown : never
+  A extends Failure<infer _A, infer _E> ? Defect | Interrupt : never
 > => new BuilderImpl(self) as any
 
 /**
  * @since 4.0.0
  * @category Builder
  */
-export type Builder<Out, A, E, I, Defect> =
+export interface Defect {
+  readonly _: unique symbol
+}
+
+/**
+ * @since 4.0.0
+ * @category Builder
+ */
+export interface Interrupt {
+  readonly _: unique symbol
+}
+
+/**
+ * @since 4.0.0
+ * @category Builder
+ */
+export type Builder<Out, A, E, I, F> =
   & Pipeable
   & {
-    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I, Defect>
-    onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I, never>
+    onWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, I, F>
     orElse<B>(orElse: LazyArg<B>): Out | B
     orNull(): Out | null
     render(): [A | I] extends [never] ? Out : Out | null
   }
-  & ([A | E | I | Defect] extends [never] ? {
+  & ([A | E | I | F] extends [never] ? {
       exhaustive(): Out
     } :
-    {})
-  & ([I] extends [never] ? {} :
+    unknown)
+  & ([I] extends [never] ? unknown :
     {
-      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never, Defect>
-      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never, Defect>
+      onInitial<B>(f: (result: Initial<A, E>) => B): Builder<Out | B, A, E, never, F>
+      onInitialOrWaiting<B>(f: (result: AsyncResult<A, E>) => B): Builder<Out | B, A, E, never, F>
     })
-  & ([A] extends [never] ? {} :
+  & ([A] extends [never] ? unknown :
     {
-      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I, Defect>
+      onSuccess<B>(f: (value: A, result: Success<A, E>) => B): Builder<Out | B, never, E, I, F>
     })
-  & ([E | Defect] extends [never] ? {} : {
-    onFailure<B>(f: (cause: Cause.Cause<E>, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, never>
-  })
-  & ([E] extends [never] ? {} : {
-    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, Defect>
+  & ([E] extends [never] ? unknown : {
+    onError<B>(f: (error: E, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, F>
 
     onErrorIf<B extends E, C>(
       refinement: Refinement<E, B>,
       f: (error: B, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I, Defect>
+    ): Builder<Out | C, A, Types.EqualsWith<E, B, E, Exclude<E, B>>, I, F>
     onErrorIf<C>(
       predicate: Predicate<E>,
       f: (error: E, result: Failure<A, E>) => C
-    ): Builder<Out | C, A, E, I, Defect>
+    ): Builder<Out | C, A, E, I, F>
 
     onErrorTag<const Tags extends ReadonlyArray<Types.Tags<E>>, B>(
       tags: Tags,
       f: (error: Types.ExtractTag<E, Tags[number]>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I, Defect>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tags[number]>, I, F>
     onErrorTag<const Tag extends Types.Tags<E>, B>(
       tag: Tag,
       f: (error: Types.ExtractTag<E, Tag>, result: Failure<A, E>) => B
-    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I, Defect>
+    ): Builder<Out | B, A, Types.ExcludeTag<E, Tag>, I, F>
   })
+  & ([E | F] extends [never] ? unknown : {
+    onFailure<B>(f: (cause: Cause.Cause<E>, result: Failure<A, E>) => B): Builder<Out | B, A, never, I, never>
+  })
+  & (Interrupt extends F ? {
+      onInterrupt<B>(
+        f: (interruptors: ReadonlySet<number>, result: Failure<A, E>) => B
+      ): Builder<Out | B, A, E, I, Exclude<F, Interrupt>>
+    } :
+    unknown)
+  & (Defect extends F ? {
+      onDefect<B>(f: (defect: unknown, result: Failure<A, E>) => B): Builder<Out | B, A, E, I, Exclude<F, Defect>>
+    } :
+    unknown)
 
 class BuilderImpl<Out, A, E> {
   constructor(result: AsyncResult<A, E>) {
@@ -748,6 +773,13 @@ class BuilderImpl<Out, A, E> {
     return this.when(isFailure, (result) => {
       const defect = Cause.findDefect(result.cause)
       return Result.isFailure(defect) ? Option.none() : Option.some(f(defect.success, result))
+    })
+  }
+
+  onInterrupt<B>(f: (interruptors: ReadonlySet<number>, result: Failure<A, E>) => B): BuilderImpl<Out | B, A, E> {
+    return this.when(isFailure, (result) => {
+      const interruptors = Cause.filterInterruptors(result.cause)
+      return Result.isFailure(interruptors) ? Option.none() : Option.some(f(interruptors.success, result))
     })
   }
 

--- a/packages/effect/test/reactivity/AsyncResult.test.ts
+++ b/packages/effect/test/reactivity/AsyncResult.test.ts
@@ -22,5 +22,18 @@ describe("AsyncResult", () => {
 
       expect(handled).toEqual("fallback")
     })
+
+    it("exhaustive returns output when typed errors are handled", () => {
+      const handled = AsyncResult.builder(
+        AsyncResult.fail<{ readonly _tag: "NotFoundError"; readonly resource: string }>({
+          _tag: "NotFoundError",
+          resource: "user"
+        })
+      )
+        .onErrorTag("NotFoundError", (error) => `missing:${error.resource}`)
+        .exhaustive()
+
+      expect(handled).toEqual("missing:user")
+    })
   })
 })

--- a/packages/effect/test/reactivity/AsyncResult.test.ts
+++ b/packages/effect/test/reactivity/AsyncResult.test.ts
@@ -31,7 +31,7 @@ describe("AsyncResult", () => {
         })
       )
         .onErrorTag("NotFoundError", (error) => `missing:${error.resource}`)
-        .onFailure(() => "failure")
+        .onDefect(() => "failure")
         .exhaustive()
 
       expect(handled).toEqual("missing:user")

--- a/packages/effect/test/reactivity/AsyncResult.test.ts
+++ b/packages/effect/test/reactivity/AsyncResult.test.ts
@@ -32,6 +32,7 @@ describe("AsyncResult", () => {
       )
         .onErrorTag("NotFoundError", (error) => `missing:${error.resource}`)
         .onDefect(() => "failure")
+        .onInterrupt(() => "interrupt")
         .exhaustive()
 
       expect(handled).toEqual("missing:user")

--- a/packages/effect/test/reactivity/AsyncResult.test.ts
+++ b/packages/effect/test/reactivity/AsyncResult.test.ts
@@ -31,6 +31,7 @@ describe("AsyncResult", () => {
         })
       )
         .onErrorTag("NotFoundError", (error) => `missing:${error.resource}`)
+        .onFailure(() => "failure")
         .exhaustive()
 
       expect(handled).toEqual("missing:user")

--- a/packages/effect/typetest/unstable/reactivity/AsyncResult.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AsyncResult.tst.ts
@@ -16,9 +16,32 @@ describe("AsyncResult", () => {
           expect(error).type.toBe<TestError>()
           return "error" as const
         })
+        .onFailure(() => "failure" as const)
         .onSuccess((value) => value)
 
-      expect(complete.exhaustive()).type.toBe<number | "loading" | "error">()
+      expect(complete.exhaustive()).type.toBe<number | "loading" | "error" | "failure">()
+
+      const completeWithFailure = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onFailure(() => "failure" as const)
+        .onSuccess((value) => value)
+
+      expect(completeWithFailure.exhaustive()).type.toBe<number | "loading" | "failure">()
+
+      const missingFailure = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onErrorTag("TestError", () => "error" as const)
+        .onSuccess((value) => value)
+
+      expect(missingFailure).type.not.toHaveProperty("exhaustive")
+
+      const missingFailureCause = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onErrorTag("TestError", () => "error" as const)
+        .onDefect(() => "defect" as const)
+        .onSuccess((value) => value)
+
+      expect(missingFailureCause).type.not.toHaveProperty("exhaustive")
 
       const missingError = AsyncResult.builder(result)
         .onInitialOrWaiting(() => "loading" as const)

--- a/packages/effect/typetest/unstable/reactivity/AsyncResult.tst.ts
+++ b/packages/effect/typetest/unstable/reactivity/AsyncResult.tst.ts
@@ -1,0 +1,42 @@
+import { AsyncResult } from "effect/unstable/reactivity"
+import { describe, expect, it } from "tstyche"
+
+interface TestError {
+  readonly _tag: "TestError"
+}
+
+declare const result: AsyncResult.AsyncResult<number, TestError>
+
+describe("AsyncResult", () => {
+  describe("builder", () => {
+    it("exhaustive is only available when all cases are handled", () => {
+      const complete = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onErrorTag("TestError", (error) => {
+          expect(error).type.toBe<TestError>()
+          return "error" as const
+        })
+        .onSuccess((value) => value)
+
+      expect(complete.exhaustive()).type.toBe<number | "loading" | "error">()
+
+      const missingError = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onSuccess((value) => value)
+
+      expect(missingError).type.not.toHaveProperty("exhaustive")
+
+      const missingInitial = AsyncResult.builder(result)
+        .onErrorTag("TestError", () => "error" as const)
+        .onSuccess((value) => value)
+
+      expect(missingInitial).type.not.toHaveProperty("exhaustive")
+
+      const missingSuccess = AsyncResult.builder(result)
+        .onInitialOrWaiting(() => "loading" as const)
+        .onErrorTag("TestError", () => "error" as const)
+
+      expect(missingSuccess).type.not.toHaveProperty("exhaustive")
+    })
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds an `exhaustive()` finalizer to `AsyncResult.builder`.

Makes it easier & safer to handle all cases, instead of relying on `.render()` which can throw for unhandled failures.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue: N/A
- Closes: N/A
