### PR TITLE
[codex] add rpc heartbeat connection hooks

### DIFF
--- a/.changeset/add-rpc-heartbeat-hooks.md
+++ b/.changeset/add-rpc-heartbeat-hooks.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add optional heartbeat hooks to RPC client socket connection hooks and request lifecycle hooks to RPC clients.

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -247,8 +247,10 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     readonly queue: Queue.Queue<any, any>
     readonly scope: Scope.Scope
     readonly context: Context.Context<never>
+    chunkCount: number
   }
   const entries = new Map<RequestId, ClientEntry>()
+  const hooks = yield* Effect.serviceOption(RequestHooks)
 
   let isShutdown = false
   yield* Scope.addFinalizer(
@@ -331,6 +333,9 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         return Effect.interrupt
       }
       const id = generateRequestId()
+      const onStart = Option.isSome(hooks) && hooks.value.onRequestStart
+        ? hooks.value.onRequestStart({ id, tag: rpc._tag, stream: false })
+        : Effect.void
       const send = middleware(
         (message) =>
           options.onFromClient({
@@ -354,7 +359,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         }
       )
       if (discard) {
-        return send
+        return onStart.pipe(Effect.andThen(send))
       }
       let fiber: Fiber.Fiber<any, any>
       return Effect.onInterrupt(
@@ -373,7 +378,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
             }
           }
           entries.set(id, entry)
-          fiber = send.pipe(
+          fiber = onStart.pipe(
+            Effect.andThen(send),
             span ? Effect.withParentSpan(span, { captureStackTrace: false }) : identity,
             Effect.runForkWith(parentFiber.context)
           )
@@ -384,10 +390,11 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
           })
         }),
         (interruptors) => {
+          const entry = entries.get(id)
           entries.delete(id)
           return Effect.andThen(
             Fiber.interrupt(fiber),
-            sendInterrupt(id, Array.from(interruptors), context)
+            sendInterrupt(id, Array.from(interruptors), context, entry?.rpc._tag)
           )
         }
       )
@@ -413,19 +420,24 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
     })
     const fiber = Fiber.getCurrent()!
     const id = generateRequestId()
+    const onStart = Option.isSome(hooks) && hooks.value.onRequestStart
+      ? hooks.value.onRequestStart({ id, tag: rpc._tag, stream: true })
+      : Effect.void
 
     const scope = Context.getUnsafe(fiber.context, Scope.Scope)
     yield* Scope.addFinalizerExit(
       scope,
       (exit) => {
-        if (!entries.has(id)) return Effect.void
+        const entry = entries.get(id)
+        if (!entry) return Effect.void
         entries.delete(id)
         return sendInterrupt(
           id,
           Exit.isFailure(exit) ?
             Array.from(Cause.interruptors(exit.cause))
             : [],
-          context
+          context,
+          entry.rpc._tag
         )
       }
     )
@@ -436,10 +448,11 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
       rpc,
       queue,
       scope,
-      context
+      context,
+      chunkCount: 0
     })
 
