### PR TITLE
Fix entity proxy RPC handler context

### DIFF
--- a/.changeset/fix-entity-proxy-rpc-handler-context.md
+++ b/.changeset/fix-entity-proxy-rpc-handler-context.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix entity proxy RPC handlers to provide the context expected by RpcServer.

--- a/packages/effect/src/unstable/cluster/EntityProxyServer.ts
+++ b/packages/effect/src/unstable/cluster/EntityProxyServer.ts
@@ -82,7 +82,7 @@ export const layerRpcHandlers = <
   entity: Entity.Entity<Type, Rpcs>
 ): Layer.Layer<RpcHandlers<Rpcs, Type>, never, Sharding | Rpc.ServicesServer<Rpcs>> =>
   Layer.effectContext(Effect.gen(function*() {
-    const services = yield* Effect.context<never>()
+    const context = yield* Effect.context<never>()
     const client = yield* entity.client
     const handlers = new Map<string, Rpc.Handler<string>>()
     for (const parentRpc_ of entity.protocol.requests.values()) {
@@ -90,12 +90,12 @@ export const layerRpcHandlers = <
       const tag = `${entity.type}.${parentRpc._tag}` as const
       const key = `effect/rpc/Rpc/${tag}`
       handlers.set(key, {
-        services,
+        context,
         tag,
         handler: ({ entityId, payload }: any) => (client(entityId) as any)[parentRpc._tag](payload) as any
       } as any)
       handlers.set(`${key}Discard`, {
-        services,
+        context,
         tag,
         handler: ({ entityId, payload }: any) =>
           (client(entityId) as any)[parentRpc._tag](payload, { discard: true }) as any

--- a/packages/platform-node/test/RpcServer.test.ts
+++ b/packages/platform-node/test/RpcServer.test.ts
@@ -1,8 +1,9 @@
 import { NodeHttpServer, NodeSocket, NodeSocketServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Layer } from "effect"
+import { Cause, Deferred, Effect, Layer } from "effect"
+import { Entity, EntityProxy, EntityProxyServer, Sharding } from "effect/unstable/cluster"
 import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
-import { RpcClient, RpcSerialization, RpcServer } from "effect/unstable/rpc"
+import { Rpc, RpcClient, RpcSerialization, RpcServer, RpcTest } from "effect/unstable/rpc"
 import { SocketServer } from "effect/unstable/socket"
 import { e2eSuite, UsersClient } from "./fixtures/rpc-e2e.ts"
 import { RpcLive, User } from "./fixtures/rpc-schemas.ts"
@@ -173,5 +174,40 @@ describe("RpcServer", () => {
         assert.strictEqual(defect.message, "detailed error")
         assert.strictEqual(defect.stack, "Error: detailed error\n  at handler.ts:1")
       }).pipe(Effect.provide(CustomDefectLayer)))
+  })
+
+  describe("entity proxy", () => {
+    it.effect("provides handler context for generated rpc handlers", () =>
+      Effect.gen(function*() {
+        const TestEntity = Entity.make("TestEntity", [Rpc.make("NoPayload")])
+        const TestEntityRpcs = EntityProxy.toRpcGroup(TestEntity)
+        const called = yield* Deferred.make<void>()
+        const testClient = (entityId: string) => ({
+          NoPayload: (payload: void, options?: { readonly discard?: boolean }) =>
+            Effect.gen(function*() {
+              assert.strictEqual(entityId, "id")
+              assert.strictEqual(payload, undefined)
+              assert.strictEqual(options?.discard, true)
+              yield* Deferred.succeed(called, undefined)
+            })
+        })
+        const sharding = Sharding.Sharding.of({
+          ...({} as Sharding.Sharding["Service"]),
+          isShutdown: Effect.succeed(false),
+          makeClient: () => Effect.succeed(testClient) as never,
+          pollStorage: Effect.void
+        })
+
+        const client = yield* RpcTest.makeClient(TestEntityRpcs).pipe(
+          Effect.provide(EntityProxyServer.layerRpcHandlers(TestEntity)),
+          Effect.provideService(Sharding.Sharding, sharding)
+        )
+
+        yield* client["TestEntity.NoPayloadDiscard"]({
+          entityId: "id",
+          payload: undefined
+        })
+        yield* Deferred.await(called)
+      }))
   })
 })


### PR DESCRIPTION
## Summary
- Fix EntityProxyServer RPC handler entries to expose `context` for RpcServer.
- Add a regression test for generated entity proxy discard RPC calls.
- Add a patch changeset for `effect`.

## Verification
- `pnpm test packages/platform-node/test/RpcServer.test.ts`
- `pnpm lint-fix`
- `pnpm check:tsgo`