### PR TITLE
expose otel export flush mechanism

### DIFF
--- a/.changeset/fuzzy-hounds-flush.md
+++ b/.changeset/fuzzy-hounds-flush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow OTLP metrics exporters to disable interval exports and rely on manual flushing.

--- a/.changeset/otlp-exporter-flush.md
+++ b/.changeset/otlp-exporter-flush.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add shared OTLP exporter flushing support and allow disabling scheduled exports.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -1368,7 +1368,23 @@ export const layerMergedContext = <E, R>(
 // internal
 // -----------------------------------------------------------------------------
 
-const responseRegistry = (() => {
+interface ResponseRegistry {
+  readonly register: (response: HttpClientResponse.HttpClientResponse, controller: AbortController) => void
+  readonly unregister: (response: HttpClientResponse.HttpClientResponse) => void
+}
+
+let responseRegistryInstance: ResponseRegistry | undefined
+
+const responseRegistry: ResponseRegistry = {
+  register(response, controller) {
+    ;(responseRegistryInstance ??= makeResponseRegistry()).register(response, controller)
+  },
+  unregister(response) {
+    ;(responseRegistryInstance ??= makeResponseRegistry()).unregister(response)
+  }
+}
+
+const makeResponseRegistry = (): ResponseRegistry => {
   if ("FinalizationRegistry" in globalThis && globalThis.FinalizationRegistry) {
     const registry = new FinalizationRegistry((controller: AbortController) => {
       controller.abort()
@@ -1395,7 +1411,7 @@ const responseRegistry = (() => {
       timers.delete(response)
     }
   }
-})()
+}
 
 const scopedRequests = new WeakMap<HttpClientRequest.HttpClientRequest, AbortController>()
 

--- a/packages/effect/src/unstable/observability/Otlp.ts
+++ b/packages/effect/src/unstable/observability/Otlp.ts
@@ -28,12 +28,12 @@ export const layer = (options: {
   readonly headers?: Headers.Input | undefined
   readonly maxBatchSize?: number | undefined
   readonly tracerContext?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
-  readonly loggerExportInterval?: Duration.Input | undefined
+  readonly loggerExportInterval?: Duration.Input | "disabled" | undefined
   readonly loggerExcludeLogSpans?: boolean | undefined
   readonly loggerMergeWithExisting?: boolean | undefined
-  readonly metricsExportInterval?: Duration.Input | undefined
+  readonly metricsExportInterval?: Duration.Input | "disabled" | undefined
   readonly metricsTemporality?: AggregationTemporality | undefined
-  readonly tracerExportInterval?: Duration.Input | undefined
+  readonly tracerExportInterval?: Duration.Input | "disabled" | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
 }): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization.OtlpSerialization> => {
   const base = HttpClientRequest.get(options.baseUrl)
@@ -83,12 +83,12 @@ export const layerJson: (options: {
   readonly headers?: Headers.Input | undefined
   readonly maxBatchSize?: number | undefined
   readonly tracerContext?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
-  readonly loggerExportInterval?: Duration.Input | undefined
+  readonly loggerExportInterval?: Duration.Input | "disabled" | undefined
   readonly loggerExcludeLogSpans?: boolean | undefined
   readonly loggerMergeWithExisting?: boolean | undefined
-  readonly metricsExportInterval?: Duration.Input | undefined
+  readonly metricsExportInterval?: Duration.Input | "disabled" | undefined
   readonly metricsTemporality?: AggregationTemporality | undefined
-  readonly tracerExportInterval?: Duration.Input | undefined
+  readonly tracerExportInterval?: Duration.Input | "disabled" | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
 }) => Layer.Layer<never, never, HttpClient.HttpClient> = flow(layer, Layer.provide(OtlpSerialization.layerJson))
 
@@ -106,11 +106,11 @@ export const layerProtobuf: (options: {
   readonly headers?: Headers.Input | undefined
   readonly maxBatchSize?: number | undefined
   readonly tracerContext?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
-  readonly loggerExportInterval?: Duration.Input | undefined
+  readonly loggerExportInterval?: Duration.Input | "disabled" | undefined
   readonly loggerExcludeLogSpans?: boolean | undefined
   readonly loggerMergeWithExisting?: boolean | undefined
-  readonly metricsExportInterval?: Duration.Input | undefined
+  readonly metricsExportInterval?: Duration.Input | "disabled" | undefined
   readonly metricsTemporality?: AggregationTemporality | undefined
-  readonly tracerExportInterval?: Duration.Input | undefined
+  readonly tracerExportInterval?: Duration.Input | "disabled" | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
 }) => Layer.Layer<never, never, HttpClient.HttpClient> = flow(layer, Layer.provide(OtlpSerialization.layerProtobuf))

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -77,9 +77,9 @@ export const flush = Effect.serviceOption(Exporters).pipe(
   Effect.flatMap(
     Option.match({
       onNone: () => Effect.void,
-      onSome: (exporters) => exporters.flush,
-    }),
-  ),
+      onSome: (exporters) => exporters.flush
+    })
+  )
 )
 
 /**

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -6,10 +6,13 @@ import * as Context from "../../Context.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
 import * as Fiber from "../../Fiber.ts"
+import * as Layer from "../../Layer.ts"
 import * as Num from "../../Number.ts"
 import * as Option from "../../Option.ts"
+import * as Ref from "../../Ref.ts"
 import * as Schedule from "../../Schedule.ts"
 import * as Scope from "../../Scope.ts"
+import * as Semaphore from "../../Semaphore.ts"
 import * as Headers from "../../unstable/http/Headers.ts"
 import * as HttpClient from "../../unstable/http/HttpClient.ts"
 import * as HttpClientError from "../../unstable/http/HttpClientError.ts"
@@ -36,6 +39,38 @@ const policy = Schedule.forever.pipe(
 
 /**
  * @since 4.0.0
+ * @category Services
+ */
+export class Exporters extends Context.Service<Exporters, {
+  readonly register: (exporter: Effect.Effect<void>) => Effect.Effect<void>
+  readonly flush: Effect.Effect<void>
+}>()("effect/unstable/observability/OtlpExporter/Exporters") {}
+
+/**
+ * @since 4.0.0
+ * @category Layers
+ */
+export const layerExporters: Layer.Layer<Exporters> = Layer.effect(
+  Exporters,
+  Effect.gen(function*() {
+    const exporters = yield* Ref.make<ReadonlyArray<Effect.Effect<void>>>([])
+
+    return {
+      register: (exporter) => Ref.update(exporters, (all) => [...all, exporter]),
+      flush: Ref.get(exporters).pipe(
+        Effect.flatMap((all) =>
+          Effect.forEach(all, (exporter) => exporter, {
+            concurrency: "unbounded",
+            discard: true
+          })
+        )
+      )
+    }
+  })
+)
+
+/**
+ * @since 4.0.0
  * @category Constructors
  */
 export const make: (
@@ -43,7 +78,7 @@ export const make: (
     readonly url: string
     readonly headers: Headers.Input | undefined
     readonly label: string
-    readonly exportInterval: Duration.Input
+    readonly exportInterval: Duration.Input | "disabled"
     readonly maxBatchSize: number | "disabled"
     readonly body: (data: Array<any>) => HttpBody
     readonly shutdownTimeout: Duration.Input
@@ -57,7 +92,6 @@ export const make: (
   const clock = Context.get(services, Clock)
   const scope = Context.get(services, Scope.Scope)
   const runFork = Effect.runForkWith(services)
-  const exportInterval = Duration.max(Duration.fromInputUnsafe(options.exportInterval), Duration.zero)
   let disabledUntil: number | undefined = undefined
 
   const client = HttpClient.filterStatusOk(Context.get(services, HttpClient.HttpClient)).pipe(
@@ -74,7 +108,8 @@ export const make: (
 
   const request = HttpClientRequest.post(options.url, { headers })
   let buffer: Array<any> = []
-  const runExport = Effect.suspend(() => {
+  const semaphore = yield* Semaphore.make(1)
+  const runExport = semaphore.withPermits(1)(Effect.suspend(() => {
     if (disabledUntil !== undefined && clock.currentTimeMillisUnsafe() < disabledUntil) {
       return Effect.void
     } else if (disabledUntil !== undefined) {
@@ -90,10 +125,11 @@ export const make: (
     return client.execute(
       HttpClientRequest.setBody(request, options.body(items))
     ).pipe(
+      Effect.flatMap((response) => response.text),
       Effect.asVoid,
       Effect.withTracerEnabled(false)
     )
-  }).pipe(
+  })).pipe(
     Effect.catchCause((cause) => {
       if (disabledUntil !== undefined) return Effect.void
       disabledUntil = clock.currentTimeMillisUnsafe() + 60_000
@@ -106,26 +142,37 @@ export const make: (
     })
   )
 
-  yield* Scope.addFinalizer(
-    scope,
-    runExport.pipe(
-      Effect.ignore,
-      Effect.interruptible,
-      Effect.timeoutOption(options.shutdownTimeout)
-    )
-  )
+  const exporters = yield* Effect.serviceOption(Exporters)
+  if (Option.isSome(exporters)) {
+    yield* exporters.value.register(runExport)
+  }
 
-  yield* Effect.sleep(exportInterval).pipe(
-    Effect.andThen(runExport),
-    Effect.forever,
-    Effect.forkIn(scope)
-  )
+  if (options.exportInterval !== "disabled") {
+    yield* Scope.addFinalizer(
+      scope,
+      runExport.pipe(
+        Effect.ignore,
+        Effect.interruptible,
+        Effect.timeoutOption(options.shutdownTimeout)
+      )
+    )
+
+    const exportInterval = Duration.max(Duration.fromInputUnsafe(options.exportInterval), Duration.zero)
+    yield* Effect.sleep(exportInterval).pipe(
+      Effect.andThen(runExport),
+      Effect.forever,
+      Effect.forkIn(scope)
+    )
+  }
 
   return {
     push(data) {
       if (disabledUntil !== undefined) return
       buffer.push(data)
-      if (options.maxBatchSize !== "disabled" && buffer.length >= options.maxBatchSize) {
+      if (
+        options.exportInterval !== "disabled" && options.maxBatchSize !== "disabled" &&
+        buffer.length >= options.maxBatchSize
+      ) {
         Fiber.runIn(runFork(runExport), scope)
       }
     }

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -71,6 +71,19 @@ export const layerExporters: Layer.Layer<Exporters> = Layer.effect(
 
 /**
  * @since 4.0.0
+ * @category Layers
+ */
+export const flush = Effect.serviceOption(Exporters).pipe(
+  Effect.flatMap(
+    Option.match({
+      onNone: () => Effect.void,
+      onSome: (exporters) => exporters.flush,
+    }),
+  ),
+)
+
+/**
+ * @since 4.0.0
  * @category Constructors
  */
 export const make: (

--- a/packages/effect/src/unstable/observability/OtlpExporter.ts
+++ b/packages/effect/src/unstable/observability/OtlpExporter.ts
@@ -71,7 +71,7 @@ export const layerExporters: Layer.Layer<Exporters> = Layer.effect(
 
 /**
  * @since 4.0.0
- * @category Layers
+ * @category constructors
  */
 export const flush = Effect.serviceOption(Exporters).pipe(
   Effect.flatMap(

--- a/packages/effect/src/unstable/observability/OtlpLogger.ts
+++ b/packages/effect/src/unstable/observability/OtlpLogger.ts
@@ -31,7 +31,7 @@ export const make: (
       readonly attributes?: Record<string, unknown>
     } | undefined
     readonly headers?: Headers.Input | undefined
-    readonly exportInterval?: Duration.Input | undefined
+    readonly exportInterval?: Duration.Input | "disabled" | undefined
     readonly maxBatchSize?: number | undefined
     readonly shutdownTimeout?: Duration.Input | undefined
     readonly excludeLogSpans?: boolean | undefined
@@ -87,7 +87,7 @@ export const layer = (options: {
     readonly attributes?: Record<string, unknown>
   } | undefined
   readonly headers?: Headers.Input | undefined
-  readonly exportInterval?: Duration.Input | undefined
+  readonly exportInterval?: Duration.Input | "disabled" | undefined
   readonly maxBatchSize?: number | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
   readonly excludeLogSpans?: boolean | undefined

--- a/packages/effect/src/unstable/observability/OtlpMetrics.ts
+++ b/packages/effect/src/unstable/observability/OtlpMetrics.ts
@@ -60,7 +60,7 @@ export const make: (options: {
     readonly attributes?: Record<string, unknown>
   } | undefined
   readonly headers?: Headers.Input | undefined
-  readonly exportInterval?: Duration.Input | undefined
+  readonly exportInterval?: Duration.Input | "disabled" | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
   readonly temporality?: AggregationTemporality | undefined
 }) => Effect.Effect<
@@ -440,7 +440,7 @@ export const layer = (options: {
     readonly attributes?: Record<string, unknown>
   } | undefined
   readonly headers?: Headers.Input | undefined
-  readonly exportInterval?: Duration.Input | undefined
+  readonly exportInterval?: Duration.Input | "disabled" | undefined
   readonly shutdownTimeout?: Duration.Input | undefined
   readonly temporality?: AggregationTemporality | undefined
 }): Layer.Layer<never, never, HttpClient.HttpClient | OtlpSerialization> => Layer.effectDiscard(make(options))

--- a/packages/effect/src/unstable/observability/OtlpTracer.ts
+++ b/packages/effect/src/unstable/observability/OtlpTracer.ts
@@ -33,7 +33,7 @@ export const make: (
       readonly attributes?: Record<string, unknown>
     } | undefined
     readonly headers?: Headers.Input | undefined
-    readonly exportInterval?: Duration.Input | undefined
+    readonly exportInterval?: Duration.Input | "disabled" | undefined
     readonly maxBatchSize?: number | undefined
     readonly context?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
     readonly shutdownTimeout?: Duration.Input | undefined
@@ -110,7 +110,7 @@ export const layer: (options: {
     readonly attributes?: Record<string, unknown>
   } | undefined
   readonly headers?: Headers.Input | undefined
-  readonly exportInterval?: Duration.Input | undefined
+  readonly exportInterval?: Duration.Input | "disabled" | undefined
   readonly maxBatchSize?: number | undefined
   readonly context?: (<X>(primitive: Tracer.EffectPrimitive<X>, span: Tracer.AnySpan) => X) | undefined
   readonly shutdownTimeout?: Duration.Input | undefined

--- a/packages/effect/test/unstable/observability/OtlpExporter.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpExporter.test.ts
@@ -28,12 +28,38 @@ const makeHttpClient = Effect.fnUntraced(function*(retryAfter: string | undefine
   return { attempts, httpClient } as const
 })
 
+const makeSuccessfulHttpClient = Effect.fnUntraced(function*() {
+  const attempts = yield* Ref.make(0)
+
+  const httpClient = HttpClient.makeWith(
+    Effect.fnUntraced(function*(requestEffect) {
+      const request = yield* requestEffect
+      yield* Ref.update(attempts, (attempts) => attempts + 1)
+      return HttpClientResponse.fromWeb(request, new Response())
+    }),
+    Effect.succeed as HttpClient.HttpClient.Preprocess<HttpClientError.HttpClientError, never>
+  )
+
+  return { attempts, httpClient } as const
+})
+
 const makeExporter = (httpClient: HttpClient.HttpClient) =>
   OtlpExporter.make({
     label: "OtlpExporterTest",
     url: "http://localhost:4318/v1/logs",
     headers: undefined,
     exportInterval: "1 hour",
+    maxBatchSize: 1,
+    body: () => HttpBody.empty,
+    shutdownTimeout: "1 second"
+  }).pipe(Effect.provideService(HttpClient.HttpClient, httpClient))
+
+const makeDisabledExporter = (httpClient: HttpClient.HttpClient) =>
+  OtlpExporter.make({
+    label: "OtlpExporterTest",
+    url: "http://localhost:4318/v1/logs",
+    headers: undefined,
+    exportInterval: "disabled",
     maxBatchSize: 1,
     body: () => HttpBody.empty,
     shutdownTimeout: "1 second"
@@ -104,5 +130,21 @@ describe("OtlpExporter", () => {
         yield* yieldNowN(2)
         assert.strictEqual(yield* Ref.get(attempts), 2)
       })
+    ))
+
+  it.effect("supports manually flushing disabled exporters", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const { attempts, httpClient } = yield* makeSuccessfulHttpClient()
+        const exporter = yield* makeDisabledExporter(httpClient)
+
+        exporter.push({ value: 1 })
+        yield* yieldNowN(3)
+        assert.strictEqual(yield* Ref.get(attempts), 0)
+
+        const exporters = yield* OtlpExporter.Exporters
+        yield* exporters.flush
+        assert.strictEqual(yield* Ref.get(attempts), 1)
+      }).pipe(Effect.provide(OtlpExporter.layerExporters))
     ))
 })

--- a/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
+++ b/packages/effect/test/unstable/observability/OtlpMetrics.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { Array, Context, Effect, Layer, Metric, Predicate, Ref } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClient, type HttpClientError, HttpClientResponse } from "effect/unstable/http"
-import { OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
+import { OtlpExporter, OtlpMetrics, OtlpSerialization } from "effect/unstable/observability"
 
 describe("OtlpMetrics", () => {
   describe("cumulative temporality", () => {
@@ -399,6 +399,30 @@ describe("OtlpMetrics", () => {
         assert.strictEqual(secondMetric?.gauge?.dataPoints[0].asDouble, 50)
       }).pipe(Effect.provide(layer)))
   })
+
+  it.effect("supports manually flushing disabled exporters", () =>
+    Effect.gen(function*() {
+      const metricName = "manual_flush_counter_test"
+      const counter = Metric.counter(metricName, {
+        description: "Test counter"
+      })
+
+      yield* Metric.update(counter, 5)
+      yield* TestClock.adjust("10 seconds")
+
+      let requests = yield* MockHttpClient.requests
+      assert.strictEqual(requests.length, 0)
+
+      yield* OtlpExporter.flush
+
+      requests = yield* MockHttpClient.requests
+      assert.strictEqual(requests.length, 1)
+      const metric = findMetric(requests[0], metricName)
+      assert.strictEqual(metric?.sum?.dataPoints[0].asDouble, 5)
+    }).pipe(
+      Effect.provide(TestLayerDisabled),
+      Effect.provide(OtlpExporter.layerExporters)
+    ))
 })
 
 interface OtlpExportRequest {
@@ -492,12 +516,23 @@ const OtlpDeltaMetricsLayer = OtlpMetrics.layer({
   exportInterval: "10 seconds"
 })
 
+const OtlpDisabledMetricsLayer = OtlpMetrics.layer({
+  url: "http://localhost:4318/v1/metrics",
+  resource: { serviceName: "test-service" },
+  exportInterval: "disabled"
+})
+
 const TestLayerCumulative = OtlpCumulativeMetricsLayer.pipe(
   Layer.provideMerge(HttpClientLayer),
   Layer.provide(OtlpSerialization.layerJson)
 )
 
 const TestLayerDelta = OtlpDeltaMetricsLayer.pipe(
+  Layer.provideMerge(HttpClientLayer),
+  Layer.provide(OtlpSerialization.layerJson)
+)
+
+const TestLayerDisabled = OtlpDisabledMetricsLayer.pipe(
   Layer.provideMerge(HttpClientLayer),
   Layer.provide(OtlpSerialization.layerJson)
 )


### PR DESCRIPTION
## Summary

- Add `OtlpExporter.Exporters` and `OtlpExporter.layerExporters` to register OTLP exporters and flush them explicitly.
- Allow OTLP logger/tracer/exporter configuration to use `exportInterval: "disabled"` for manual flush mode.
- Make OTLP exports semaphore-protected and fully consume HTTP response bodies after export requests.
- Lazily initialize the HTTP client response finalization registry to avoid side effects in workerd (see https://gist.github.com/danieljvdm/726f9dcd8bc808eac5b82a502329e9e6).
- Add test coverage for manually flushing disabled OTLP exporters.

## Rationale

Managed runtimes in environments such as workerd cannot reliably depend on background interval fibers to export telemetry. For example, a Durable Object may go into hibernation before the next scheduled OTLP export interval runs.

This change introduces a manual flush model for those environments:

- telemetry is buffered during request handling
- scheduled interval exports can be disabled
- the runtime integration can call `OtlpExporter.Exporters.flush`
- and platforms such as Cloudflare can pass that flush effect to `ctx.waitUntil(...)` so logs/spans are exported after the response is returned but before the runtime is allowed to shut down the computation.

This makes OTLP exporting compatible with request-scoped and hibernation-prone runtimes without forcing exports to happen inline on the critical response path.

## Notes

`exportInterval: "disabled"` should be understood as manual flush mode, not as disabling telemetry export entirely. Consumers using this mode should provide `OtlpExporter.layerExporters` and explicitly call `flush` from their platform lifecycle hook.