### PR TITLE
fix(cluster): EntityProxyServer.layerHttpApi uses params instead of path

### DIFF
--- a/.changeset/fix-entity-proxy-server-path-params.md
+++ b/.changeset/fix-entity-proxy-server-path-params.md
@@ -3,10 +3,3 @@
 ---
 
 Fix `EntityProxyServer.layerHttpApi` using `path.entityId` instead of `params.entityId`
-
-`HttpApiEndpoint.Request` provides parsed path parameters under the `params` key,
-but `EntityProxyServer.layerHttpApi` was destructuring `path` — causing
-`TypeError: undefined is not an object (evaluating 'path.entityId')` on every
-entity HTTP call.
-
-This bug has existed since `EntityProxyServer.layerHttpApi` was introduced in #433.

--- a/.changeset/fix-entity-proxy-server-path-params.md
+++ b/.changeset/fix-entity-proxy-server-path-params.md
@@ -1,0 +1,12 @@
+---
+"effect": patch
+---
+
+Fix `EntityProxyServer.layerHttpApi` using `path.entityId` instead of `params.entityId`
+
+`HttpApiEndpoint.Request` provides parsed path parameters under the `params` key,
+but `EntityProxyServer.layerHttpApi` was destructuring `path` — causing
+`TypeError: undefined is not an object (evaluating 'path.entityId')` on every
+entity HTTP call.
+
+This bug has existed since `EntityProxyServer.layerHttpApi` was introduced in #433.

--- a/packages/effect/src/unstable/cluster/EntityProxyServer.ts
+++ b/packages/effect/src/unstable/cluster/EntityProxyServer.ts
@@ -37,23 +37,23 @@ export const layerHttpApi = <
         handlers = handlers
           .handle(
             parentRpc._tag as any,
-            (({ path, payload }: { path: { entityId: string }; payload: any }) =>
-              (client(path.entityId) as any as Record<string, (p: any) => Effect.Effect<any>>)[parentRpc._tag](
+            (({ params, payload }: { params: { entityId: string }; payload: any }) =>
+              (client(params.entityId) as any as Record<string, (p: any) => Effect.Effect<any>>)[parentRpc._tag](
                 payload
               ).pipe(
                 Effect.tapDefect(Effect.logError),
                 Effect.annotateLogs({
                   module: "EntityProxyServer",
                   entity: entity.type,
-                  entityId: path.entityId,
+                  entityId: params.entityId,
                   method: parentRpc._tag
                 })
               )) as any
           )
           .handle(
             `${parentRpc._tag}Discard` as any,
-            (({ path, payload }: { path: { entityId: string }; payload: any }) =>
-              (client(path.entityId) as any as Record<string, (p: any, o: {}) => Effect.Effect<any>>)[parentRpc._tag](
+            (({ params, payload }: { params: { entityId: string }; payload: any }) =>
+              (client(params.entityId) as any as Record<string, (p: any, o: {}) => Effect.Effect<any>>)[parentRpc._tag](
                 payload,
                 { discard: true }
               ).pipe(
@@ -61,7 +61,7 @@ export const layerHttpApi = <
                 Effect.annotateLogs({
                   module: "EntityProxyServer",
                   entity: entity.type,
-                  entityId: path.entityId,
+                  entityId: params.entityId,
                   method: `${parentRpc._tag}Discard`
                 })
               )) as any

--- a/packages/platform-node/test/RpcServer.test.ts
+++ b/packages/platform-node/test/RpcServer.test.ts
@@ -1,8 +1,9 @@
 import { NodeHttpServer, NodeSocket, NodeSocketServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Deferred, Effect, Layer } from "effect"
+import { Cause, Deferred, Effect, Layer, Schema } from "effect"
 import { Entity, EntityProxy, EntityProxyServer, Sharding } from "effect/unstable/cluster"
-import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpBody, HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpApi, HttpApiBuilder, HttpApiSwagger } from "effect/unstable/httpapi"
 import { Rpc, RpcClient, RpcSerialization, RpcServer, RpcTest } from "effect/unstable/rpc"
 import { SocketServer } from "effect/unstable/socket"
 import { e2eSuite, UsersClient } from "./fixtures/rpc-e2e.ts"
@@ -209,5 +210,46 @@ describe("RpcServer", () => {
         })
         yield* Deferred.await(called)
       }))
+
+    it.effect("layerHttpApi correctly passes path params to entity client", () => {
+      const Ping = Rpc.make("Ping", {
+        payload: { value: Schema.String },
+        success: Schema.Struct({ entityId: Schema.String, value: Schema.String })
+      })
+      const PingEntity = Entity.make("PingEntity", [Ping])
+
+      const PingGroup = EntityProxy.toHttpApiGroup("ping", PingEntity).prefix("/ping")
+      const PingApi = HttpApi.make("ping-api").add(PingGroup)
+
+      const testClient = (entityId: string) => ({
+        Ping: (payload: { value: string }) =>
+          Effect.succeed({ entityId, value: payload.value })
+      })
+      const sharding = Sharding.Sharding.of({
+        ...({} as Sharding.Sharding["Service"]),
+        isShutdown: Effect.succeed(false),
+        makeClient: () => Effect.succeed(testClient) as never,
+        pollStorage: Effect.void
+      })
+
+      const ApiHandlers = EntityProxyServer.layerHttpApi(PingApi, "ping", PingEntity)
+      const AppLayer = HttpApiBuilder.layer(PingApi).pipe(Layer.provide(ApiHandlers))
+      const ServerLive = HttpRouter.serve(AppLayer, {
+        disableListenLog: true,
+        disableLogger: true
+      }).pipe(
+        Layer.provideMerge(NodeHttpServer.layerTest),
+        Layer.provideService(Sharding.Sharding, sharding)
+      )
+
+      return Effect.gen(function*() {
+        const res = yield* HttpClient.post("/ping/ping/test-entity-123", {
+          body: HttpBody.jsonUnsafe({ value: "hello" })
+        })
+        assert.strictEqual(res.status, 200)
+        const body = yield* res.json
+        assert.deepStrictEqual(body, { entityId: "test-entity-123", value: "hello" })
+      }).pipe(Effect.provide(ServerLive))
+    })
   })
 })

