### PR TITLE
EFF-786 Move fiber lifetime metric start hook

### DIFF
--- a/.changeset/fiber-runtime-start-metrics.md
+++ b/.changeset/fiber-runtime-start-metrics.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Record fiber runtime start metrics when fibers are constructed so yielded fibers are only counted once.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -511,6 +511,7 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     this._children = undefined
     this._interruptedCause = undefined
     this._yielded = undefined
+    this.runtimeMetrics?.recordFiberStart(this.context)
   }
 
   readonly [FiberTypeId]: Fiber.Fiber.Variance<A, E>
@@ -582,7 +583,6 @@ export class FiberImpl<A = any, E = any> implements Fiber.Fiber<A, E> {
     return this._exit
   }
   evaluate(effect: Primitive): void {
-    this.runtimeMetrics?.recordFiberStart(this.context)
     if (this._exit) {
       return
     } else if (this._yielded !== undefined) {

--- a/packages/effect/test/Metric.test.ts
+++ b/packages/effect/test/Metric.test.ts
@@ -60,6 +60,31 @@ describe("Metric", () => {
       assert.strictEqual(result, expected)
     }).pipe(Effect.provideService(Metric.MetricRegistry, new Map())))
 
+  it.effect("should record fiber runtime metrics once for yielded fibers", () => {
+    let starts = 0
+    let ends = 0
+    const service: Metric.FiberRuntimeMetricsService = {
+      recordFiberStart: () => {
+        starts++
+      },
+      recordFiberEnd: () => {
+        ends++
+      }
+    }
+
+    return Effect.gen(function*() {
+      const fiber = yield* Effect.forkChild(Effect.gen(function*() {
+        yield* Effect.yieldNow
+        yield* Effect.yieldNow
+      }))
+
+      yield* Fiber.join(fiber)
+
+      assert.strictEqual(starts, 1)
+      assert.strictEqual(ends, 1)
+    }).pipe(Effect.provideService(Metric.FiberRuntimeMetrics, service))
+  })
+
   describe("Counter", () => {
     it.effect("custom increment with value", () =>
       Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- Move fiber runtime start metric recording from FiberImpl.evaluate() to FiberImpl construction so yielded/resumed fibers are only counted once.
- Keep fiber end metric recording at fiber completion.
- Add coverage ensuring a yielding child fiber reports exactly one start and one end event.

## Checks
- pnpm lint-fix
- pnpm test Metric.test.ts
- pnpm check:tsgo
- cd packages/effect && pnpm docgen