### PR TITLE
EFF-787: Allow null K8s condition lastTransitionTime

### DIFF
--- a/.changeset/k8s-last-transition-null.md
+++ b/.changeset/k8s-last-transition-null.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow Kubernetes pod condition `lastTransitionTime` values to be null in K8sHttpClient schemas.

--- a/packages/effect/src/unstable/cluster/K8sHttpClient.ts
+++ b/packages/effect/src/unstable/cluster/K8sHttpClient.ts
@@ -203,7 +203,7 @@ export class PodStatus extends Schema.Class<PodStatus>("@effect/cluster/K8sHttpC
   conditions: Schema.Array(Schema.Struct({
     type: Schema.String,
     status: Schema.String,
-    lastTransitionTime: Schema.String
+    lastTransitionTime: Schema.NullOr(Schema.String)
   })),
   podIP: Schema.String,
   hostIP: Schema.String
@@ -227,8 +227,8 @@ export class Pod extends Schema.Class<Pod>("@effect/cluster/K8sHttpClient/Pod")(
   }
 
   get isReadyOrInitializing(): boolean {
-    let initializedAt: string | undefined
-    let readyAt: string | undefined
+    let initializedAt: string | null | undefined
+    let readyAt: string | null | undefined
     for (let i = 0; i < this.status.conditions.length; i++) {
       const condition = this.status.conditions[i]
       switch (condition.type) {

--- a/packages/effect/test/cluster/K8sHttpClient.test.ts
+++ b/packages/effect/test/cluster/K8sHttpClient.test.ts
@@ -1,0 +1,34 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import * as K8sHttpClient from "effect/unstable/cluster/K8sHttpClient"
+
+describe.concurrent("K8sHttpClient", () => {
+  describe("Pod", () => {
+    it.effect("decodes null condition lastTransitionTime values", () =>
+      Effect.gen(function*() {
+        const pod = yield* Schema.decodeUnknownEffect(K8sHttpClient.Pod)({
+          status: {
+            phase: "Running",
+            podIP: "10.0.0.1",
+            hostIP: "10.0.0.2",
+            conditions: [
+              {
+                type: "Initialized",
+                status: "True",
+                lastTransitionTime: null
+              },
+              {
+                type: "Ready",
+                status: "False",
+                lastTransitionTime: null
+              }
+            ]
+          }
+        })
+
+        assert.strictEqual(pod.status.conditions[0].lastTransitionTime, null)
+        assert.strictEqual(pod.isReady, false)
+        assert.strictEqual(pod.isReadyOrInitializing, true)
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- Allow Kubernetes pod condition `lastTransitionTime` values to decode as `null` in K8sHttpClient.
- Preserve readiness/initializing comparison logic when transition times are null.
- Add regression coverage for decoding pods with null condition transition times.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/cluster/K8sHttpClient.test.ts`
- `pnpm check:tsgo`
- `cd packages/effect && pnpm docgen`