### PR TITLE
feat: add acquireDisposable

### DIFF
--- a/.changeset/sparkly-bears-act.md
+++ b/.changeset/sparkly-bears-act.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 add `Effect.acquireDisposable`

--- a/.changeset/sparkly-bears-act.md
+++ b/.changeset/sparkly-bears-act.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add `Effect.acquireDisposable`

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -6277,6 +6277,47 @@ export const acquireRelease: <A, E, R, R2>(
 ) => Effect<A, E, R | R2 | Scope> = internal.acquireRelease
 
 /**
+ * This function constructs a scoped resource from an Effect that acquires a
+ * disposable value.
+ *
+ * The resource is automatically disposed when the surrounding
+ * {@link Scope} is closed, using {@link Symbol.dispose} for
+ * synchronous disposables or {@link Symbol.asyncDispose} for asynchronous
+ * disposables.
+ *
+ * This is similar to {@link acquireRelease}, but uses the standard
+ * JavaScript disposal protocal instead of requiring an explicit release
+ * function.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using}
+ *
+ * @example
+ * ```ts
+ * import sqlite from "node:sqlite";
+ * import { Effect } from "effect";
+ *
+ * const program = Effect.scoped(
+ *   Effect.gen(function* () {
+ *     // acquire database connection
+ *     // database will be closed when the scope is closed
+ *     const db = yield* Effect.acquireDisposable(
+ *       Effect.sync(() => new sqlite.DatabaseSync(":memory:"))
+ *     )
+ *
+ *     const row = db.prepare("SELECT 1 AS value").get()
+ *     yield* Effect.log(row) // { value: 1 }
+ *   })
+ * )
+ * ```
+ *
+ * @since 4.0.0
+ * @category Resource Management & Finalization
+ */
+export const acquireDisposable: <A extends AsyncDisposable | Disposable, E, R>(
+  acquire: Effect<A, E, R>
+) => Effect<A, E, R | Scope> = internal.acquireDisposable
+
+/**
  * This function is used to ensure that an `Effect` value that represents the
  * acquisition of a resource (for example, opening a file, launching a thread,
  * etc.) will not be interrupted, and that the resource will always be released

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4053,6 +4053,15 @@ export const acquireUseRelease = <Resource, E, R, A, E2, R2, E3, R3>(
       ))
   )
 
+/** @internal */
+export const acquireDisposable = <A extends AsyncDisposable | Disposable, E, R>(
+  acquire: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, R | Scope.Scope> =>
+  acquireRelease(acquire, (resource) =>
+    hasProperty(resource, Symbol.asyncDispose)
+      ? promise(() => resource[Symbol.asyncDispose]())
+      : sync(() => resource[Symbol.dispose]()))
+
 // ----------------------------------------------------------------------------
 // Caching
 // ----------------------------------------------------------------------------

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { assert, describe, it, vi } from "@effect/vitest"
 import { assertExitFailure } from "@effect/vitest/utils"
 import {
   Cause,
@@ -539,6 +539,26 @@ describe("Effect", () => {
       Effect.gen(function*() {
         const results = yield* Effect.filter(new Set([1, 2, 3, 4, 5]), (value) => Effect.succeed(value % 2 === 1))
         assert.deepStrictEqual(results, [1, 3, 5])
+      }))
+  })
+
+  describe("acquireDisposable", () => {
+    it.effect("releases disposables", ({ expect }) =>
+      Effect.gen(function*() {
+        const acquire = Effect.sync((): Disposable => ({ [Symbol.dispose]: release }))
+        const release = vi.fn(() => void 0)
+
+        yield* Effect.scoped(Effect.acquireDisposable(acquire))
+        expect(release).toHaveBeenCalledTimes(1)
+      }))
+
+    it.effect("relases async disposables", ({ expect }) =>
+      Effect.gen(function*() {
+        const acquire = Effect.sync((): AsyncDisposable => ({ [Symbol.asyncDispose]: release }))
+        const release = vi.fn(async () => void 0)
+
+        yield* Effect.scoped(Effect.acquireDisposable(acquire))
+        expect(release).toHaveBeenCalledTimes(1)
       }))
   })
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

from [discord](https://discord.com/channels/795981131316985866/795983589644304396/1500242272262819861):

> this could be a helpful api for libraries and environments that support the new `using` keyword
> 
> ```ts
> /**
>  * Constructs a scoped resource from an {@linkcode AsyncDisposable} or {@linkcode Disposable}
>  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using}
>  * 
>  * @example
>  * import sqlite from "node:sqlite";
>  * import { pipe } from "effect";
>  * 
>  * // Effect.Effect<sqlite.DatabaseSync, never, Scope>
>  * pipe(
>  *   Effect.sync(() => new sqlite.DatabaseSync(":memory:")),
>  *   Effect.aquireDisposable
>  * )
>  * 
>  * @since 4.0.0
>  * @category Resource Management & Finalization
>  */
> const aquireDisposable = <A extends AsyncDisposable | Disposable, E, R>(acquire: Effect.Effect<A, E, R>) =>
>   Effect.acquireRelease(acquire, (resource) =>
>     Predicate.hasProperty(resource, Symbol.asyncDispose)
>       ? Effect.promise(() => resource[Symbol.asyncDispose]())
>       : Effect.sync(() => resource[Symbol.dispose]()),
>   );
> ```

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- n/a
