### PR TITLE
EFF-789 SqlModel repositories support soft delete columns

### DIFF
--- a/.changeset/soft-delete-sqlmodel.md
+++ b/.changeset/soft-delete-sqlmodel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add optional soft delete column support to SqlModel repositories and resolvers.

--- a/packages/effect/src/unstable/sql/SqlModel.ts
+++ b/packages/effect/src/unstable/sql/SqlModel.ts
@@ -21,11 +21,13 @@ import * as SqlSchema from "./SqlSchema.ts"
  */
 export const makeRepository = <
   S extends Model.Any,
-  Id extends (keyof S["Type"]) & (keyof S["update"]["Type"]) & (keyof S["fields"])
+  Id extends (keyof S["Type"]) & (keyof S["update"]["Type"]) & (keyof S["fields"]),
+  SoftDelete extends keyof S["fields"] = never
 >(Model: S, options: {
   readonly tableName: string
   readonly spanPrefix: string
   readonly idColumn: Id
+  readonly softDeleteColumn?: SoftDelete | undefined
 }): Effect.Effect<
   {
     readonly insert: (
@@ -66,6 +68,12 @@ export const makeRepository = <
     const sql = yield* SqlClient
     const idSchema = Model.fields[options.idColumn] as Schema.Top
     const idColumn = options.idColumn as string
+    const softDeleteColumn = options.softDeleteColumn as string | undefined
+    const withSoftDeleteFilter = (where: any) =>
+      softDeleteColumn === undefined ? where : sql.and([where, sql`${sql(softDeleteColumn)} is null`])
+    const setSoftDeleted = softDeleteColumn === undefined
+      ? undefined
+      : sql`${sql(softDeleteColumn)} = CURRENT_TIMESTAMP`
 
     const insertSchema = SqlSchema.findOne({
       Request: Model.insert,
@@ -74,9 +82,10 @@ export const makeRepository = <
         sql.onDialectOrElse({
           mysql: () =>
             sql`insert into ${sql(options.tableName)} ${sql.insert(request as any)};
-select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID();`.unprepared.pipe(
-              Effect.map(([, results]) => results as any)
-            ),
+select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(idColumn)} = LAST_INSERT_ID()`)};`
+              .unprepared.pipe(
+                Effect.map(([, results]) => results as any)
+              ),
           orElse: () => sql`insert into ${sql(options.tableName)} ${sql.insert(request as any).returning("*")}`
         })
     })
@@ -111,15 +120,16 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
       execute: (request: any) =>
         sql.onDialectOrElse({
           mysql: () =>
-            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${sql(idColumn)} = ${
-              request[idColumn]
+            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+              withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
             };
-select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idColumn]};`.unprepared.pipe(
-              Effect.map(([, results]) => results as any)
-            ),
+select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)};`
+              .unprepared.pipe(
+                Effect.map(([, results]) => results as any)
+              ),
           orElse: () =>
-            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${sql(idColumn)} = ${
-              request[idColumn]
+            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+              withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
             } returning *`
         })
     })
@@ -142,8 +152,8 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
     const updateVoidSchema = SqlSchema.void({
       Request: Model.update,
       execute: (request: any) =>
-        sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${sql(idColumn)} = ${
-          request[idColumn]
+        sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+          withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
         }`
     })
     const updateVoid = (
@@ -160,7 +170,8 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
     const findByIdSchema = SqlSchema.findOne({
       Request: idSchema,
       Result: Model,
-      execute: (id: any) => sql`select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${id}`
+      execute: (id: any) =>
+        sql`select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(idColumn)} = ${id}`)}`
     })
     const findById = (
       id: S["fields"][Id]["Type"]
@@ -177,7 +188,12 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
 
     const deleteSchema = SqlSchema.void({
       Request: idSchema,
-      execute: (id: any) => sql`delete from ${sql(options.tableName)} where ${sql(idColumn)} = ${id}`
+      execute: (id: any) =>
+        softDeleteColumn === undefined
+          ? sql`delete from ${sql(options.tableName)} where ${sql(idColumn)} = ${id}`
+          : sql`update ${sql(options.tableName)} set ${setSoftDeleted} where ${
+            withSoftDeleteFilter(sql`${sql(idColumn)} = ${id}`)
+          }`
     })
     const delete_ = (
       id: S["fields"][Id]["Type"]
@@ -201,13 +217,15 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = ${request[idCol
  */
 export const makeResolvers = <
   S extends Model.Any,
-  Id extends (keyof S["Type"]) & (keyof S["update"]["Type"]) & (keyof S["fields"])
+  Id extends (keyof S["Type"]) & (keyof S["update"]["Type"]) & (keyof S["fields"]),
+  SoftDelete extends keyof S["fields"] = never
 >(
   Model: S,
   options: {
     readonly tableName: string
     readonly spanPrefix: string
     readonly idColumn: Id
+    readonly softDeleteColumn?: SoftDelete | undefined
   }
 ): Effect.Effect<
   {
@@ -246,6 +264,12 @@ export const makeResolvers = <
     const sql = yield* SqlClient
     const idSchema = Model.fields[options.idColumn] as Schema.Top
     const idColumn = options.idColumn as string
+    const softDeleteColumn = options.softDeleteColumn as string | undefined
+    const withSoftDeleteFilter = (where: any) =>
+      softDeleteColumn === undefined ? where : sql.and([where, sql`${sql(softDeleteColumn)} is null`])
+    const setSoftDeleted = softDeleteColumn === undefined
+      ? undefined
+      : sql`${sql(softDeleteColumn)} = CURRENT_TIMESTAMP`
 
     const insert: RequestResolver.RequestResolver<
       SqlResolver.SqlRequest<
@@ -262,9 +286,10 @@ export const makeResolvers = <
           mysql: () =>
             Effect.forEach(request, (request: any) =>
               sql`insert into ${sql(options.tableName)} ${sql.insert(request)};
-select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID();`.unprepared.pipe(
-                Effect.map(([, results]) => results[0] as any)
-              ), { concurrency: 10 }),
+select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(idColumn)} = LAST_INSERT_ID()`)};`
+                .unprepared.pipe(
+                  Effect.map(([, results]) => results[0] as any)
+                ), { concurrency: 10 }),
           orElse: () => sql`insert into ${sql(options.tableName)} ${sql.insert(request).returning("*")}`
         })
     }).pipe(
@@ -293,7 +318,8 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
       ResultId(request: any) {
         return request[idColumn]
       },
-      execute: (ids: any) => sql`select * from ${sql(options.tableName)} where ${sql.in(idColumn, ids)}`
+      execute: (ids: any) =>
+        sql`select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql.in(idColumn, ids))}`
     }).pipe(
       RequestResolver.withSpan(`${options.spanPrefix}.findByIdResolver`)
     )
@@ -307,7 +333,12 @@ select * from ${sql(options.tableName)} where ${sql(idColumn)} = LAST_INSERT_ID(
       >
     > = SqlResolver.void({
       Request: idSchema,
-      execute: (ids: any) => sql`delete from ${sql(options.tableName)} where ${sql.in(idColumn, ids)}`
+      execute: (ids: any) =>
+        softDeleteColumn === undefined
+          ? sql`delete from ${sql(options.tableName)} where ${sql.in(idColumn, ids)}`
+          : sql`update ${sql(options.tableName)} set ${setSoftDeleted} where ${
+            withSoftDeleteFilter(sql.in(idColumn, ids))
+          }`
     }).pipe(
       RequestResolver.withSpan(`${options.spanPrefix}.deleteResolver`)
     )

--- a/packages/sql/mysql2/test/Model.test.ts
+++ b/packages/sql/mysql2/test/Model.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
 import { Model } from "effect/unstable/schema"
 import { SqlClient, SqlModel, SqlResolver } from "effect/unstable/sql"
 import { MysqlContainer } from "./utils.ts"
@@ -8,6 +8,12 @@ class User extends Model.Class<User>("User")({
   id: Model.Generated(Schema.Int),
   name: Schema.String,
   age: Schema.Int
+}) {}
+
+class SoftDeleteUser extends Model.Class<SoftDeleteUser>("SoftDeleteUser")({
+  id: Model.Generated(Schema.Int),
+  name: Schema.String,
+  deletedAt: Model.Generated(Schema.NullOr(Schema.String))
 }) {}
 
 describe("SqlModel", () => {
@@ -102,6 +108,76 @@ describe("SqlModel", () => {
 
       assert.deepStrictEqual(alice2.name, "Alice")
       assert.deepStrictEqual(john2.name, "John")
+    }).pipe(
+      Effect.provide(MysqlContainer.layerClient),
+      Effect.catchTag("ContainerError", () => Effect.void)
+    ), { timeout: 60_000 })
+
+  it.effect("findById ignores soft deleted rows", () =>
+    Effect.gen(function*() {
+      const repo = yield* SqlModel.makeRepository(SoftDeleteUser, {
+        tableName: "soft_delete_users",
+        idColumn: "id",
+        spanPrefix: "SoftDeleteUserRepository",
+        softDeleteColumn: "deletedAt"
+      })
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`CREATE TABLE soft_delete_users (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), deletedAt VARCHAR(255) NULL)`
+
+      const alice = yield* repo.insert(SoftDeleteUser.insert.make({ name: "Alice" }))
+      const bob = yield* repo.insert(SoftDeleteUser.insert.make({ name: "Bob" }))
+      yield* sql`UPDATE soft_delete_users SET deletedAt = CURRENT_TIMESTAMP WHERE id = ${bob.id}`
+
+      const aliceResult = yield* repo.findById(alice.id)
+      assert.deepStrictEqual(aliceResult, new SoftDeleteUser({ id: alice.id, name: "Alice", deletedAt: null }))
+
+      const error = yield* Effect.flip(repo.findById(bob.id))
+      assert.isTrue(Cause.isNoSuchElementError(error))
+
+      yield* repo.delete(alice.id)
+      const rows = yield* sql<
+        { deletedAt: string | null }
+      >`SELECT deletedAt FROM soft_delete_users WHERE id = ${alice.id}`
+      assert.strictEqual(rows.length, 1)
+      assert.isNotNull(rows[0]!.deletedAt)
+
+      const deletedError = yield* Effect.flip(repo.findById(alice.id))
+      assert.isTrue(Cause.isNoSuchElementError(deletedError))
+    }).pipe(
+      Effect.provide(MysqlContainer.layerClient),
+      Effect.catchTag("ContainerError", () => Effect.void)
+    ), { timeout: 60_000 })
+
+  it.live("findById data loader ignores soft deleted rows", () =>
+    Effect.gen(function*() {
+      const repo = yield* SqlModel.makeResolvers(SoftDeleteUser, {
+        tableName: "soft_delete_user_resolvers",
+        idColumn: "id",
+        spanPrefix: "SoftDeleteUserRepository",
+        softDeleteColumn: "deletedAt"
+      })
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`CREATE TABLE soft_delete_user_resolvers (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), deletedAt VARCHAR(255) NULL)`
+
+      const alice = yield* SqlResolver.request(SoftDeleteUser.insert.make({ name: "Alice" }), repo.insert)
+      const bob = yield* SqlResolver.request(SoftDeleteUser.insert.make({ name: "Bob" }), repo.insert)
+      yield* sql`UPDATE soft_delete_user_resolvers SET deletedAt = CURRENT_TIMESTAMP WHERE id = ${bob.id}`
+
+      const aliceResult = yield* SqlResolver.request(alice.id, repo.findById)
+      assert.deepStrictEqual(aliceResult, new SoftDeleteUser({ id: alice.id, name: "Alice", deletedAt: null }))
+
+      const error = yield* Effect.flip(SqlResolver.request(bob.id, repo.findById))
+      assert.isTrue(Cause.isNoSuchElementError(error))
+
+      yield* SqlResolver.request(alice.id, repo.delete)
+      const rows = yield* sql<
+        { deletedAt: string | null }
+      >`SELECT deletedAt FROM soft_delete_user_resolvers WHERE id = ${alice.id}`
+      assert.strictEqual(rows.length, 1)
+      assert.isNotNull(rows[0]!.deletedAt)
+
+      const deletedError = yield* Effect.flip(SqlResolver.request(alice.id, repo.findById))
+      assert.isTrue(Cause.isNoSuchElementError(deletedError))
     }).pipe(
       Effect.provide(MysqlContainer.layerClient),
       Effect.catchTag("ContainerError", () => Effect.void)


### PR DESCRIPTION
## Summary

- Add an optional `softDeleteColumn` option to SqlModel repositories and resolvers
- Filter find/update/delete operations to rows where the soft delete column is null
- Soft-delete rows by setting the soft delete column to `CURRENT_TIMESTAMP` instead of hard deleting
- Add MySQL integration coverage for repository and resolver soft-delete behavior

## Validation

- `pnpm lint-fix`
- `pnpm test packages/sql/mysql2/test/Model.test.ts`
- `pnpm check:tsgo`
- `cd packages/effect && pnpm docgen`
