### PR TITLE
Add server-to-client response headers support in RPC framework

### DIFF
--- a/.changeset/rpc-server-response-headers.md
+++ b/.changeset/rpc-server-response-headers.md
@@ -1,0 +1,37 @@
+---
+"effect": minor
+---
+
+unstable/rpc: add server-to-client response headers
+
+Server handlers can now attach headers to the response sent back to the client.
+The headers are emitted on `Chunk` and `Exit` messages and exposed to the
+client via a new per-call `onResponseHeaders` option.
+
+Server-side handlers and middleware can set response headers either via the
+mutable `responseHeaders` holder available on the metadata object, or via
+the new `Rpc.setResponseHeader`, `Rpc.setAllResponseHeaders`, and
+`Rpc.mergeResponseHeaders` effects.
+
+```ts
+import { Effect } from "effect"
+import { Rpc, RpcGroup } from "effect/unstable/rpc"
+
+const group = RpcGroup.make(
+  Rpc.make("Echo", { payload: { value: Schema.String }, success: Schema.String })
+)
+
+const handlers = group.toLayer({
+  Echo: (req) =>
+    Effect.gen(function*() {
+      yield* Rpc.setResponseHeader("x-echo", req.value)
+      return req.value
+    })
+})
+
+// client side
+const result = yield* client.Echo(
+  { value: "hi" },
+  { onResponseHeaders: (headers) => console.log(headers) }
+)
+```

--- a/.changeset/rpc-server-response-headers.md
+++ b/.changeset/rpc-server-response-headers.md
@@ -37,21 +37,27 @@ const handlers = group.toLayer({
 Three options on the call site:
 
 ```ts
-// 1. withResponseHeaders — wrap the call, get [result, headers]
-const [user, headers] = yield* RpcClient.withResponseHeaders(client.GetUser({ id: 1 }))
+Effect.gen(function*() {
+  // 1. withResponseHeaders — wrap the call, get [result, headers]
+  const [user, headers] = yield* RpcClient.withResponseHeaders(client.GetUser({ id: 1 }))
 
-// 2. onResponseHeaders — Effect callback. Its E and R bubble into the call's
-//    error and requirements. Failures propagate into the result Cause.
-yield* client.GetUser(
-  { id: 1 },
-  { onResponseHeaders: (h) => Logger.log(`headers: ${JSON.stringify(h)}`) }
-)
+  // 2. onResponseHeaders — Effect callback. Its E and R bubble into the call's
+  //    error and requirements. Failures propagate into the result Cause.
+  yield* client.GetUser(
+    { id: 1 },
+    { onResponseHeaders: (h) => Logger.log(`headers: ${JSON.stringify(h)}`) }
+  )
 
-// 3. onResponseHeadersSync — fire-and-forget sync callback
-yield* client.GetUser(
-  { id: 1 },
-  { onResponseHeadersSync: (h) => { lastHeaders = h } }
-)
+  // 3. onResponseHeadersSync — fire-and-forget sync callback
+  yield* client.GetUser(
+    { id: 1 },
+    {
+      onResponseHeadersSync: (h) => {
+        lastHeaders = h
+      }
+    }
+  )
+})
 ```
 
 For streaming RPCs, `onResponseHeaders` / `onResponseHeadersSync` fire on

--- a/.changeset/rpc-server-response-headers.md
+++ b/.changeset/rpc-server-response-headers.md
@@ -4,17 +4,19 @@
 
 unstable/rpc: add server-to-client response headers
 
-Server handlers can now attach headers to the response sent back to the client.
-The headers are emitted on `Chunk` and `Exit` messages and exposed to the
-client via a new per-call `onResponseHeaders` option.
+Server handlers can now attach headers to the response sent back to the
+client. Headers ride along on every `Chunk` and `Exit` message and are
+exposed to the client via per-call options or the new
+`RpcClient.withResponseHeaders` helper.
 
-Server-side handlers and middleware can set response headers either via the
-mutable `responseHeaders` holder available on the metadata object, or via
-the new `Rpc.setResponseHeader`, `Rpc.setAllResponseHeaders`, and
-`Rpc.mergeResponseHeaders` effects.
+### Setting headers (server)
+
+Handlers and middleware receive a mutable `responseHeaders` holder on the
+metadata object. The same value is also available through `Rpc.setResponseHeader`,
+`Rpc.setAllResponseHeaders` and `Rpc.mergeResponseHeaders`:
 
 ```ts
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { Rpc, RpcGroup } from "effect/unstable/rpc"
 
 const group = RpcGroup.make(
@@ -28,10 +30,35 @@ const handlers = group.toLayer({
       return req.value
     })
 })
+```
 
-// client side
-const result = yield* client.Echo(
-  { value: "hi" },
-  { onResponseHeaders: (headers) => console.log(headers) }
+### Reading headers (client)
+
+Three options on the call site:
+
+```ts
+// 1. withResponseHeaders — wrap the call, get [result, headers]
+const [user, headers] = yield* RpcClient.withResponseHeaders(client.GetUser({ id: 1 }))
+
+// 2. onResponseHeaders — Effect callback. Its E and R bubble into the call's
+//    error and requirements. Failures propagate into the result Cause.
+yield* client.GetUser(
+  { id: 1 },
+  { onResponseHeaders: (h) => Logger.log(`headers: ${JSON.stringify(h)}`) }
+)
+
+// 3. onResponseHeadersSync — fire-and-forget sync callback
+yield* client.GetUser(
+  { id: 1 },
+  { onResponseHeadersSync: (h) => { lastHeaders = h } }
 )
 ```
+
+For streaming RPCs, `onResponseHeaders` / `onResponseHeadersSync` fire on
+each chunk and on the final exit; `withResponseHeaders` is for single-response
+calls.
+
+### Message shape
+
+`ResponseChunk(Encoded)` and `ResponseExit(Encoded)` now carry a (required)
+`headers` field, defaulting to an empty value when none are set.

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.4.1"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.1.tgz",
+      "integrity": "sha512-5PqQGUAVeNPNM6PyQATSe5q7ICwFSIFYEMFHzD6Efw2fSd1ij5vskgtxEZFl/oiXkPx/w8/DPR9EZS9bkoHYnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.1",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.1.tgz",
+      "integrity": "sha512-7wWHs8Og5W5+fuJmHDi7oy1yK6c9mmVfK1Ll9hPHZZ5xj357fVl+oI4i0jeUdjonEoXb3Svq/U5blraSArX5OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -215,7 +215,8 @@ export class McpServer extends Context.Service<McpServer, {
             clientId: 0,
             requestId: message.id,
             _tag: "Exit",
-            exit: Exit.void as any
+            exit: Exit.void as any,
+            headers: Headers.empty
           })
         })
     })
