### PR TITLE
Port Effect.firstSuccessOf from effect v3

### DIFF
--- a/.changeset/first-success-of.md
+++ b/.changeset/first-success-of.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Port `Effect.firstSuccessOf` from Effect v3.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -4351,6 +4351,53 @@ export const orElseSucceed: {
   ): Effect<A | A2, never, R>
 } = internal.orElseSucceed
 
+/**
+ * Runs a sequence of effects and returns the result of the first successful
+ * one.
+ *
+ * **Details**
+ *
+ * This function executes the provided effects in sequence, stopping at the
+ * first success. If an effect succeeds, its result is returned immediately and
+ * no further effects in the sequence are executed.
+ *
+ * If all effects fail, the returned effect fails with the error from the last
+ * effect. If the collection is empty, the returned effect defects with an
+ * `Error` whose message is `"Received an empty collection of effects"`.
+ *
+ * **When to Use**
+ *
+ * Use `firstSuccessOf` when you have prioritized fallback strategies, such as
+ * attempting multiple APIs, reading configuration from several sources, or
+ * trying alternative resource locations in order.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect"
+ *
+ * const primary = Effect.fail("primary unavailable")
+ * const secondary = Effect.succeed("secondary result")
+ * const tertiary = Effect.sync(() => {
+ *   throw new Error("not evaluated")
+ * })
+ *
+ * const program = Effect.firstSuccessOf([
+ *   primary,
+ *   secondary,
+ *   tertiary
+ * ])
+ *
+ * console.log(Effect.runSync(program))
+ * // Output: "secondary result"
+ * ```
+ *
+ * @since 2.0.0
+ * @category Fallback
+ */
+export const firstSuccessOf: <Eff extends Effect<any, any, any>>(
+  effects: Iterable<Eff>
+) => Effect<Success<Eff>, Error<Eff>, Services<Eff>> = internal.firstSuccessOf
+
 // -----------------------------------------------------------------------------
 // Delays & timeouts
 // -----------------------------------------------------------------------------

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3184,6 +3184,23 @@ export const orElseSucceed: {
 )
 
 /** @internal */
+export const firstSuccessOf = <Eff extends Effect.Effect<any, any, any>>(
+  effects: Iterable<Eff>
+): Effect.Effect<Effect.Success<Eff>, Effect.Error<Eff>, Effect.Services<Eff>> =>
+  suspend(() => {
+    const list = Arr.fromIterable(effects)
+    if (list.length === 0) {
+      return die(new Error("Received an empty collection of effects"))
+    }
+    let effect: Effect.Effect<any, any, any> = list[0]
+    for (let i = 1; i < list.length; i++) {
+      const next = list[i]
+      effect = catch_(effect, () => next)
+    }
+    return effect
+  }) as any
+
+/** @internal */
 export const eventually = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, never, R> =>
   catch_(self, (_) => flatMap(yieldNow, () => eventually(self)))
 

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -3188,17 +3188,18 @@ export const firstSuccessOf = <Eff extends Effect.Effect<any, any, any>>(
   effects: Iterable<Eff>
 ): Effect.Effect<Effect.Success<Eff>, Effect.Error<Eff>, Effect.Services<Eff>> =>
   suspend(() => {
-    const list = Arr.fromIterable(effects)
-    if (list.length === 0) {
+    const iterator = effects[Symbol.iterator]()
+    let state = iterator.next()
+    if (state.done) {
       return die(new Error("Received an empty collection of effects"))
     }
-    let effect: Effect.Effect<any, any, any> = list[0]
-    for (let i = 1; i < list.length; i++) {
-      const next = list[i]
-      effect = catch_(effect, () => next)
+    function loop(current: IteratorYieldResult<Eff>): Eff {
+      const next = iterator.next()
+      if (next.done) return current.value
+      return catch_(current.value, (_) => loop(next)) as any
     }
-    return effect
-  }) as any
+    return loop(state)
+  })
 
 /** @internal */
 export const eventually = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, never, R> =>

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -2168,6 +2168,50 @@ describe("Effect", () => {
       }))
   })
 
+  describe("firstSuccessOf", () => {
+    it.effect("returns the first success and does not run later effects", () =>
+      Effect.gen(function*() {
+        const executed: Array<string> = []
+        const result = yield* Effect.firstSuccessOf([
+          Effect.sync(() => executed.push("first")).pipe(
+            Effect.flatMap(() => Effect.fail("e1" as const))
+          ),
+          Effect.sync(() => executed.push("second")).pipe(
+            Effect.as("success" as const)
+          ),
+          Effect.sync(() => executed.push("third")).pipe(
+            Effect.as("unreachable" as const)
+          )
+        ])
+
+        assert.strictEqual(result, "success")
+        assert.deepStrictEqual(executed, ["first", "second"])
+      }))
+
+    it.effect("fails with the last failure when all effects fail", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.firstSuccessOf([
+          Effect.fail("e1" as const),
+          Effect.fail("e2" as const),
+          Effect.fail("e3" as const)
+        ]).pipe(Effect.flip)
+
+        assert.strictEqual(result, "e3")
+      }))
+
+    it.effect("defects on an empty collection", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.firstSuccessOf([]).pipe(Effect.sandbox, Effect.flip)
+        const reason = result.reasons[0]
+
+        assert.isTrue(Cause.isDieReason(reason))
+        if (Cause.isDieReason(reason)) {
+          assert.instanceOf(reason.defect, Error)
+          assert.strictEqual(reason.defect.message, "Received an empty collection of effects")
+        }
+      }))
+  })
+
   describe("catchCause", () => {
     it.effect("first argument as success", () =>
       Effect.gen(function*() {

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -153,6 +153,17 @@ describe("Effect.catchReason", () => {
   })
 })
 
+describe("Effect.firstSuccessOf", () => {
+  it("infers success, error, and requirements from the effect collection", () => {
+    const result = Effect.firstSuccessOf([
+      string,
+      number
+    ])
+
+    expect(result).type.toBe<Effect.Effect<string | number, "err-1" | "err-2", "dep-1" | "dep-2">>()
+  })
+})
+
 describe("Effect.catchReasons", () => {
   it("handlers receive respective reason types", () => {
     pipe(


### PR DESCRIPTION
## Summary

- Port `Effect.firstSuccessOf` from Effect v3 with sequential fallback semantics
- Add runtime tests for first success, all failures returning the last error, and empty collection defects
- Add a type-level inference test and changeset

## Checks

- `pnpm lint-fix`
- `pnpm test Effect.test.ts`
- `pnpm test-types Effect.tst.ts`
- `cd packages/effect && pnpm docgen`
- `pnpm check:tsgo`
- `git diff --check`