### PR TITLE
fix(ai-openai): don't spread library-only config fields into request body

### DIFF
--- a/.changeset/ai-openai-config-field-leak.md
+++ b/.changeset/ai-openai-config-field-leak.md
@@ -1,0 +1,6 @@
+---
+"@effect/ai-openai": patch
+"@effect/ai-openai-compat": patch
+---
+
+Fix `OpenAiLanguageModel` leaking library-only config fields (`fileIdPrefixes`, `strictJsonSchema`) into request body, causing OpenAI 400 errors.

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -372,8 +372,9 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         config,
         options
       })
+      const { fileIdPrefixes: _fip, strictJsonSchema: _sjs, ...apiConfig } = config
       const request: CreateResponse = {
-        ...config,
+        ...apiConfig,
         input: messages,
         include: include.size > 0 ? Array.from(include) : null,
         text: {

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -1027,6 +1027,40 @@ describe("OpenAiLanguageModel", () => {
         assert.isTrue(capturedRequest.url.endsWith("/chat/completions"))
       }))
   })
+
+  describe("config", () => {
+    it.effect("does not leak library-only fields into request body", () =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, makeChatCompletion()))
+            })
+          ))
+        )
+
+        yield* LanguageModel.generateText({ prompt: "test" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini", {
+            fileIdPrefixes: ["file-"],
+            strictJsonSchema: false,
+            temperature: 0.5
+          })),
+          Effect.provide(layer)
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) return
+
+        const requestBody = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(requestBody.fileIdPrefixes, undefined)
+        assert.strictEqual(requestBody.strictJsonSchema, undefined)
+        assert.strictEqual(requestBody.temperature, 0.5)
+      }))
+  })
 })
 
 const TestTool = Tool.make("TestTool", {

--- a/packages/ai/openai/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai/src/OpenAiLanguageModel.ts
@@ -376,8 +376,9 @@ export const make = Effect.fnUntraced(function*({ model, config: providerConfig 
         config,
         options
       })
+      const { fileIdPrefixes: _fip, strictJsonSchema: _sjs, ...apiConfig } = config
       const request: Mutable<typeof OpenAiSchema.CreateResponse.Encoded> = {
-        ...config,
+        ...apiConfig,
         input: messages,
         include: include.size > 0 ? Array.from(include) : undefined,
         text: {

--- a/packages/ai/openai/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai/test/OpenAiLanguageModel.test.ts
@@ -1282,6 +1282,26 @@ describe("OpenAiLanguageModel", () => {
         strictEqual(body.temperature, 0.9)
       }).pipe(Effect.provide(makeTestLayer())))
   })
+
+  describe("config", () => {
+    it.effect("does not leak library-only fields into request body", () =>
+      Effect.gen(function*() {
+        yield* LanguageModel.generateText({ prompt: "test" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini", {
+            fileIdPrefixes: ["file-"],
+            strictJsonSchema: false,
+            temperature: 0.5
+          }))
+        )
+
+        const requests = yield* MockHttpClient.requests
+        const body = yield* getRequestBody(requests[0])
+
+        strictEqual(body.fileIdPrefixes, undefined)
+        strictEqual(body.strictJsonSchema, undefined)
+        strictEqual(body.temperature, 0.5)
+      }).pipe(Effect.provide(makeTestLayer())))
+  })
 })
 
 // =============================================================================


### PR DESCRIPTION
Closes #2125

## Summary

- `Config.Service` holds two library-internal fields (`fileIdPrefixes`, `strictJsonSchema`) that have no meaning on the OpenAI API. `makeRequest` spreads the whole config into the request body, so both fields land in the JSON and OpenAI rejects the call with `400 Unknown parameter`.
- Destructure those two fields out before spreading, keeping all real API params intact. Same fix in `@effect/ai-openai-compat` where the fields would pass through `extractCustomRequestProperties` to the chat completions endpoint.
- Added a regression test to each package: pass `fileIdPrefixes`, `strictJsonSchema`, and `temperature` in the model config, run `generateText`, inspect the captured body. Library-only fields absent, `temperature` present. Both tests fail without the fix.

## Checks

- `pnpm exec dprint fmt` on changed files
- `pnpm --filter "@effect/ai-openai" test`
- `pnpm --filter "@effect/ai-openai-compat" test`
- `pnpm check:tsgo`