### PR TITLE
EFF-793 Fix SqlModel soft delete updates

### DIFF
--- a/.changeset/quiet-lions-sqlmodel.md
+++ b/.changeset/quiet-lions-sqlmodel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Prevent SqlModel repository updates from modifying configured soft delete columns.

--- a/packages/effect/src/unstable/sql/SqlModel.ts
+++ b/packages/effect/src/unstable/sql/SqlModel.ts
@@ -74,6 +74,7 @@ export const makeRepository = <
     const setSoftDeleted = softDeleteColumn === undefined
       ? undefined
       : sql`${sql(softDeleteColumn)} = CURRENT_TIMESTAMP`
+    const updateOmitColumns = softDeleteColumn === undefined ? [idColumn] : [idColumn, softDeleteColumn]
 
     const insertSchema = SqlSchema.findOne({
       Request: Model.insert,
@@ -120,7 +121,7 @@ select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(i
       execute: (request: any) =>
         sql.onDialectOrElse({
           mysql: () =>
-            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+            sql`update ${sql(options.tableName)} set ${sql.update(request, updateOmitColumns)} where ${
               withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
             };
 select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)};`
@@ -128,7 +129,7 @@ select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(i
                 Effect.map(([, results]) => results as any)
               ),
           orElse: () =>
-            sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+            sql`update ${sql(options.tableName)} set ${sql.update(request, updateOmitColumns)} where ${
               withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
             } returning *`
         })
@@ -152,7 +153,7 @@ select * from ${sql(options.tableName)} where ${withSoftDeleteFilter(sql`${sql(i
     const updateVoidSchema = SqlSchema.void({
       Request: Model.update,
       execute: (request: any) =>
-        sql`update ${sql(options.tableName)} set ${sql.update(request, [idColumn])} where ${
+        sql`update ${sql(options.tableName)} set ${sql.update(request, updateOmitColumns)} where ${
           withSoftDeleteFilter(sql`${sql(idColumn)} = ${request[idColumn]}`)
         }`
     })

--- a/packages/effect/test/unstable/sql/SqlModel.test.ts
+++ b/packages/effect/test/unstable/sql/SqlModel.test.ts
@@ -1,0 +1,133 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema, Stream } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+import * as Model from "effect/unstable/schema/Model"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
+import * as SqlModel from "effect/unstable/sql/SqlModel"
+import * as SqlResolver from "effect/unstable/sql/SqlResolver"
+import * as Statement from "effect/unstable/sql/Statement"
+
+class User extends Model.Class<User>("User")({
+  id: Model.Generated(Schema.Number),
+  name: Schema.String,
+  deletedAt: Schema.NullOr(Schema.String)
+}) {}
+
+const makeClient = (
+  captured: Array<{ readonly sql: string; readonly params: ReadonlyArray<unknown> }>,
+  rows: ReadonlyArray<unknown> = [{ id: 1, name: "Grace", deletedAt: null }]
+) =>
+  SqlClient.make({
+    acquirer: Effect.succeed({
+      execute(sql, params) {
+        return Effect.sync(() => {
+          captured.push({ sql, params })
+          return rows
+        })
+      },
+      executeRaw(sql, params) {
+        return Effect.sync(() => {
+          captured.push({ sql, params })
+          return rows
+        })
+      },
+      executeStream(sql, params) {
+        captured.push({ sql, params })
+        return Stream.fromIterable(rows)
+      },
+      executeValues(sql, params) {
+        return Effect.sync(() => {
+          captured.push({ sql, params })
+          return []
+        })
+      },
+      executeUnprepared(sql, params) {
+        return Effect.sync(() => {
+          captured.push({ sql, params })
+          return rows
+        })
+      }
+    }),
+    compiler: Statement.makeCompilerSqlite(),
+    spanAttributes: []
+  }).pipe(Effect.provide(Reactivity.layer))
+
+const makeRepository = (client: SqlClient.SqlClient) =>
+  SqlModel.makeRepository(User, {
+    tableName: "users",
+    spanPrefix: "User",
+    idColumn: "id",
+    softDeleteColumn: "deletedAt"
+  }).pipe(Effect.provideService(SqlClient.SqlClient, client))
+
+const makeResolvers = (client: SqlClient.SqlClient) =>
+  SqlModel.makeResolvers(User, {
+    tableName: "users",
+    spanPrefix: "User",
+    idColumn: "id",
+    softDeleteColumn: "deletedAt"
+  }).pipe(Effect.provideService(SqlClient.SqlClient, client))
+
+describe("SqlModel", () => {
+  describe("soft delete", () => {
+    it.effect("omits the soft delete column from updates and ignores soft deleted rows", () =>
+      Effect.gen(function*() {
+        const captured: Array<{ readonly sql: string; readonly params: ReadonlyArray<unknown> }> = []
+        const client = yield* makeClient(captured)
+        const repository = yield* makeRepository(client)
+
+        yield* repository.update({ id: 1, name: "Grace", deletedAt: "already-deleted" })
+
+        assert.strictEqual(
+          captured[0].sql,
+          "update \"users\" set \"name\" = ? where (\"id\" = ? AND \"deletedAt\" is null) returning *"
+        )
+        assert.deepStrictEqual(captured[0].params, ["Grace", 1])
+      }))
+
+    it.effect("omits the soft delete column from void updates and ignores soft deleted rows", () =>
+      Effect.gen(function*() {
+        const captured: Array<{ readonly sql: string; readonly params: ReadonlyArray<unknown> }> = []
+        const client = yield* makeClient(captured)
+        const repository = yield* makeRepository(client)
+
+        yield* repository.updateVoid({ id: 1, name: "Grace", deletedAt: "already-deleted" })
+
+        assert.strictEqual(
+          captured[0].sql,
+          "update \"users\" set \"name\" = ? where (\"id\" = ? AND \"deletedAt\" is null)"
+        )
+        assert.deepStrictEqual(captured[0].params, ["Grace", 1])
+      }))
+
+    it.effect("soft deletes only rows that have not already been soft deleted", () =>
+      Effect.gen(function*() {
+        const captured: Array<{ readonly sql: string; readonly params: ReadonlyArray<unknown> }> = []
+        const client = yield* makeClient(captured)
+        const repository = yield* makeRepository(client)
+
+        yield* repository.delete(1)
+
+        assert.strictEqual(
+          captured[0].sql,
+          "update \"users\" set \"deletedAt\" = CURRENT_TIMESTAMP where (\"id\" = ? AND \"deletedAt\" is null)"
+        )
+        assert.deepStrictEqual(captured[0].params, [1])
+      }))
+
+    it.effect("resolver soft deletes only rows that have not already been soft deleted", () =>
+      Effect.gen(function*() {
+        const captured: Array<{ readonly sql: string; readonly params: ReadonlyArray<unknown> }> = []
+        const client = yield* makeClient(captured)
+        const resolvers = yield* makeResolvers(client)
+
+        yield* SqlResolver.request(1, resolvers.delete)
+
+        assert.strictEqual(
+          captured[0].sql,
+          "update \"users\" set \"deletedAt\" = CURRENT_TIMESTAMP where (\"id\" IN (?) AND \"deletedAt\" is null)"
+        )
+        assert.deepStrictEqual(captured[0].params, [1])
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- Omit configured soft delete columns from SqlModel repository update/updateVoid SET clauses.
- Keep update/delete operations scoped to non-soft-deleted rows via the existing soft-delete filter.
- Add focused SqlModel soft-delete SQL tests and a changeset.

## Verification
- pnpm lint-fix
- pnpm test packages/effect/test/unstable/sql/SqlModel.test.ts
- pnpm check:tsgo
- cd packages/effect && pnpm docgen