@@ -440,7 +441,8 @@ export const run: (options: {
                   rpc,
                   requestId: RpcMessage.RequestId(request.id),
                   client: new Rpc.ServerClient(clientId),
-                  headers: Headers.fromInput(request.headers)
+                  headers: Headers.fromInput(request.headers),
+                  responseHeaders: new Rpc.ResponseHeaders()
                 }) as any as Effect.Effect<void>
                 : Effect.void
             }

--- a/packages/effect/src/unstable/cluster/Sharding.ts
+++ b/packages/effect/src/unstable/cluster/Sharding.ts
@@ -27,6 +27,7 @@ import * as Schedule from "../../Schedule.ts"
 import * as Scope from "../../Scope.ts"
 import * as Semaphore from "../../Semaphore.ts"
 import * as Stream from "../../Stream.ts"
+import * as Headers from "../http/Headers.ts"
 import type * as Rpc from "../rpc/Rpc.ts"
 import * as RpcClient from "../rpc/RpcClient.ts"
 import { type FromServer, RequestId } from "../rpc/RpcMessage.ts"
@@ -1178,7 +1179,8 @@ const make = Effect.gen(function*() {
           _tag: "Chunk",
           clientId: 0,
           requestId: RequestId(reply.requestId),
-          values: reply.values
+          values: reply.values,
+          headers: Headers.empty
         })
       }
       case "WithExit": {
@@ -1187,7 +1189,8 @@ const make = Effect.gen(function*() {
           _tag: "Exit",
           clientId: 0,
           requestId: RequestId(reply.requestId),
-          exit: reply.exit
+          exit: reply.exit,
+          headers: Headers.empty
         })
       }
     }

--- a/packages/effect/src/unstable/rpc/Rpc.ts
+++ b/packages/effect/src/unstable/rpc/Rpc.ts
@@ -4,7 +4,7 @@
 import type * as Cause from "../../Cause.ts"
 import * as Context from "../../Context.ts"
 import type { Deferred } from "../../Deferred.ts"
-import type { Effect } from "../../Effect.ts"
+import * as Effect from "../../Effect.ts"
 import type { Exit as Exit_ } from "../../Exit.ts"
 import * as Option from "../../Option.ts"
 import { type Pipeable, pipeArguments } from "../../Pipeable.ts"
@@ -15,6 +15,7 @@ import * as Schema from "../../Schema.ts"
 import type { Stream } from "../../Stream.ts"
 import type * as Struct from "../../Struct.ts"
 import type { NoInfer } from "../../Types.ts"
+import * as Headers_ from "../http/Headers.ts"
 import type { Headers } from "../http/Headers.ts"
 import type { RequestId } from "./RpcMessage.ts"
 import type * as RpcMiddleware from "./RpcMiddleware.ts"