-    yield* middleware(
+    yield* onStart.pipe(Effect.andThen(middleware(
       (message) =>
         options.onFromClient({
           message,
@@ -460,7 +473,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
           {}),
         headers: Headers.merge(fiber.getRef(CurrentHeaders), headers)
       }
-    ).pipe(
+    ))).pipe(
       span ? Effect.withParentSpan(span, { captureStackTrace: false }) : identity,
       Effect.catchCause((error) => Queue.failCause(queue, error)),
       Effect.interruptible,
@@ -508,22 +521,25 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
   const sendInterrupt = (
     requestId: RequestId,
     interruptors: ReadonlyArray<number>,
-    context: Context.Context<never>
+    context: Context.Context<never>,
+    tag?: string | undefined
   ): Effect.Effect<void> =>
-    Effect.callback<void>((resume) => {
-      const parentFiber = Fiber.getCurrent()!
-      const fiber = options.onFromClient({
-        message: { _tag: "Interrupt", requestId, interruptors },
-        context,
-        discard: false
-      }).pipe(
-        Effect.timeout(1000),
-        Effect.runForkWith(parentFiber.context)
-      )
-      fiber.addObserver(() => {
-        resume(Effect.void)
-      })
-    })
+    (Option.isSome(hooks) && hooks.value.onRequestInterrupt
+      ? hooks.value.onRequestInterrupt({ id: requestId, tag })
+      : Effect.void).pipe(Effect.andThen(Effect.callback<void>((resume) => {
+        const parentFiber = Fiber.getCurrent()!
+        const fiber = options.onFromClient({
+          message: { _tag: "Interrupt", requestId, interruptors },
+          context,
+          discard: false
+        }).pipe(
+          Effect.timeout(1000),
+          Effect.runForkWith(parentFiber.context)
+        )
+        fiber.addObserver(() => {
+          resume(Effect.void)
+        })
+      })))
 
   const write = (message: FromServer<Rpcs>): Effect.Effect<void> => {
     switch (message._tag) {
@@ -531,7 +547,12 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const requestId = message.requestId
         const entry = entries.get(requestId)
         if (!entry || entry._tag !== "Queue") return Effect.void
+        entry.chunkCount++
+        const onChunk = Option.isSome(hooks) && hooks.value.onRequestChunk
+          ? hooks.value.onRequestChunk({ id: requestId, tag: entry.rpc._tag, chunkCount: entry.chunkCount })
+          : Effect.void
         return Queue.offerAll(entry.queue, message.values).pipe(
+          Effect.andThen(onChunk),
           supportsAck
             ? Effect.flatMap(() =>
               options.onFromClient({
@@ -549,13 +570,26 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any, E, const Flatten extend
         const entry = entries.get(requestId)
         if (!entry) return Effect.void
         entries.delete(requestId)
+        const onExit = Option.isSome(hooks) && hooks.value.onRequestExit
+          ? hooks.value.onRequestExit({
+            id: requestId,
+            tag: entry.rpc._tag,
+            stream: entry._tag === "Queue",
+            exit: message.exit
+          })
+          : Effect.void
         if (entry._tag === "Effect") {
-          entry.resume(message.exit)
-          return Effect.void
+          return onExit.pipe(Effect.andThen(Effect.sync(() => {
+            entry.resume(message.exit)
+          })))
         }
-        return message.exit._tag === "Success"
-          ? Queue.end(entry.queue)
-          : Queue.failCause(entry.queue, message.exit.cause)
+        return onExit.pipe(
+          Effect.andThen(
+            message.exit._tag === "Success"
+              ? Queue.end(entry.queue)
+              : Queue.failCause(entry.queue, message.exit.cause)
+          )
+        )
       }
       case "Defect": {
         return clearEntries(Exit.die(message.defect))
@@ -938,7 +972,10 @@ export const makeProtocolSocket = (options?: {
 
     let parser = serialization.makeUnsafe()
 
-    const pinger = yield* makePinger(write(parser.encode(constPing)!))
+    const pinger = yield* makePinger(
+      write(parser.encode(constPing)!),
+      Option.isSome(hooks) ? hooks.value : undefined
+    )
     let currentError: RpcClientError | undefined
     const onOpen = Effect.suspend(() => {
       currentError = undefined
@@ -961,8 +998,7 @@ export const makeProtocolSocket = (options?: {
             body: () => {
               const response = responses[i++]
               if (response._tag === "Pong") {
-                pinger.onPong()
-                return Effect.void
+                return pinger.onPong
               }
               if ("requestId" in response) {
                 const clientId = requestClientMap.get(response.requestId)
@@ -992,13 +1028,16 @@ export const makeProtocolSocket = (options?: {
         Effect.raceFirst(Effect.flatMap(
           pinger.timeout,
           () =>
-            Effect.fail(
-              new Socket.SocketError({
-                reason: new Socket.SocketOpenError({
-                  kind: "Timeout",
-                  cause: new Error("ping timeout")
+            Effect.andThen(
+              Option.isSome(hooks) && hooks.value.onPingTimeout ? hooks.value.onPingTimeout : Effect.void,
+              Effect.fail(
+                new Socket.SocketError({
+                  reason: new Socket.SocketOpenError({
+                    kind: "Timeout",
+                    cause: new Error("ping timeout")
+                  })
                 })
-              })
+              )
             )
         ))
       )
@@ -1056,20 +1095,23 @@ const defaultRetryPolicy = Schedule.exponential(500, 1.5).pipe(
   Schedule.either(Schedule.spaced(5000))
 )
 
-const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect<A, E, R>) {
+const makePinger = Effect.fnUntraced(function*<A, E, R>(
+  writePing: Effect.Effect<A, E, R>,
+  hooks: ConnectionHooks["Service"] | undefined
+) {
   let recievedPong = true
   const latch = Latch.makeUnsafe()
   const reset = () => {
     recievedPong = true
     latch.closeUnsafe()
   }
-  const onPong = () => {
+  const onPong = Effect.sync(() => {
     recievedPong = true
-  }
+  }).pipe(Effect.andThen(hooks?.onPong ?? Effect.void))
   yield* Effect.suspend((): Effect.Effect<void, E, R> => {
     if (!recievedPong) return latch.open
     recievedPong = false
-    return writePing
+    return (hooks?.onPing ?? Effect.void).pipe(Effect.andThen(writePing))
   }).pipe(
     Effect.delay("5 seconds"),
     Effect.ignore,
@@ -1279,11 +1321,49 @@ export const layerProtocolWorker: (
 
 /**
  * @since 4.0.0
+ * @category RequestHooks
+ */
+export class RequestHooks extends Context.Service<RequestHooks, {
+  readonly onRequestStart?:
+    | ((info: {
+      readonly id: RequestId
+      readonly tag: string
+      readonly stream: boolean
+    }) => Effect.Effect<void>)
+    | undefined
+  readonly onRequestChunk?:
+    | ((info: {
+      readonly id: RequestId
+      readonly tag: string
+      readonly chunkCount: number
+    }) => Effect.Effect<void>)
+    | undefined
+  readonly onRequestExit?:
+    | ((info: {
+      readonly id: RequestId
+      readonly tag: string
+      readonly stream: boolean
+      readonly exit: Exit.Exit<unknown, unknown>
+    }) => Effect.Effect<void>)
+    | undefined
+  readonly onRequestInterrupt?:
+    | ((info: {
+      readonly id: RequestId
+      readonly tag?: string | undefined
+    }) => Effect.Effect<void>)
+    | undefined
+}>()("effect/rpc/RpcClient/RequestHooks") {}
+
+/**
+ * @since 4.0.0
  * @category ConnectionHooks
  */
 export class ConnectionHooks extends Context.Service<ConnectionHooks, {
   readonly onConnect: Effect.Effect<void>
   readonly onDisconnect: Effect.Effect<void>
+  readonly onPing?: Effect.Effect<void> | undefined
+  readonly onPong?: Effect.Effect<void> | undefined
+  readonly onPingTimeout?: Effect.Effect<void> | undefined
 }>()("effect/rpc/RpcClient/ConnectionHooks") {}
 
 // internal

--- a/packages/effect/test/rpc/RpcClient.test.ts
+++ b/packages/effect/test/rpc/RpcClient.test.ts
@@ -1,12 +1,24 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Cause, Effect, Layer, Schema } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Queue, Schedule, Schema } from "effect"
+import { TestClock } from "effect/testing"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse"
 import { Rpc, RpcClient, RpcGroup, RpcSerialization } from "effect/unstable/rpc"
 import { RpcClientError } from "effect/unstable/rpc/RpcClientError"
+import { type FromClient, RequestId } from "effect/unstable/rpc/RpcMessage"
+import { Socket } from "effect/unstable/socket"
 
 const TestGroup = RpcGroup.make(
   Rpc.make("Ping", { success: Schema.String })
+)
+
+const LifecycleGroup = RpcGroup.make(
+  Rpc.make("Get", { success: Schema.String }),
+  Rpc.make("Subscribe", {
+    success: Schema.Number,
+    error: Schema.String,
+    stream: true
+  })
 )
 
 const makeHttpClient = (body: string): HttpClient.HttpClient =>
@@ -49,10 +61,227 @@ const assertEmptyResponseFailsRequest = (
     assert.strictEqual(error.reason.message, "Received empty HTTP response from RPC server")
   })
 
+const makeSocket = (
+  written: Array<string>,
+  setHandler?: (handler: (message: string) => Effect.Effect<void>) => void
+): Socket.Socket =>
+  Socket.make({
+    runRaw: (handler, options) =>
+      Effect.sync(() => {
+        setHandler?.((message) => (handler(message) as Effect.Effect<void> | void) ?? Effect.void)
+      }).pipe(
+        Effect.andThen(options?.onOpen ?? Effect.void),
+        Effect.andThen(Effect.never)
+      ),
+    writer: Effect.succeed((chunk) =>
+      Effect.sync(() => {
+        written.push(String(chunk))
+      })
+    )
+  })
+
 describe("RpcClient", () => {
   it.effect("fails request on empty HTTP response for unframed serialization", () =>
     assertEmptyResponseFailsRequest(RpcSerialization.layerJson, "[]"))
 
   it.effect("fails request on empty HTTP response for framed serialization", () =>
     assertEmptyResponseFailsRequest(RpcSerialization.layerNdjson, ""))
+
+  it.effect("runs heartbeat hooks for ping and pong messages", () =>
+    Effect.gen(function*() {
+      const connected = yield* Deferred.make<void>()
+      const written: Array<string> = []
+      const events: Array<string> = []
+      let emit = (_message: string): Effect.Effect<void> => Effect.void
+
+      yield* RpcClient.makeProtocolSocket().pipe(
+        Effect.provideService(
+          Socket.Socket,
+          makeSocket(written, (handler) => {
+            emit = handler
+          })
+        ),
+        Effect.provideService(
+          RpcClient.ConnectionHooks,
+          RpcClient.ConnectionHooks.of({
+            onConnect: Deferred.succeed(connected, void 0),
+            onDisconnect: Effect.sync(() => {
+              events.push("disconnect")
+            }),
+            onPing: Effect.sync(() => {
+              events.push("ping")
+            }),
+            onPong: Effect.sync(() => {
+              events.push("pong")
+            })
+          })
+        ),
+        Effect.provide(RpcSerialization.layerJson)
+      )
+
+      yield* Deferred.await(connected)
+      yield* TestClock.adjust("5 seconds")
+      yield* emit(JSON.stringify({ _tag: "Pong" }))
+
+      assert.deepStrictEqual(events, ["ping", "pong"])
+      assert.deepStrictEqual(written.map((message) => JSON.parse(message)), [{ _tag: "Ping" }])
+    }).pipe(Effect.scoped) as Effect.Effect<void>)
+
+  it.effect("runs heartbeat hook before failing on ping timeout", () =>
+    Effect.gen(function*() {
+      const connected = yield* Deferred.make<void>()
+      const written: Array<string> = []
+      const events: Array<string> = []
+
+      yield* RpcClient.makeProtocolSocket({ retryPolicy: Schedule.recurs(0) }).pipe(
+        Effect.provideService(Socket.Socket, makeSocket(written)),
+        Effect.provideService(
+          RpcClient.ConnectionHooks,
+          RpcClient.ConnectionHooks.of({
+            onConnect: Deferred.succeed(connected, void 0),
+            onDisconnect: Effect.sync(() => {
+              events.push("disconnect")
+            }),
+            onPingTimeout: Effect.sync(() => {
+              events.push("timeout")
+            })
+          })
+        ),
+        Effect.provide(RpcSerialization.layerJson)
+      )
+
+      yield* Deferred.await(connected)
+      yield* TestClock.adjust("10 seconds")
+
+      assert.deepStrictEqual(events, ["timeout", "disconnect"])
+      assert.deepStrictEqual(written.map((message) => JSON.parse(message)), [{ _tag: "Ping" }])
+    }).pipe(Effect.scoped) as Effect.Effect<void>)
+
+  it.effect("runs request lifecycle hooks for effect requests", () =>
+    Effect.gen(function*() {
+      const sent: Array<FromClient<any>> = []
+      const events: Array<string> = []
+      const requestSent = yield* Deferred.make<void>()
+      const { client, write } = yield* RpcClient.makeNoSerialization(LifecycleGroup, {
+        disableTracing: true,
+        generateRequestId: () => RequestId(1n),
+        onFromClient: ({ message }) =>
+          Effect.sync(() => {
+            sent.push(message)
+          }).pipe(
+            Effect.andThen(message._tag === "Request" ? Deferred.succeed(requestSent, void 0) : Effect.void)
+          )
+      }).pipe(
+        Effect.provideService(
+          RpcClient.RequestHooks,
+          RpcClient.RequestHooks.of({
+            onRequestStart: (info) =>
+              Effect.sync(() => {
+                events.push(`start:${info.id}:${info.tag}:${info.stream}`)
+              }),
+            onRequestExit: (info) =>
+              Effect.sync(() => {
+                events.push(`exit:${info.id}:${info.tag}:${info.stream}:${info.exit._tag}`)
+              })
+          })
+        )
+      )
+
+      const fiber = yield* Effect.forkScoped((client as any).Get())
+      yield* Deferred.await(requestSent)
+      yield* write({ _tag: "Exit", clientId: 0, requestId: RequestId(1n), exit: Exit.succeed("ok") })
+      const result = yield* Fiber.join(fiber)
+
+      assert.strictEqual(result, "ok")
+      assert.deepStrictEqual(events, ["start:1:Get:false", "exit:1:Get:false:Success"])
+      assert.deepStrictEqual(sent.map((message) => message._tag), ["Request"])
+    }).pipe(Effect.scoped) as Effect.Effect<void>)
+
+  it.effect("runs request lifecycle hooks for stream chunks and exits", () =>
+    Effect.gen(function*() {
+      const sent: Array<FromClient<any>> = []
+      const events: Array<string> = []
+      let nextRequestId = 1n
+      const { client, write } = yield* RpcClient.makeNoSerialization(LifecycleGroup, {
+        disableTracing: true,
+        generateRequestId: () => RequestId(nextRequestId++),
+        onFromClient: ({ message }) =>
+          Effect.sync(() => {
+            sent.push(message)
+          })
+      }).pipe(
+        Effect.provideService(
+          RpcClient.RequestHooks,
+          RpcClient.RequestHooks.of({
+            onRequestStart: (info) =>
+              Effect.sync(() => {
+                events.push(`start:${info.id}:${info.tag}:${info.stream}`)
+              }),
+            onRequestChunk: (info) =>
+              Effect.sync(() => {
+                events.push(`chunk:${info.id}:${info.tag}:${info.chunkCount}`)
+              }),
+            onRequestExit: (info) =>
+              Effect.sync(() => {
+                events.push(`exit:${info.id}:${info.tag}:${info.stream}:${info.exit._tag}`)
+              })
+          })
+        )
+      )
+
+      const queue = yield* (client as any).Subscribe(undefined, { asQueue: true })
+      yield* write({ _tag: "Chunk", clientId: 0, requestId: RequestId(1n), values: [1] as any })
+      const value = yield* Queue.take(queue)
+      yield* write({ _tag: "Exit", clientId: 0, requestId: RequestId(1n), exit: Exit.succeed(void 0) })
+
+      assert.strictEqual(value, 1)
+      assert.strictEqual(
+        events.join("|"),
+        [
+          "start:1:Subscribe:true",
+          "chunk:1:Subscribe:1",
+          "exit:1:Subscribe:true:Success"
+        ].join("|")
+      )
+      assert.deepStrictEqual(sent.map((message) => message._tag), ["Request", "Ack"])
+    }).pipe(Effect.scoped) as Effect.Effect<void>)
+
+  it.effect("runs request lifecycle hook for interrupts", () =>
+    Effect.gen(function*() {
+      const sent: Array<FromClient<any>> = []
+      const events: Array<string> = []
+      const requestSent = yield* Deferred.make<void>()
+      const { client } = yield* RpcClient.makeNoSerialization(LifecycleGroup, {
+        disableTracing: true,
+        generateRequestId: () => RequestId(1n),
+        onFromClient: ({ message }) =>
+          Effect.sync(() => {
+            sent.push(message)
+          }).pipe(
+            Effect.andThen(message._tag === "Request" ? Deferred.succeed(requestSent, void 0) : Effect.void)
+          )
+      }).pipe(
+        Effect.provideService(
+          RpcClient.RequestHooks,
+          RpcClient.RequestHooks.of({
+            onRequestStart: (info) =>
+              Effect.sync(() => {
+                events.push(`start:${info.id}:${info.tag}:${info.stream}`)
+              }),
+            onRequestInterrupt: (info) =>
+              Effect.sync(() => {
+                events.push(`interrupt:${info.id}:${info.tag}`)
+              })
+          })
+        )
+      )
+
+      yield* Effect.scoped(Effect.gen(function*() {
+        yield* (client as any).Subscribe(undefined, { asQueue: true })
+        yield* Deferred.await(requestSent)
+      }))
+
+      assert.deepStrictEqual(events, ["start:1:Subscribe:true", "interrupt:1:Subscribe"])
+      assert.deepStrictEqual(sent.map((message) => message._tag), ["Request", "Interrupt"])
+    }).pipe(Effect.scoped) as Effect.Effect<void>)
 })


### PR DESCRIPTION
## What changed

- Added optional `onPing`, `onPong`, and `onPingTimeout` hooks to `RpcClient.ConnectionHooks`.
- Added `RpcClient.RequestHooks` for client-side request start, stream chunk, exit, and interrupt lifecycle events.
- Wired request hooks through `makeNoSerialization`, where request ids, tags, stream-ness, chunks, exits, and interrupts are available without changing the wire protocol.
- Added deterministic RPC client tests for heartbeat and request lifecycle hooks.
- Added a patch changeset for `effect`.

## Why

This exposes first-party transport heartbeat and RPC request lifecycle observability without requiring applications to duplicate RPC socket heartbeat logic or change the protocol.

The request hooks help applications distinguish a healthy socket from a stale or exited stream subscription. They are observability hooks only; app-level replay or snapshot semantics are still required for no-missed-event correctness.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/rpc/RpcClient.test.ts`
- `pnpm check:tsgo`