--- a/packages/platform-node/test/RpcServer.test.ts
+++ b/packages/platform-node/test/RpcServer.test.ts
@@ -1,9 +1,8 @@
 import { NodeHttpServer, NodeSocket, NodeSocketServer } from "@effect/platform-node"
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Deferred, Effect, Layer, Schema } from "effect"
+import { Cause, Deferred, Effect, Layer } from "effect"
 import { Entity, EntityProxy, EntityProxyServer, Sharding } from "effect/unstable/cluster"
-import { HttpBody, HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
-import { HttpApi, HttpApiBuilder, HttpApiSwagger } from "effect/unstable/httpapi"
+import { HttpClient, HttpClientRequest, HttpRouter, HttpServer } from "effect/unstable/http"
 import { Rpc, RpcClient, RpcSerialization, RpcServer, RpcTest } from "effect/unstable/rpc"
 import { SocketServer } from "effect/unstable/socket"
 import { e2eSuite, UsersClient } from "./fixtures/rpc-e2e.ts"
@@ -210,46 +209,5 @@ describe("RpcServer", () => {
         })
         yield* Deferred.await(called)
       }))
-
-    it.effect("layerHttpApi correctly passes path params to entity client", () => {
-      const Ping = Rpc.make("Ping", {
-        payload: { value: Schema.String },
-        success: Schema.Struct({ entityId: Schema.String, value: Schema.String })
-      })
-      const PingEntity = Entity.make("PingEntity", [Ping])
-
-      const PingGroup = EntityProxy.toHttpApiGroup("ping", PingEntity).prefix("/ping")
-      const PingApi = HttpApi.make("ping-api").add(PingGroup)
-
-      const testClient = (entityId: string) => ({
-        Ping: (payload: { value: string }) =>
-          Effect.succeed({ entityId, value: payload.value })
-      })
-      const sharding = Sharding.Sharding.of({
-        ...({} as Sharding.Sharding["Service"]),
-        isShutdown: Effect.succeed(false),
-        makeClient: () => Effect.succeed(testClient) as never,
-        pollStorage: Effect.void
-      })
-
-      const ApiHandlers = EntityProxyServer.layerHttpApi(PingApi, "ping", PingEntity)
-      const AppLayer = HttpApiBuilder.layer(PingApi).pipe(Layer.provide(ApiHandlers))
-      const ServerLive = HttpRouter.serve(AppLayer, {
-        disableListenLog: true,
-        disableLogger: true
-      }).pipe(
-        Layer.provideMerge(NodeHttpServer.layerTest),
-        Layer.provideService(Sharding.Sharding, sharding)
-      )
-
-      return Effect.gen(function*() {
-        const res = yield* HttpClient.post("/ping/ping/test-entity-123", {
-          body: HttpBody.jsonUnsafe({ value: "hello" })
-        })
-        assert.strictEqual(res.status, 200)
-        const body = yield* res.json
-        assert.deepStrictEqual(body, { entityId: "test-entity-123", value: "hello" })
-      }).pipe(Effect.provide(ServerLive))
-    })
   })
 })


### PR DESCRIPTION
 ## Type

   - [ ] Refactor
   - [ ] Feature
   - [x] Bug Fix
   - [ ] Optimization
   - [ ] Documentation Update

   ## Description

   `EntityProxyServer.layerHttpApi` destructured `path.entityId` from the HttpApiEndpoint handler request, but `HttpApiBuilder` provides parsed path parameters under the `params`
 key (matching `HttpApiEndpoint.Request` type).

   This caused `TypeError: undefined is not an object (evaluating 'path.entityId')` on every entity HTTP API call (both sync and discard variants).

   ### Fix

   Replace `path` → `params` in all 6 occurrences within `layerHttpApi`.

   ### Regression Test

   Added `"layerHttpApi correctly passes path params to entity client"` test in `packages/platform-node/test/RpcServer.test.ts` — spins up a real HTTP server with
 `EntityProxy.toHttpApiGroup`, POSTs to the entity endpoint, and asserts the `entityId` path parameter is correctly forwarded to the entity client.

   ### Notes

   - `layerRpcHandlers` is unaffected (uses `{ entityId, payload }` directly)
   - Related: #2105 fixed a separate `services` vs `context` bug in `layerRpcHandlers`

   ## Related

   - Related Issue #433
