### PR TITLE
Change the current it.effect.each to it.effect.for

### DIFF
--- a/.changeset/jolly-grapes-mate.md
+++ b/.changeset/jolly-grapes-mate.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": minor
+---
+
+Rename it.effect.each to it.effect.for for Vitest alignment and add support for accessing the test context.

--- a/ai-docs/src/09_testing/10_effect-tests.ts
+++ b/ai-docs/src/09_testing/10_effect-tests.ts
@@ -16,7 +16,7 @@ describe("@effect/vitest basics", () => {
       assert.isTrue(upper.includes("ADA"))
     }))
 
-  it.effect.each([
+  it.effect.for([
     { input: " Ada ", expected: "ada" },
     { input: " Lin ", expected: "lin" },
     { input: " Nia ", expected: "nia" }

--- a/packages/effect/test/unstable/cli/LogLevel.test.ts
+++ b/packages/effect/test/unstable/cli/LogLevel.test.ts
@@ -120,7 +120,7 @@ describe("LogLevel", () => {
     "none"
   ]
 
-  it.effect.each(testCases)("level=%s", (level) =>
+  it.effect.for(testCases)("level=%s", (level) =>
     Effect.gen(function*() {
       const logs = yield* testLogLevels(level)
       assert.deepStrictEqual(logs, filterLogs(level))

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -370,7 +370,7 @@ describe("OtlpMetrics", () => {
   })
 
   describe("Gauge (no temporality)", () => {
-    it.effect.each([
+    it.effect.for([
       ["cumulative", TestLayerCumulative] as const,
       ["delta", TestLayerDelta] as const
     ])("%s temporality reports current value", ([_, layer]) =>

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -59,7 +59,7 @@ export namespace Vitest {
     only: Vitest.Test<R>
     each: <T>(
       cases: ReadonlyArray<T>
-    ) => <A, E>(name: string, self: TestFunction<A, E, R, Array<T>>, timeout?: number | V.TestOptions) => void
+    ) => <A, E>(name: string, self: TestFunction<A, E, R, [T, V.TestContext]>, timeout?: number | V.TestOptions) => void
     fails: Vitest.Test<R>
 
     /**

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -57,7 +57,7 @@ export namespace Vitest {
     skipIf: (condition: unknown) => Vitest.Test<R>
     runIf: (condition: unknown) => Vitest.Test<R>
     only: Vitest.Test<R>
-    each: <T>(
+    for: <T>(
       cases: ReadonlyArray<T>
     ) => <A, E>(name: string, self: TestFunction<A, E, R, [T, V.TestContext]>, timeout?: number | V.TestOptions) => void
     fails: Vitest.Test<R>

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -78,7 +78,7 @@ const makeTester = <R>(
     it.for(cases)(
       name,
       testOptions(timeout),
-      (args, ctx) => run(ctx, [args], self) as any
+      (args, ctx) => run(ctx, [args, ctx], self) as any
     )
 
   const fails: Vitest.Vitest.Tester<R>["fails"] = (name, self, timeout) =>

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -74,7 +74,7 @@ const makeTester = <R>(
   const only: Vitest.Vitest.Tester<R>["only"] = (name, self, timeout) =>
     it.only(name, testOptions(timeout), (ctx) => run(ctx, [ctx], self))
 
-  const each: Vitest.Vitest.Tester<R>["each"] = (cases) => (name, self, timeout) =>
+  const for_: Vitest.Vitest.Tester<R>["for"] = (cases) => (name, self, timeout) =>
     it.for(cases)(
       name,
       testOptions(timeout),
@@ -132,7 +132,7 @@ const makeTester = <R>(
     )
   }
 
-  return Object.assign(f, { skip, skipIf, runIf, only, each, fails, prop })
+  return Object.assign(f, { skip, skipIf, runIf, only, for: for_, fails, prop })
 }
 
 /** @internal */

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -13,11 +13,11 @@ it.live(
 
 // each
 
-it.effect.each([1, 2, 3])(
+it.effect.for([1, 2, 3])(
   "effect each %s",
   (n) => Effect.acquireRelease(Effect.sync(() => expect(n).toEqual(n)), () => Effect.void)
 )
-it.live.each([1, 2, 3])(
+it.live.for([1, 2, 3])(
   "live each %s",
   (n) => Effect.acquireRelease(Effect.sync(() => expect(n).toEqual(n)), () => Effect.void)
 )


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On vanilla non-effect Vitest, there are two ways to provide a list of test cases:

* [`it.each`](https://vitest.dev/api/test.html#test-each) which treat each input array entry as var args
* [`it.for`](https://vitest.dev/api/test.html#test-for) which directly assigns each input array entry as the first arg, leaving room for a second arg - the vitest test context

Currently, the behavior of `it.effect.each` behaves more like vanilla `it.for` in that it's not var arg, but currently does not pass  the test context.

The pull request changes the ff:

* Add the vitest test context on the second arg
* Rename `it.effect.each` to `it.effect.for` so it aligns more with vitest naming.

## Related

https://github.com/Effect-TS/effect/issues/5839 notes that the current `it.effect.each` is undocumented still.