@@ -168,6 +169,78 @@ export class ServerClient {
 }
 
 /**
+ * Mutable holder for response headers attached by a server-side handler or
+ * middleware. The current value is read by the `RpcServer` when it emits a
+ * `Chunk` or `Exit` message back to the client.
+ *
+ * @since 4.0.0
+ * @category models
+ */
+export class ResponseHeaders {
+  current: Headers = Headers_.empty
+  setUnsafe(key: string, value: string): void {
+    this.current = Headers_.set(this.current, key, value)
+  }
+  setAllUnsafe(headers: Headers_.Input): void {
+    this.current = Headers_.setAll(this.current, headers)
+  }
+  mergeUnsafe(headers: Headers): void {
+    this.current = Headers_.merge(this.current, headers)
+  }
+}
+
+/**
+ * A `Context.Reference` that exposes the current request's
+ * `ResponseHeaders` holder to a server-side handler.
+ *
+ * Available within the handler fiber so `setAllResponseHeaders` /
+ * `setResponseHeader` / `mergeResponseHeaders` can be called as effects.
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const CurrentResponseHeaders: Context.Reference<ResponseHeaders> = Context.Reference<ResponseHeaders>(
+  "effect/rpc/Rpc/CurrentResponseHeaders",
+  { defaultValue: () => new ResponseHeaders() }
+)
+
+/**
+ * Replace the current set of response headers with the provided input.
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const setAllResponseHeaders = (input: Headers_.Input): Effect.Effect<void> =>
+  Effect.flatMap(CurrentResponseHeaders.asEffect(), (ref) =>
+    Effect.sync(() => {
+      ref.setAllUnsafe(input)
+    }))
+
+/**
+ * Set a single response header.
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const setResponseHeader = (key: string, value: string): Effect.Effect<void> =>
+  Effect.flatMap(CurrentResponseHeaders.asEffect(), (ref) =>
+    Effect.sync(() => {
+      ref.setUnsafe(key, value)
+    }))
+
+/**
+ * Merge another `Headers` value into the current response headers.
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const mergeResponseHeaders = (headers: Headers): Effect.Effect<void> =>
+  Effect.flatMap(CurrentResponseHeaders.asEffect(), (ref) =>
+    Effect.sync(() => {
+      ref.mergeUnsafe(headers)
+    }))
+
+/**
  * Represents an implemented rpc.
  *
  * @since 4.0.0
@@ -180,8 +253,9 @@ export interface Handler<Tag extends string> {
     readonly client: ServerClient
     readonly requestId: RequestId
     readonly headers: Headers
+    readonly responseHeaders: ResponseHeaders
     readonly rpc: Any
-  }) => Effect<{} | Deferred<any, any>, any> | Stream<any, any>
+  }) => Effect.Effect<{} | Deferred<any, any>, any> | Stream<any, any>
   readonly context: Context.Context<never>
 }
 
@@ -500,6 +574,7 @@ export type ToHandlerFn<Current extends Any, R = any> = (
     readonly client: ServerClient
     readonly requestId: RequestId
     readonly headers: Headers
+    readonly responseHeaders: ResponseHeaders
     readonly rpc: Current
   }
 ) => WrapperOr<ResultFrom<Current, R>>
@@ -586,12 +661,12 @@ export type ResultFrom<R extends Any, Services> = R extends Rpc<
         _SE["Type"] | _Error["Type"],
         Services
       >
-      | Effect<
+      | Effect.Effect<
         Queue.Dequeue<_SA["Type"], _SE["Type"] | _Error["Type"] | Cause.Done>,
         _SE["Type"] | Schema.Schema.Type<_Error>,
         Services
       > :
-  Effect<
+  Effect.Effect<
     _Success["Type"] | Deferred<_Success["Type"], _Error["Type"]>,
     _Error["Type"],
     Services

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -67,11 +67,13 @@ export declare namespace RpcClient {
           readonly streamBufferSize?: number | undefined
           readonly headers?: Headers.Input | undefined
           readonly context?: Context.Context<never> | undefined
+          readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
         } :
         {
           readonly headers?: Headers.Input | undefined
           readonly context?: Context.Context<never> | undefined
           readonly discard?: Discard | undefined
+          readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
         }
     ) => Current extends Rpc.Rpc<
       infer _Tag,
@@ -130,11 +132,13 @@ export declare namespace RpcClient {
         readonly streamBufferSize?: number | undefined
         readonly headers?: Headers.Input | undefined
         readonly context?: Context.Context<never> | undefined
+        readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
       } :
       {
         readonly headers?: Headers.Input | undefined
         readonly context?: Context.Context<never> | undefined
         readonly discard?: Discard | undefined
+        readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
       }
   ) => Rpc.ExtractTag<Rpcs, Tag> extends Rpc.Rpc<
     infer _Tag,
@@ -240,6 +244,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly _tag: "Effect"
     readonly rpc: Rpc.AnyWithProps
     readonly context: Context.Context<never>
+    readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
     resume: (_: Exit.Exit<any, any>) => void
   } | {
     readonly _tag: "Queue"
@@ -247,6 +252,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly queue: Queue.Queue<any, any>
     readonly scope: Scope.Scope
     readonly context: Context.Context<never>
+    readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
   }
   const entries = new Map<RequestId, ClientEntry>()
 
@@ -281,6 +287,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
       readonly headers?: Headers.Input | undefined
       readonly context?: Context.Context<never> | undefined
       readonly discard?: boolean | undefined
+      readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
     }) => {
       const headers = opts?.headers ? Headers.fromInput(opts.headers) : Headers.empty
       const context = opts?.context ?? Context.empty()
@@ -293,7 +300,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
             rpc.payloadSchema.make(payload),
             headers,
             context,
-            opts?.discard ?? false
+            opts?.discard ?? false,
+            opts?.onResponseHeaders
           )
         return disableTracing ? onRequest(undefined) : Effect.useSpan(
           `${spanPrefix}.${rpc._tag}`,
@@ -307,7 +315,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         rpc.payloadSchema.make(payload),
         headers,
         opts?.streamBufferSize ?? 16,
-        context
+        context,
+        opts?.onResponseHeaders
       )
       if (opts?.asQueue) return queue
       return Stream.unwrap(Effect.map(queue, Stream.fromQueue))
@@ -324,7 +333,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     payload: any,
     headers: Headers.Headers,
     context: Context.Context<never>,
-    discard: boolean
+    discard: boolean,
+    onResponseHeaders: ((headers: Headers.Headers) => void) | undefined
   ) =>
     Effect.withFiber<any, any, any>((parentFiber) => {
       if (isShutdown) {
@@ -363,6 +373,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
             _tag: "Effect",
             rpc,
             context,
+            onResponseHeaders,
             resume(exit) {
               resume(exit)
               if (fiber && !fiber.pollUnsafe()) {
@@ -402,7 +413,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     payload: any,
     headers: Headers.Headers,
     streamBufferSize: number,
-    context: Context.Context<never>
+    context: Context.Context<never>,
+    onResponseHeaders: ((headers: Headers.Headers) => void) | undefined
   ) {
     if (isShutdown) {
       return yield* Effect.interrupt
@@ -436,7 +448,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
       rpc,
       queue,
       scope,
-      context
+      context,
+      onResponseHeaders
     })
 
     yield* middleware(
@@ -531,6 +544,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const requestId = message.requestId
         const entry = entries.get(requestId)
         if (!entry || entry._tag !== "Queue") return Effect.void
+        if (entry.onResponseHeaders) {
+          entry.onResponseHeaders(message.headers)
+        }
         return Queue.offerAll(entry.queue, message.values).pipe(
           supportsAck
             ? Effect.flatMap(() =>
@@ -549,6 +565,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const entry = entries.get(requestId)
         if (!entry) return Effect.void
         entries.delete(requestId)
+        if (entry.onResponseHeaders) {
+          entry.onResponseHeaders(message.headers)
+        }
         if (entry._tag === "Effect") {
           entry.resume(message.exit)
           return Effect.void
@@ -687,18 +706,20 @@ export const make: <Rpcs extends Rpc.Any, const Flatten extends boolean = false>
         const requestId = RequestId(message.requestId)
         const entry = entries.get(requestId)
         if (!entry || Option.isNone(entry.schemas.decodeChunk)) return Effect.void
+        const headers = Headers.fromInput(message.headers)
         return entry.schemas.decodeChunk.value(message.values).pipe(
           Effect.provideContext(entry.context),
           Effect.orDie,
           Effect.flatMap((chunk) =>
-            write({ _tag: "Chunk", clientId: 0, requestId: RequestId(message.requestId), values: chunk })
+            write({ _tag: "Chunk", clientId: 0, requestId: RequestId(message.requestId), values: chunk, headers })
           ),
           Effect.onError((cause) =>
             write({
               _tag: "Exit",
               clientId: 0,
               requestId: RequestId(message.requestId),
-              exit: Exit.failCause(cause)
+              exit: Exit.failCause(cause),
+              headers: Headers.empty
             })
           )
         ) as Effect.Effect<void>
@@ -708,12 +729,14 @@ export const make: <Rpcs extends Rpc.Any, const Flatten extends boolean = false>
         const entry = entries.get(requestId)
         if (!entry) return Effect.void
         entries.delete(requestId)
+        const headers = Headers.fromInput(message.headers)
         return entry.schemas.decodeExit(message.exit).pipe(
           Effect.provideContext(entry.context),
           Effect.orDie,
           Effect.matchCauseEffect({
-            onSuccess: (exit) => write({ _tag: "Exit", clientId: 0, requestId, exit }),
-            onFailure: (cause) => write({ _tag: "Exit", clientId: 0, requestId, exit: Exit.failCause(cause) })
+            onSuccess: (exit) => write({ _tag: "Exit", clientId: 0, requestId, exit, headers }),
+            onFailure: (cause) =>
+              write({ _tag: "Exit", clientId: 0, requestId, exit: Exit.failCause(cause), headers: Headers.empty })
           })
         ) as Effect.Effect<void>
       }
@@ -724,7 +747,7 @@ export const make: <Rpcs extends Rpc.Any, const Flatten extends boolean = false>
         const exit = Exit.fail(message.error)
         return Effect.forEach(
           entries.keys(),
-          (requestId) => write({ _tag: "Exit", clientId: 0, requestId, exit: exit as any })
+          (requestId) => write({ _tag: "Exit", clientId: 0, requestId, exit: exit as any, headers: Headers.empty })
         )
       }
       default: {

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -59,7 +59,9 @@ export declare namespace RpcClient {
   export type From<Rpcs extends Rpc.Any, E = never> = {
     readonly [Current in Rpcs as Current["_tag"]]: <
       const AsQueue extends boolean = false,
-      const Discard = false
+      const Discard = false,
+      HE = never,
+      HR = never
     >(
       input: Rpc.PayloadConstructor<Current>,
       options?: Rpc.Success<Current> extends Stream.Stream<infer _A, infer _E, infer _R> ? {
@@ -67,13 +69,15 @@ export declare namespace RpcClient {
           readonly streamBufferSize?: number | undefined
           readonly headers?: Headers.Input | undefined
           readonly context?: Context.Context<never> | undefined
-          readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+          readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, HE, HR>) | undefined
+          readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
         } :
         {
           readonly headers?: Headers.Input | undefined
           readonly context?: Context.Context<never> | undefined
           readonly discard?: Discard | undefined
-          readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+          readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, HE, HR>) | undefined
+          readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
         }
     ) => Current extends Rpc.Rpc<
       infer _Tag,
@@ -85,10 +89,17 @@ export declare namespace RpcClient {
     > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsQueue extends true ? Effect.Effect<
             Queue.Dequeue<
               _A["Type"],
-              _E["Type"] | _Error["Type"] | E | _Middleware["error"]["Type"] | _Middleware["~ClientError"] | Cause.Done
+              | _E["Type"]
+              | _Error["Type"]
+              | E
+              | HE
+              | _Middleware["error"]["Type"]
+              | _Middleware["~ClientError"]
+              | Cause.Done
             >,
             never,
             | Scope.Scope
+            | HR
             | _Payload["EncodingServices"]
             | _Success["DecodingServices"]
             | _Error["DecodingServices"]
@@ -96,7 +107,8 @@ export declare namespace RpcClient {
           >
         : Stream.Stream<
           _A["Type"],
-          _E["Type"] | _Error["Type"] | E | _Middleware["error"]["Type"] | _Middleware["~ClientError"],
+          _E["Type"] | _Error["Type"] | E | HE | _Middleware["error"]["Type"] | _Middleware["~ClientError"],
+          | HR
           | _Payload["EncodingServices"]
           | _Success["DecodingServices"]
           | _Error["DecodingServices"]
@@ -106,8 +118,10 @@ export declare namespace RpcClient {
         Discard extends true ? void : _Success["Type"],
         | (Discard extends true ? never : _Error["Type"])
         | E
+        | HE
         | _Middleware["error"]["Type"]
         | _Middleware["~ClientError"],
+        | HR
         | _Payload["EncodingServices"]
         | _Success["DecodingServices"]
         | _Error["DecodingServices"]
@@ -123,7 +137,9 @@ export declare namespace RpcClient {
   export type Flat<Rpcs extends Rpc.Any, E = never> = <
     const Tag extends Rpcs["_tag"],
     const AsQueue extends boolean = false,
-    const Discard = false
+    const Discard = false,
+    HE = never,
+    HR = never
   >(
     tag: Tag,
     payload: Rpc.PayloadConstructor<Rpc.ExtractTag<Rpcs, Tag>>,
@@ -132,13 +148,15 @@ export declare namespace RpcClient {
         readonly streamBufferSize?: number | undefined
         readonly headers?: Headers.Input | undefined
         readonly context?: Context.Context<never> | undefined
-        readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+        readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, HE, HR>) | undefined
+        readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
       } :
       {
         readonly headers?: Headers.Input | undefined
         readonly context?: Context.Context<never> | undefined
         readonly discard?: Discard | undefined
-        readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+        readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, HE, HR>) | undefined
+        readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
       }
   ) => Rpc.ExtractTag<Rpcs, Tag> extends Rpc.Rpc<
     infer _Tag,
@@ -150,10 +168,11 @@ export declare namespace RpcClient {
   > ? [_Success] extends [RpcSchema.Stream<infer _A, infer _E>] ? AsQueue extends true ? Effect.Effect<
           Queue.Dequeue<
             _A["Type"],
-            _E["Type"] | _Error["Type"] | E | _Middleware["error"]["Type"] | _Middleware["~ClientError"]
+            _E["Type"] | _Error["Type"] | E | HE | _Middleware["error"]["Type"] | _Middleware["~ClientError"]
           >,
           never,
           | Scope.Scope
+          | HR
           | _Payload["EncodingServices"]
           | _Success["DecodingServices"]
           | _Error["DecodingServices"]
@@ -161,7 +180,8 @@ export declare namespace RpcClient {
         >
       : Stream.Stream<
         _A["Type"],
-        _E["Type"] | _Error["Type"] | E | _Middleware["error"]["Type"] | _Middleware["~ClientError"],
+        _E["Type"] | _Error["Type"] | E | HE | _Middleware["error"]["Type"] | _Middleware["~ClientError"],
+        | HR
         | _Payload["EncodingServices"]
         | _Success["DecodingServices"]
         | _Error["DecodingServices"]
@@ -169,7 +189,12 @@ export declare namespace RpcClient {
       >
     : Effect.Effect<
       Discard extends true ? void : _Success["Type"],
-      (Discard extends true ? never : _Error["Type"]) | E | _Middleware["error"]["Type"] | _Middleware["~ClientError"],
+      | (Discard extends true ? never : _Error["Type"])
+      | E
+      | HE
+      | _Middleware["error"]["Type"]
+      | _Middleware["~ClientError"],
+      | HR
       | _Payload["EncodingServices"]
       | _Success["DecodingServices"]
       | _Error["DecodingServices"]
@@ -244,7 +269,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly _tag: "Effect"
     readonly rpc: Rpc.AnyWithProps
     readonly context: Context.Context<never>
-    readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+    readonly parentContext: Context.Context<never>
+    readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, any, any>) | undefined
+    readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
     resume: (_: Exit.Exit<any, any>) => void
   } | {
     readonly _tag: "Queue"
@@ -252,7 +279,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly queue: Queue.Queue<any, any>
     readonly scope: Scope.Scope
     readonly context: Context.Context<never>
-    readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+    readonly parentContext: Context.Context<never>
+    readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, any, any>) | undefined
+    readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
   }
   const entries = new Map<RequestId, ClientEntry>()
 
@@ -287,7 +316,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
       readonly headers?: Headers.Input | undefined
       readonly context?: Context.Context<never> | undefined
       readonly discard?: boolean | undefined
-      readonly onResponseHeaders?: ((headers: Headers.Headers) => void) | undefined
+      readonly onResponseHeaders?: ((headers: Headers.Headers) => Effect.Effect<void, any, any>) | undefined
+      readonly onResponseHeadersSync?: ((headers: Headers.Headers) => void) | undefined
     }) => {
       const headers = opts?.headers ? Headers.fromInput(opts.headers) : Headers.empty
       const context = opts?.context ?? Context.empty()
@@ -301,7 +331,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
             headers,
             context,
             opts?.discard ?? false,
-            opts?.onResponseHeaders
+            opts?.onResponseHeaders,
+            opts?.onResponseHeadersSync
           )
         return disableTracing ? onRequest(undefined) : Effect.useSpan(
           `${spanPrefix}.${rpc._tag}`,
@@ -316,7 +347,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         headers,
         opts?.streamBufferSize ?? 16,
         context,
-        opts?.onResponseHeaders
+        opts?.onResponseHeaders,
+        opts?.onResponseHeadersSync
       )
       if (opts?.asQueue) return queue
       return Stream.unwrap(Effect.map(queue, Stream.fromQueue))
@@ -334,7 +366,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     headers: Headers.Headers,
     context: Context.Context<never>,
     discard: boolean,
-    onResponseHeaders: ((headers: Headers.Headers) => void) | undefined
+    onResponseHeaders: ((headers: Headers.Headers) => Effect.Effect<void, any, any>) | undefined,
+    onResponseHeadersSync: ((headers: Headers.Headers) => void) | undefined
   ) =>
     Effect.withFiber<any, any, any>((parentFiber) => {
       if (isShutdown) {
@@ -373,7 +406,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
             _tag: "Effect",
             rpc,
             context,
+            parentContext: parentFiber.context,
             onResponseHeaders,
+            onResponseHeadersSync,
             resume(exit) {
               resume(exit)
               if (fiber && !fiber.pollUnsafe()) {
@@ -414,7 +449,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     headers: Headers.Headers,
     streamBufferSize: number,
     context: Context.Context<never>,
-    onResponseHeaders: ((headers: Headers.Headers) => void) | undefined
+    onResponseHeaders: ((headers: Headers.Headers) => Effect.Effect<void, any, any>) | undefined,
+    onResponseHeadersSync: ((headers: Headers.Headers) => void) | undefined
   ) {
     if (isShutdown) {
       return yield* Effect.interrupt
@@ -449,7 +485,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
       queue,
       scope,
       context,
-      onResponseHeaders
+      parentContext: fiber.context,
+      onResponseHeaders,
+      onResponseHeadersSync
     })
 
     yield* middleware(
@@ -544,10 +582,16 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const requestId = message.requestId
         const entry = entries.get(requestId)
         if (!entry || entry._tag !== "Queue") return Effect.void
-        if (entry.onResponseHeaders) {
-          entry.onResponseHeaders(message.headers)
+        const ref = Context.get(entry.parentContext, ResponseHeadersRef)
+        if (ref) ref.value = message.headers
+        if (entry.onResponseHeadersSync) {
+          entry.onResponseHeadersSync(message.headers)
         }
-        return Queue.offerAll(entry.queue, message.values).pipe(
+        const headersEffect: Effect.Effect<void> = entry.onResponseHeaders
+          ? Effect.provideContext(entry.onResponseHeaders(message.headers), entry.parentContext) as any
+          : Effect.void
+        return headersEffect.pipe(
+          Effect.flatMap(() => Queue.offerAll(entry.queue, message.values)),
           supportsAck
             ? Effect.flatMap(() =>
               options.onFromClient({
@@ -557,7 +601,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
               })
             )
             : identity,
-          Effect.catchCause((cause) => Queue.failCause(entry.queue, cause))
+          Effect.catchCause((cause) => Queue.failCause(entry.queue, cause)),
+          Effect.asVoid
         )
       }
       case "Exit": {
@@ -565,16 +610,37 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const entry = entries.get(requestId)
         if (!entry) return Effect.void
         entries.delete(requestId)
-        if (entry.onResponseHeaders) {
-          entry.onResponseHeaders(message.headers)
+        const ref = Context.get(entry.parentContext, ResponseHeadersRef)
+        if (ref) ref.value = message.headers
+        if (entry.onResponseHeadersSync) {
+          entry.onResponseHeadersSync(message.headers)
         }
+        const headersEffect: Effect.Effect<void> = entry.onResponseHeaders
+          ? Effect.provideContext(entry.onResponseHeaders(message.headers), entry.parentContext) as any
+          : Effect.void
         if (entry._tag === "Effect") {
-          entry.resume(message.exit)
-          return Effect.void
+          const resume = entry.resume
+          return Effect.matchCauseEffect(headersEffect, {
+            onFailure: (cause) =>
+              Effect.sync(() => {
+                resume(Exit.failCause(
+                  message.exit._tag === "Failure" ? Cause.combine(message.exit.cause, cause) : cause
+                ))
+              }),
+            onSuccess: () =>
+              Effect.sync(() => {
+                resume(message.exit)
+              })
+          })
         }
-        return message.exit._tag === "Success"
-          ? Queue.end(entry.queue)
-          : Queue.failCause(entry.queue, message.exit.cause)
+        const queue = entry.queue
+        return Effect.matchCauseEffect(headersEffect, {
+          onFailure: (cause) => Queue.failCause(queue, cause),
+          onSuccess: () =>
+            message.exit._tag === "Success"
+              ? Queue.end(queue)
+              : Queue.failCause(queue, message.exit.cause)
+        })
       }
       case "Defect": {
         return clearEntries(Exit.die(message.defect))
@@ -809,6 +875,47 @@ export const withHeaders: {
   <A, E, R>(effect: Effect.Effect<A, E, R>, headers: Headers.Input): Effect.Effect<A, E, R> =>
     Effect.updateService(effect, CurrentHeaders, Headers.merge(Headers.fromInput(headers)))
 )
+
+/**
+ * Internal mutable cell used by {@link withResponseHeaders} to receive the
+ * response headers of the wrapped client call.
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const ResponseHeadersRef: Context.Reference<{ value: Headers.Headers } | undefined> = Context.Reference<
+  { value: Headers.Headers } | undefined
+>(
+  "effect/rpc/RpcClient/ResponseHeadersRef",
+  { defaultValue: () => undefined }
+)
+
+/**
+ * Wrap a single client call and return a tuple of `[result, headers]` where
+ * `headers` is the response headers sent by the server.
+ *
+ * The wrapped effect must produce a single response (i.e. a non-stream rpc).
+ * For streams, use the `onResponseHeaders` / `onResponseHeadersSync` options
+ * on the call directly.
+ *
+ * @example
+ * ```ts skip-type-checking
+ * const [user, headers] = yield* RpcClient.withResponseHeaders(client.GetUser({ id: 1 }))
+ * ```
+ *
+ * @since 4.0.0
+ * @category headers
+ */
+export const withResponseHeaders = <A, E, R>(
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<readonly [A, Headers.Headers], E, R> =>
+  Effect.suspend(() => {
+    const ref: { value: Headers.Headers } = { value: Headers.empty }
+    return Effect.map(
+      Effect.provideService(effect, ResponseHeadersRef, ref),
+      (a) => [a, ref.value] as const
+    )
+  })
 
 /**
  * @since 4.0.0

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -175,6 +175,7 @@ export interface ResponseChunkEncoded {
   readonly _tag: "Chunk"
   readonly requestId: string
   readonly values: NonEmptyReadonlyArray<unknown>
+  readonly headers: ReadonlyArray<[string, string]>
 }
 
 /**
@@ -186,6 +187,7 @@ export interface ResponseChunk<A extends Rpc.Any> {
   readonly clientId: number
   readonly requestId: RequestId
   readonly values: NonEmptyReadonlyArray<Rpc.SuccessChunk<A>>
+  readonly headers: Headers
 }
 
 /**
@@ -219,6 +221,7 @@ export interface ResponseExitEncoded {
   readonly _tag: "Exit"
   readonly requestId: string
   readonly exit: ExitEncoded<unknown, unknown>
+  readonly headers: ReadonlyArray<[string, string]>
 }
 
 /**
@@ -239,6 +242,7 @@ export interface ResponseExit<A extends Rpc.Any> {
   readonly clientId: number
   readonly requestId: RequestId
   readonly exit: Rpc.Exit<A>
+  readonly headers: Headers
 }
 
 /**
@@ -268,7 +272,8 @@ export const ResponseExitDieEncoded = (options: {
       _tag: "Die",
       defect: encodeDefect(options.defect)
     }]
-  }
+  },
+  headers: []
 })
 
 /**

--- a/packages/effect/src/unstable/rpc/RpcMiddleware.ts
+++ b/packages/effect/src/unstable/rpc/RpcMiddleware.ts
@@ -36,6 +36,7 @@ export interface RpcMiddleware<Provides, E, Requires> {
       readonly rpc: Rpc.AnyWithProps
       readonly payload: unknown
       readonly headers: Headers
+      readonly responseHeaders: Rpc.ResponseHeaders
     }
   ): Effect.Effect<SuccessValue, unhandled | E, Requires | Scope>
 }
@@ -82,6 +83,7 @@ export interface Any {
       readonly rpc: Rpc.AnyWithProps
       readonly payload: unknown
       readonly headers: Headers
+      readonly responseHeaders: Rpc.ResponseHeaders
     }
   ): Effect.Effect<SuccessValue, any, any>
 }

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -215,7 +215,8 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
     return {
       _tag: "Chunk",
       requestId: String(decoded.id),
-      values: decoded.result as any
+      values: decoded.result as any,
+      headers: decoded.headers ?? []
     }
   }
   return {
@@ -234,7 +235,8 @@ function decodeJsonRpcMessage(decoded: JsonRpcMessage): RpcMessage.FromClientEnc
       {
         _tag: "Success",
         value: decoded.result
-      }
+      },
+    headers: decoded.headers ?? []
   }
 }
 
@@ -329,14 +331,16 @@ function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessag
         jsonrpc: "2.0",
         chunk: true,
         id: Number(response.requestId),
-        result: response.values
+        result: response.values,
+        headers: response.headers
       }
     case "Exit": {
       if (response.exit._tag === "Success") {
         return {
           jsonrpc: "2.0",
           id: response.requestId !== "" ? Number(response.requestId) : undefined,
-          result: response.exit.value
+          result: response.exit.value,
+          headers: response.headers
         } as any
       }
       const error = response.exit.cause.find((failure) => failure._tag === "Fail")
@@ -352,7 +356,8 @@ function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessag
               : JSON.stringify(response.exit.cause),
             data: response.exit.cause
           } :
-          undefined
+          undefined,
+        headers: response.headers
       } as any
     }
     case "Defect":
@@ -389,6 +394,7 @@ interface JsonRpcResponse {
   readonly id?: number | string | null
   readonly result?: unknown
   readonly chunk?: boolean
+  readonly headers?: ReadonlyArray<[string, string]>
   readonly error?: {
     readonly code: number
     readonly message: string

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -184,7 +184,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
               _tag: "Exit",
               clientId,
               requestId: message.requestId,
-              exit: Exit.interrupt()
+              exit: Exit.interrupt(),
+              headers: Headers.empty
             })
           }
           case "Eof": {
@@ -228,7 +229,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
           _tag: "Exit",
           clientId: client.id,
           requestId: request.id,
-          exit: Exit.die(`Unknown request tag: ${request.tag}`)
+          exit: Exit.die(`Unknown request tag: ${request.tag}`),
+          headers: Headers.empty
         }),
         (defect) => sendDefect(client, defect)
       )
@@ -236,12 +238,14 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
       return Effect.ensuring(write, endClient(client))
     }
     const isStream = RpcSchema.isStreamSchema(rpc.successSchema)
+    const responseHeaders = new Rpc.ResponseHeaders()
     const metadata = {
       rpc,
       client: client.serverClient,
       requestId: request.id,
       headers: request.headers,
-      payload: request.payload
+      payload: request.payload,
+      responseHeaders
     }
     const result = entry.handler(request.payload, metadata)
 
@@ -252,7 +256,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
     // unwrap the fork data type
     const streamOrEffect = isWrapper ? result.value : result
     const handler = isStream
-      ? (streamEffect(client, request, streamOrEffect) as Effect.Effect<{} | Deferred.Deferred<any, any>>)
+      ? (streamEffect(client, request, responseHeaders, streamOrEffect) as Effect.Effect<
+        {} | Deferred.Deferred<any, any>
+      >)
       : (streamOrEffect as Effect.Effect<{} | Deferred.Deferred<any, any>>)
 
     const withMiddleware = rpc.middlewares.size > 0
@@ -273,7 +279,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
             _tag: "Exit",
             clientId: client.id,
             requestId: request.id,
-            exit: exit as any
+            exit: exit as any,
+            headers: responseHeaders.current
           })
         }
       } else if (
@@ -287,7 +294,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
           _tag: "Exit",
           clientId: client.id,
           requestId: request.id,
-          exit: exit as any
+          exit: exit as any,
+          headers: responseHeaders.current
         })
       }
       const close = Scope.closeUnsafe(scope, exit)
@@ -326,6 +334,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
     const context = new Map(entry.context.mapUnsafe)
     requestFiber.context.mapUnsafe.forEach((value, key) => context.set(key, value))
     context.set(Scope.Scope.key, scope)
+    context.set(Rpc.CurrentResponseHeaders.key, responseHeaders)
     const runFork = Effect.runForkWith(Context.makeUnsafe(context))
     const fiber = trackFiber(
       runFork(
@@ -341,7 +350,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
             _tag: "Exit",
             clientId: client.id,
             requestId: request.id,
-            exit: exit as any
+            exit: exit as any,
+            headers: responseHeaders.current
           }))))
         client.fibers.set(request.id, fiber)
         deferred = undefined
@@ -355,7 +365,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
               _tag: "Exit",
               clientId: client.id,
               requestId: request.id,
-              exit: Exit.interrupt()
+              exit: Exit.interrupt(),
+              headers: responseHeaders.current
             })
           )
         )
@@ -372,6 +383,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
   const streamEffect = (
     client: Client,
     request: Request<Rpcs>,
+    responseHeaders: Rpc.ResponseHeaders,
     stream:
       | Stream.Stream<any, any>
       | Effect.Effect<Queue.Dequeue<any, any>, any, Scope.Scope>
@@ -392,7 +404,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
                   _tag: "Chunk",
                   clientId: client.id,
                   requestId: request.id,
-                  values
+                  values,
+                  headers: responseHeaders.current
                 })
                 if (!latch) return write
                 latch.closeUnsafe()
@@ -411,7 +424,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
         _tag: "Chunk",
         clientId: client.id,
         requestId: request.id,
-        values
+        values,
+        headers: responseHeaders.current
       })
       if (!latch) return write
       latch.closeUnsafe()
@@ -446,6 +460,7 @@ const applyMiddleware = <A, E, R>(
     readonly requestId: RequestId
     readonly headers: Headers.Headers
     readonly payload: unknown
+    readonly responseHeaders: Rpc.ResponseHeaders
   }
 ) => {
   for (const service of options.rpc.middlewares) {
@@ -511,26 +526,28 @@ export const make: <Rpcs extends Rpc.Any>(
         case "Chunk": {
           const schemas = client.schemas.get(response.requestId)
           if (!schemas) return Effect.void
+          const encodedHeaders = Object.entries(response.headers)
           return handleEncode(
             client,
             response.requestId,
             schemas.encodeDefect,
             schemas.collector,
             Effect.provideContext(schemas.encodeChunk(response.values), schemas.context),
-            (values) => ({ _tag: "Chunk", requestId: String(response.requestId), values })
+            (values) => ({ _tag: "Chunk", requestId: String(response.requestId), values, headers: encodedHeaders })
           )
         }
         case "Exit": {
           const schemas = client.schemas.get(response.requestId)
           if (!schemas) return Effect.void
           client.schemas.delete(response.requestId)
+          const encodedHeaders = Object.entries(response.headers)
           return handleEncode(
             client,
             response.requestId,
             schemas.encodeDefect,
             schemas.collector,
             Effect.provideContext(schemas.encodeExit(response.exit), schemas.context),
-            (exit) => ({ _tag: "Exit", requestId: String(response.requestId), exit })
+            (exit) => ({ _tag: "Exit", requestId: String(response.requestId), exit, headers: encodedHeaders })
           )
         }
         case "Defect": {
@@ -634,7 +651,8 @@ export const make: <Rpcs extends Rpc.Any>(
               _tag: "Die",
               defect: encodedDefect
             }]
-          }
+          },
+          headers: []
         })),
       (cause) => sendDefect(client, Cause.squash(cause))
     )

--- a/packages/effect/test/rpc/RpcResponseHeaders.test.ts
+++ b/packages/effect/test/rpc/RpcResponseHeaders.test.ts
@@ -1,0 +1,100 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option, Schema, Stream } from "effect"
+import { Headers } from "effect/unstable/http"
+import { Rpc, RpcGroup, RpcSerialization, RpcTest } from "effect/unstable/rpc"
+
+const TestGroup = RpcGroup.make(
+  Rpc.make("Echo", { payload: { value: Schema.String }, success: Schema.String }),
+  Rpc.make("Counter", {
+    payload: { count: Schema.Number },
+    success: Schema.Number,
+    stream: true
+  })
+)
+
+const TestHandlers = TestGroup.toLayer({
+  Echo: (req) =>
+    Effect.gen(function*() {
+      yield* Rpc.setResponseHeader("x-echo", req.value)
+      yield* Rpc.setAllResponseHeaders({ "x-extra": "1" })
+      return req.value
+    }),
+  Counter: (req) =>
+    Stream.range(1, req.count).pipe(
+      Stream.tap(() => Rpc.setResponseHeader("x-stream", "on"))
+    )
+})
+
+const headerValue = (headers: Headers.Headers, key: string): string | undefined =>
+  Option.getOrUndefined(Headers.get(headers, key))
+
+describe("Rpc response headers", () => {
+  it.effect("server handler sets response headers, client receives them on Exit", () =>
+    Effect.gen(function*() {
+      const client = yield* RpcTest.makeClient(TestGroup)
+      let captured: Headers.Headers | undefined
+      const result = yield* client.Echo(
+        { value: "hi" },
+        { onResponseHeaders: (h) => (captured = h) }
+      )
+      assert.strictEqual(result, "hi")
+      assert.ok(captured, "headers callback fired")
+      assert.strictEqual(headerValue(captured!, "x-echo"), "hi")
+      assert.strictEqual(headerValue(captured!, "x-extra"), "1")
+    }).pipe(Effect.provide(TestHandlers)))
+
+  it.effect("response headers fire on stream Chunk and Exit", () =>
+    Effect.gen(function*() {
+      const client = yield* RpcTest.makeClient(TestGroup)
+      const captures: Array<Headers.Headers> = []
+      const stream = client.Counter(
+        { count: 3 },
+        { onResponseHeaders: (h) => captures.push(h) }
+      )
+      const values = yield* Stream.runCollect(stream)
+      assert.deepStrictEqual([...values], [1, 2, 3])
+      assert.ok(captures.length > 0, "callback fired at least once")
+      const last = captures[captures.length - 1]
+      assert.strictEqual(headerValue(last, "x-stream"), "on")
+    }).pipe(Effect.provide(TestHandlers)))
+
+  it("jsonRpc serialization round-trips response headers on Exit", () => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    parser.decode("{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"foo\"}")
+    const encoded = parser.encode({
+      _tag: "Exit",
+      requestId: "7",
+      exit: { _tag: "Success", value: 42 },
+      headers: [["x-foo", "bar"]]
+    })
+    assert.ok(typeof encoded === "string")
+    const message = JSON.parse(encoded as string)
+    assert.deepStrictEqual(message, {
+      jsonrpc: "2.0",
+      id: 7,
+      result: 42,
+      headers: [["x-foo", "bar"]]
+    })
+
+    const decoded = parser.decode(encoded as string)
+    assert.deepStrictEqual(decoded, [{
+      _tag: "Exit",
+      requestId: "7",
+      exit: { _tag: "Success", value: 42 },
+      headers: [["x-foo", "bar"]]
+    }])
+  })
+
+  it("jsonRpc Exit without headers encodes empty array", () => {
+    const parser = RpcSerialization.jsonRpc().makeUnsafe()
+    parser.decode("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"foo\"}")
+    const encoded = parser.encode({
+      _tag: "Exit",
+      requestId: "1",
+      exit: { _tag: "Success", value: "ok" },
+      headers: []
+    })
+    const message = JSON.parse(encoded as string)
+    assert.deepStrictEqual(message.headers, [])
+  })
+})

--- a/packages/effect/test/rpc/RpcResponseHeaders.test.ts
+++ b/packages/effect/test/rpc/RpcResponseHeaders.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Option, Schema, Stream } from "effect"
+import { Context, Effect, Layer, Option, Schema, Stream } from "effect"
 import { Headers } from "effect/unstable/http"
-import { Rpc, RpcGroup, RpcSerialization, RpcTest } from "effect/unstable/rpc"
+import { Rpc, RpcClient, RpcGroup, RpcSerialization, RpcTest } from "effect/unstable/rpc"
 
 const TestGroup = RpcGroup.make(
   Rpc.make("Echo", { payload: { value: Schema.String }, success: Schema.String }),
@@ -35,7 +35,11 @@ describe("Rpc response headers", () => {
       let captured: Headers.Headers | undefined
       const result = yield* client.Echo(
         { value: "hi" },
-        { onResponseHeaders: (h) => (captured = h) }
+        {
+          onResponseHeadersSync: (h) => {
+            captured = h
+          }
+        }
       )
       assert.strictEqual(result, "hi")
       assert.ok(captured, "headers callback fired")
@@ -49,13 +53,51 @@ describe("Rpc response headers", () => {
       const captures: Array<Headers.Headers> = []
       const stream = client.Counter(
         { count: 3 },
-        { onResponseHeaders: (h) => captures.push(h) }
+        {
+          onResponseHeadersSync: (h) => {
+            captures.push(h)
+          }
+        }
       )
       const values = yield* Stream.runCollect(stream)
       assert.deepStrictEqual([...values], [1, 2, 3])
       assert.ok(captures.length > 0, "callback fired at least once")
       const last = captures[captures.length - 1]
       assert.strictEqual(headerValue(last, "x-stream"), "on")
+    }).pipe(Effect.provide(TestHandlers)))
+
+  it.effect("onResponseHeaders effect runs in client's context, propagates errors", () =>
+    Effect.gen(function*() {
+      class Sink extends Context.Service<Sink, { record: (h: Headers.Headers) => Effect.Effect<void> }>()(
+        "test/Sink"
+      ) {}
+      const recorded: Array<Headers.Headers> = []
+      const SinkLayer = Layer.succeed(Sink)({
+        record: (h) =>
+          Effect.sync(() => {
+            recorded.push(h)
+          })
+      })
+
+      const client = yield* RpcTest.makeClient(TestGroup)
+      const result = yield* client.Echo(
+        { value: "yo" },
+        {
+          onResponseHeaders: (h) => Effect.flatMap(Sink.asEffect(), (s) => s.record(h))
+        }
+      ).pipe(Effect.provide(SinkLayer))
+      assert.strictEqual(result, "yo")
+      assert.strictEqual(recorded.length, 1)
+      assert.strictEqual(headerValue(recorded[0], "x-echo"), "yo")
+    }).pipe(Effect.provide(TestHandlers)))
+
+  it.effect("withResponseHeaders returns [result, headers]", () =>
+    Effect.gen(function*() {
+      const client = yield* RpcTest.makeClient(TestGroup)
+      const [result, headers] = yield* RpcClient.withResponseHeaders(client.Echo({ value: "ok" }))
+      assert.strictEqual(result, "ok")
+      assert.strictEqual(headerValue(headers, "x-echo"), "ok")
+      assert.strictEqual(headerValue(headers, "x-extra"), "1")
     }).pipe(Effect.provide(TestHandlers)))
 
   it("jsonRpc serialization round-trips response headers on Exit", () => {


### PR DESCRIPTION
Implement server-to-client response headers in the RPC framework, allowing handlers to attach headers to responses. Introduce new helper methods for clients to access these headers, enhancing the communication between server and client. Update relevant interfaces and message structures to accommodate the new headers. Documentation reflects these changes for clarity.

