### PR TITLE
feat(effect): add HttpMiddleware.compression for gzip/deflate response compression

### DIFF
--- a/.changeset/add-http-compression-middleware.md
+++ b/.changeset/add-http-compression-middleware.md
@@ -1,0 +1,9 @@
+---
+"effect": minor
+---
+
+Add `HttpMiddleware.compression` (and matching `HttpRouter.compression` layer) for gzip/deflate response compression.
+
+The middleware uses the Web Standard `CompressionStream`, so it works in Node, Bun, Deno, and browser-style runtimes without a `node:zlib` dependency. It supports both `Uint8Array` and `Stream` response bodies, and mirrors Hono's `compress` defaults: skips `HEAD` requests, responses that already have `Content-Encoding`, `Cache-Control: no-transform`, `text/event-stream`, non-compressible content types, and bodies smaller than the configured threshold (default 1024 bytes). When compression is applied, `Vary: Accept-Encoding` is merged into any existing `Vary` header and strong `ETag`s are weakened.
+
+Also adds `HttpServerResponse.removeHeader`, used internally to drop stale `Content-Length` after a stream body swap.

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -368,9 +368,16 @@ export type CompressionEncoding = "gzip" | "deflate"
 
 const compressionEncodingsDefault: ReadonlyArray<CompressionEncoding> = ["gzip", "deflate"]
 
-// Mirrors Hono's compressible content-type allowlist.
+// Curated set of compressible content types. Each entry is flagged
+// `compressible: true` in the IANA-derived mime-db dataset. Already-compressed
+// formats (woff/woff2, image/png, image/jpeg, video/*, audio/*, etc.) are
+// intentionally excluded. text/event-stream is excluded directly from the
+// regex so the policy is self-consistent even without the separate runtime
+// guard. Structured-syntax suffixes (+json, +xml, +text, +yaml) are matched
+// generically, which covers things like application/ld+json, image/svg+xml,
+// and application/xhtml+xml without listing them explicitly.
 const compressibleContentTypeDefault =
-  /^\s*(?:text\/[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|xhtml\+xml)|font\/(?:otf|ttf)|image\/(?:bmp|svg\+xml|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
+  /^\s*(?:text\/(?!event-stream(?:[;\s]|$))[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
 
 const pickCompressionEncoding = (
   acceptEncoding: string | undefined,

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -377,9 +377,14 @@ const pickCompressionEncoding = (
   preferred: ReadonlyArray<CompressionEncoding>
 ): CompressionEncoding | undefined => {
   if (!acceptEncoding) return undefined
-  const lower = acceptEncoding.toLowerCase()
+  // Parse RFC 7231 tokens so values like "gzipold" don't match "gzip".
+  const tokens = new Set<string>()
+  for (const part of acceptEncoding.split(",")) {
+    const token = part.split(";")[0].trim().toLowerCase()
+    if (token.length > 0) tokens.add(token)
+  }
   for (const enc of preferred) {
-    if (lower.includes(enc)) return enc
+    if (tokens.has(enc)) return enc
   }
   return undefined
 }
@@ -462,7 +467,7 @@ const compressStream = (
  */
 export const compression = (options?: {
   readonly threshold?: number | undefined
-  readonly skip?: ((request: Request.HttpServerRequest) => boolean) | undefined
+  readonly skip?: Predicate<Request.HttpServerRequest> | undefined
   readonly compressibleContentType?: RegExp | undefined
   readonly encodings?: ReadonlyArray<CompressionEncoding> | undefined
 }): <E, R>(
@@ -506,11 +511,6 @@ export const compression = (options?: {
     const applyHeaders = (next: HttpServerResponse): HttpServerResponse => {
       let out = Response.setHeader(next, "content-encoding", encoding)
       out = Response.setHeader(out, "vary", varyAcceptEncoding(out.headers["vary"]))
-      // Stream bodies have unknown compressed length; remove any stale value
-      // that survived the body swap.
-      if (out.body._tag === "Stream" && out.headers["content-length"] !== undefined) {
-        out = Response.removeHeader(out, "content-length")
-      }
       const etag = out.headers["etag"]
       if (etag && !etag.startsWith("W/")) {
         out = Response.setHeader(out, "etag", `W/${etag}`)
@@ -519,7 +519,10 @@ export const compression = (options?: {
     }
 
     if (body._tag === "Stream") {
-      return Effect.succeed(applyHeaders(Response.setBody(response, compressStream(body, encoding))))
+      // Compressed stream length is unknown; drop any stale value carried over
+      // from the original body before applying the encoding headers.
+      const next = Response.setBody(response, compressStream(body, encoding))
+      return Effect.succeed(applyHeaders(Response.removeHeader(next, "content-length")))
     }
 
     return compressBytes(body.body, encoding).pipe(

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -11,8 +11,10 @@ import * as Option from "../../Option.ts"
 import type { Predicate } from "../../Predicate.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
 import { TracerEnabled } from "../../References.ts"
+import * as Stream from "../../Stream.ts"
 import { ParentSpan } from "../../Tracer.ts"
 import * as Headers from "./Headers.ts"
+import * as HttpBody from "./HttpBody.ts"
 import { causeResponseStripped, exitResponse } from "./HttpServerError.ts"
 import { HttpServerRequest } from "./HttpServerRequest.ts"
 import * as Request from "./HttpServerRequest.ts"
@@ -353,6 +355,185 @@ export const cors = (options?: {
           headers: headersFromRequestOptions(request)
         }))
       }
+      appendPreResponseHandlerUnsafe(request, preResponseHandler)
+      return httpApp
+    })
+}
+
+/**
+ * @since 4.0.0
+ * @category Compression
+ */
+export type CompressionEncoding = "gzip" | "deflate"
+
+const compressionEncodingsDefault: ReadonlyArray<CompressionEncoding> = ["gzip", "deflate"]
+
+// Mirrors Hono's compressible content-type allowlist.
+const compressibleContentTypeDefault =
+  /^\s*(?:text\/[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|xhtml\+xml)|font\/(?:otf|ttf)|image\/(?:bmp|svg\+xml|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
+
+const pickCompressionEncoding = (
+  acceptEncoding: string | undefined,
+  preferred: ReadonlyArray<CompressionEncoding>
+): CompressionEncoding | undefined => {
+  if (!acceptEncoding) return undefined
+  const lower = acceptEncoding.toLowerCase()
+  for (const enc of preferred) {
+    if (lower.includes(enc)) return enc
+  }
+  return undefined
+}
+
+const varyAcceptEncoding = (existing: string | undefined): string => {
+  if (!existing) return "Accept-Encoding"
+  const parts = existing.split(",").map((part) => part.trim())
+  if (parts.some((part) => part.toLowerCase() === "accept-encoding")) {
+    return existing
+  }
+  return `${existing}, Accept-Encoding`
+}
+
+const compressBytes = (
+  bytes: globalThis.Uint8Array,
+  encoding: CompressionEncoding
+): Effect.Effect<globalThis.Uint8Array> =>
+  Effect.promise(async () => {
+    const transform = new globalThis.CompressionStream(encoding)
+    const writer = transform.writable.getWriter() as WritableStreamDefaultWriter<globalThis.Uint8Array>
+    await writer.write(bytes)
+    await writer.close()
+    const reader = transform.readable.getReader() as ReadableStreamDefaultReader<globalThis.Uint8Array>
+    const chunks: Array<globalThis.Uint8Array> = []
+    let total = 0
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      total += value.length
+    }
+    const out = new globalThis.Uint8Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+      out.set(chunk, offset)
+      offset += chunk.length
+    }
+    return out
+  })
+
+const compressStream = (
+  body: HttpBody.Stream,
+  encoding: CompressionEncoding
+): HttpBody.Stream => {
+  const compressed = Stream.fromReadableStream<globalThis.Uint8Array, unknown>({
+    evaluate: () => {
+      const source = Stream.toReadableStream(body.stream) as ReadableStream<globalThis.Uint8Array>
+      const transform = new globalThis.CompressionStream(encoding) as unknown as ReadableWritablePair<
+        globalThis.Uint8Array,
+        globalThis.Uint8Array
+      >
+      return source.pipeThrough(transform)
+    },
+    onError: (cause) => cause
+  })
+  return new HttpBody.Stream(compressed, body.contentType, undefined)
+}
+
+/**
+ * Compresses HTTP response bodies using gzip or deflate based on the request's
+ * `Accept-Encoding` header.
+ *
+ * Skips responses that:
+ * - Are for `HEAD` requests
+ * - Already have a `Content-Encoding` header
+ * - Have `Cache-Control: no-transform`
+ * - Have a content type that is not in the configured allowlist (defaults to a
+ *   list mirroring Hono's `compress` middleware; `text/event-stream` is always
+ *   excluded)
+ * - Have a known `Content-Length` smaller than the configured threshold
+ *   (defaults to 1024 bytes)
+ * - Have a body that is not `Uint8Array` or `Stream`
+ *
+ * When compression is applied, the response body is replaced, `Content-Encoding`
+ * is set, `Content-Length` is dropped, `Vary` gains `Accept-Encoding`, and any
+ * strong `ETag` is weakened.
+ *
+ * @since 4.0.0
+ * @category Compression
+ */
+export const compression = (options?: {
+  readonly threshold?: number | undefined
+  readonly skip?: ((request: Request.HttpServerRequest) => boolean) | undefined
+  readonly compressibleContentType?: RegExp | undefined
+  readonly encodings?: ReadonlyArray<CompressionEncoding> | undefined
+}): <E, R>(
+  httpApp: Effect.Effect<HttpServerResponse, E, R>
+) => Effect.Effect<HttpServerResponse, E, R | HttpServerRequest> => {
+  const threshold = options?.threshold ?? 1024
+  const skip = options?.skip
+  const compressibleContentType = options?.compressibleContentType ?? compressibleContentTypeDefault
+  const encodings = options?.encodings ?? compressionEncodingsDefault
+
+  const preResponseHandler = (request: Request.HttpServerRequest, response: HttpServerResponse) => {
+    if (request.method === "HEAD") return Effect.succeed(response)
+    if (skip?.(request)) return Effect.succeed(response)
+    if (response.headers["content-encoding"]) return Effect.succeed(response)
+
+    const cacheControl = response.headers["cache-control"]
+    if (cacheControl && cacheControl.toLowerCase().includes("no-transform")) {
+      return Effect.succeed(response)
+    }
+
+    const encoding = pickCompressionEncoding(request.headers["accept-encoding"], encodings)
+    if (!encoding) return Effect.succeed(response)
+
+    const body = response.body
+    if (body._tag !== "Uint8Array" && body._tag !== "Stream") {
+      return Effect.succeed(response)
+    }
+
+    const contentType = body.contentType
+    if (!contentType || contentType.toLowerCase().includes("text/event-stream")) {
+      return Effect.succeed(response)
+    }
+    if (!compressibleContentType.test(contentType)) {
+      return Effect.succeed(response)
+    }
+
+    if (body.contentLength !== undefined && body.contentLength < threshold) {
+      return Effect.succeed(response)
+    }
+
+    const applyHeaders = (next: HttpServerResponse): HttpServerResponse => {
+      let out = Response.setHeader(next, "content-encoding", encoding)
+      out = Response.setHeader(out, "vary", varyAcceptEncoding(out.headers["vary"]))
+      // Stream bodies have unknown compressed length; remove any stale value
+      // that survived the body swap.
+      if (out.body._tag === "Stream" && out.headers["content-length"] !== undefined) {
+        out = Response.removeHeader(out, "content-length")
+      }
+      const etag = out.headers["etag"]
+      if (etag && !etag.startsWith("W/")) {
+        out = Response.setHeader(out, "etag", `W/${etag}`)
+      }
+      return out
+    }
+
+    if (body._tag === "Stream") {
+      return Effect.succeed(applyHeaders(Response.setBody(response, compressStream(body, encoding))))
+    }
+
+    return compressBytes(body.body, encoding).pipe(
+      Effect.map((compressed) =>
+        applyHeaders(Response.setBody(response, HttpBody.uint8Array(compressed, body.contentType)))
+      )
+    )
+  }
+
+  return <E, R>(
+    httpApp: Effect.Effect<HttpServerResponse, E, R>
+  ): Effect.Effect<HttpServerResponse, E, R | HttpServerRequest> =>
+    Effect.withFiber((fiber) => {
+      const request = Context.getUnsafe(fiber.context, HttpServerRequest)
       appendPreResponseHandlerUnsafe(request, preResponseHandler)
       return httpApp
     })

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1005,6 +1005,25 @@ export const cors = (
 ): Layer.Layer<never, never, HttpRouter> => middleware(HttpMiddleware.cors(options), { global: true })
 
 /**
+ * A middleware that compresses HTTP response bodies using gzip or deflate
+ * based on the request's `Accept-Encoding` header.
+ *
+ * See `HttpMiddleware.compression` for the list of conditions under which
+ * compression is skipped.
+ *
+ * @since 4.0.0
+ * @category Middleware
+ */
+export const compression = (
+  options?: {
+    readonly threshold?: number | undefined
+    readonly skip?: ((request: HttpServerRequest.HttpServerRequest) => boolean) | undefined
+    readonly compressibleContentType?: RegExp | undefined
+    readonly encodings?: ReadonlyArray<HttpMiddleware.CompressionEncoding> | undefined
+  } | undefined
+): Layer.Layer<never, never, HttpRouter> => middleware(HttpMiddleware.compression(options), { global: true })
+
+/**
  * A middleware that disables the logger for some routes.
  *
  * ```ts

--- a/packages/effect/src/unstable/http/HttpRouter.ts
+++ b/packages/effect/src/unstable/http/HttpRouter.ts
@@ -1015,12 +1015,7 @@ export const cors = (
  * @category Middleware
  */
 export const compression = (
-  options?: {
-    readonly threshold?: number | undefined
-    readonly skip?: ((request: HttpServerRequest.HttpServerRequest) => boolean) | undefined
-    readonly compressibleContentType?: RegExp | undefined
-    readonly encodings?: ReadonlyArray<HttpMiddleware.CompressionEncoding> | undefined
-  } | undefined
+  options?: Parameters<typeof HttpMiddleware.compression>[0]
 ): Layer.Layer<never, never, HttpRouter> => middleware(HttpMiddleware.compression(options), { global: true })
 
 /**

--- a/packages/effect/src/unstable/http/HttpServerResponse.ts
+++ b/packages/effect/src/unstable/http/HttpServerResponse.ts
@@ -431,6 +431,22 @@ export const setHeaders: {
  * @since 4.0.0
  * @category combinators
  */
+export const removeHeader: {
+  (key: string): (self: HttpServerResponse) => HttpServerResponse
+  (self: HttpServerResponse, key: string): HttpServerResponse
+} = dual(
+  2,
+  (self: HttpServerResponse, key: string): HttpServerResponse =>
+    makeResponse({
+      ...self,
+      headers: Headers.remove(self.headers, key)
+    })
+)
+
+/**
+ * @since 4.0.0
+ * @category combinators
+ */
 export const removeCookie: {
   (name: string): (self: HttpServerResponse) => HttpServerResponse
   (self: HttpServerResponse, name: string): HttpServerResponse

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -161,6 +161,33 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(out.headers["content-encoding"], undefined)
       }))
 
+    it.effect("does not match unrelated tokens that share a prefix with gzip", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzipold, identity" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("ignores q-values when matching encodings", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip;q=0.5, deflate;q=1.0" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response)
+        // We honour the configured priority (gzip first), not q-values yet.
+        assert.strictEqual(out.headers["content-encoding"], "gzip")
+      }))
+
     it.effect("skips bodies smaller than threshold", () =>
       Effect.gen(function*() {
         const request = HttpServerRequest.fromWeb(

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -217,6 +217,54 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(out.headers["content-encoding"], undefined)
       }))
 
+    // Locks the default content-type policy against the IANA mime-db
+    // `compressible` flags. The "skip" cases are formats that are already
+    // compressed (woff is zlib-wrapped, woff2 is brotli-wrapped, png/jpeg/mp4
+    // are inherently compressed) and re-compressing wastes CPU for no gain.
+    const compressiblePolicyCases: ReadonlyArray<[string, boolean]> = [
+      ["text/plain", true],
+      ["text/html; charset=utf-8", true],
+      ["application/json", true],
+      ["application/wasm", true],
+      ["application/ld+json", true],
+      ["application/manifest+json", true],
+      ["application/xhtml+xml", true],
+      ["image/svg+xml", true],
+      ["image/bmp", true],
+      ["font/otf", true],
+      ["font/ttf", true],
+      ["text/event-stream", false],
+      ["font/woff", false],
+      ["font/woff2", false],
+      ["image/png", false],
+      ["image/jpeg", false],
+      ["video/mp4", false],
+      ["audio/mpeg", false],
+      ["application/zip", false],
+      ["application/octet-stream", false]
+    ]
+    for (const [contentType, shouldCompress] of compressiblePolicyCases) {
+      it.effect(`${shouldCompress ? "compresses" : "skips"} ${contentType}`, () =>
+        Effect.gen(function*() {
+          const request = HttpServerRequest.fromWeb(
+            new Request("http://api.example.com/data", {
+              method: "GET",
+              headers: { "accept-encoding": "gzip" }
+            })
+          )
+          const response = HttpServerResponse.uint8Array(
+            new TextEncoder().encode(largeBody),
+            { contentType }
+          )
+          const out = yield* runCompression(request, response)
+          assert.strictEqual(
+            out.headers["content-encoding"],
+            shouldCompress ? "gzip" : undefined,
+            `${contentType} should ${shouldCompress ? "compress" : "skip"}`
+          )
+        }))
+    }
+
     it.effect("skips text/event-stream", () =>
       Effect.gen(function*() {
         const request = HttpServerRequest.fromWeb(

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -2,9 +2,12 @@ import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Logger from "effect/Logger"
 import * as References from "effect/References"
+import * as Stream from "effect/Stream"
+import * as HttpBody from "effect/unstable/http/HttpBody"
 import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware"
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest"
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse"
+import { requestPreResponseHandlers } from "effect/unstable/http/internal/preResponseHandler"
 
 describe("HttpMiddleware", () => {
   describe("logger", () => {
@@ -32,6 +35,275 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(annotations[0]?.["http.method"], "GET")
         assert.strictEqual(annotations[0]?.["http.url"], "/todos/1")
         assert.strictEqual(annotations[0]?.["http.status"], 204)
+      }))
+  })
+
+  describe("compression", () => {
+    const decompress = async (
+      bytes: globalThis.Uint8Array,
+      encoding: "gzip" | "deflate"
+    ): Promise<string> => {
+      const ds = new globalThis.DecompressionStream(encoding)
+      const writer = ds.writable.getWriter() as WritableStreamDefaultWriter<globalThis.Uint8Array>
+      void writer.write(bytes)
+      void writer.close()
+      const reader = ds.readable.getReader() as ReadableStreamDefaultReader<globalThis.Uint8Array>
+      const chunks: Array<globalThis.Uint8Array> = []
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        chunks.push(value)
+      }
+      let total = 0
+      for (const c of chunks) total += c.length
+      const out = new globalThis.Uint8Array(total)
+      let offset = 0
+      for (const c of chunks) {
+        out.set(c, offset)
+        offset += c.length
+      }
+      return new TextDecoder().decode(out)
+    }
+
+    const runCompression = (
+      request: HttpServerRequest.HttpServerRequest,
+      response: HttpServerResponse.HttpServerResponse,
+      options?: Parameters<typeof HttpMiddleware.compression>[0]
+    ) =>
+      Effect.gen(function*() {
+        yield* HttpMiddleware.compression(options)(Effect.succeed(response)).pipe(
+          Effect.provideService(HttpServerRequest.HttpServerRequest, request)
+        )
+        const handler = requestPreResponseHandlers.get(request.source)
+        assert.exists(handler, "compression should register a preResponseHandler")
+        return yield* handler!(request, response)
+      })
+
+    const largeBody = "x".repeat(2048)
+
+    it.effect("compresses Uint8Array bodies with gzip when accepted", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip, deflate" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody, { contentType: "text/plain" })
+        const compressed = yield* runCompression(request, response)
+
+        assert.strictEqual(compressed.headers["content-encoding"], "gzip")
+        assert.strictEqual(compressed.headers["vary"], "Accept-Encoding")
+        assert.strictEqual(compressed.body._tag, "Uint8Array")
+        const body = compressed.body as HttpBody.Uint8Array
+        assert.strictEqual(compressed.headers["content-length"], body.contentLength.toString())
+        assert.isBelow(body.contentLength, largeBody.length, "compressed body should be smaller")
+        const decoded = yield* Effect.promise(() => decompress(body.body, "gzip"))
+        assert.strictEqual(decoded, largeBody)
+      }))
+
+    it.effect("prefers gzip over deflate", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "deflate, gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const compressed = yield* runCompression(request, response)
+        assert.strictEqual(compressed.headers["content-encoding"], "gzip")
+      }))
+
+    it.effect("compresses Stream bodies and clears stale Content-Length", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const encoder = new TextEncoder()
+        const body = HttpBody.stream(
+          Stream.fromIterable([encoder.encode(largeBody)]),
+          "text/plain",
+          largeBody.length
+        )
+        const response = HttpServerResponse.empty().pipe(HttpServerResponse.setBody(body))
+        const compressed = yield* runCompression(request, response)
+
+        assert.strictEqual(compressed.headers["content-encoding"], "gzip")
+        assert.strictEqual(compressed.headers["content-length"], undefined)
+        assert.strictEqual(compressed.body._tag, "Stream")
+      }))
+
+    it.effect("skips when Accept-Encoding is missing", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", { method: "GET" })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+        assert.strictEqual(out.body, response.body)
+      }))
+
+    it.effect("skips when no encoding is supported", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "br" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("skips bodies smaller than threshold", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text("tiny")
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("skips non-compressible content types", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.uint8Array(
+          new TextEncoder().encode(largeBody),
+          { contentType: "image/png" }
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("skips text/event-stream", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody, { contentType: "text/event-stream" })
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("skips when response already has Content-Encoding", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody).pipe(
+          HttpServerResponse.setHeader("content-encoding", "br")
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], "br")
+      }))
+
+    it.effect("skips when Cache-Control: no-transform", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody).pipe(
+          HttpServerResponse.setHeader("cache-control", "public, no-transform")
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("skips HEAD requests", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "HEAD",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("respects user skip predicate", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/skip-me", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody)
+        const out = yield* runCompression(request, response, {
+          skip: (req) => req.url.includes("/skip-me")
+        })
+        assert.strictEqual(out.headers["content-encoding"], undefined)
+      }))
+
+    it.effect("merges Accept-Encoding into existing Vary", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody).pipe(
+          HttpServerResponse.setHeader("vary", "Origin")
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["vary"], "Origin, Accept-Encoding")
+      }))
+
+    it.effect("weakens strong ETag when compressing", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody).pipe(
+          HttpServerResponse.setHeader("etag", "\"abc123\"")
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["etag"], "W/\"abc123\"")
+      }))
+
+    it.effect("leaves weak ETag unchanged", () =>
+      Effect.gen(function*() {
+        const request = HttpServerRequest.fromWeb(
+          new Request("http://api.example.com/data", {
+            method: "GET",
+            headers: { "accept-encoding": "gzip" }
+          })
+        )
+        const response = HttpServerResponse.text(largeBody).pipe(
+          HttpServerResponse.setHeader("etag", "W/\"abc123\"")
+        )
+        const out = yield* runCompression(request, response)
+        assert.strictEqual(out.headers["etag"], "W/\"abc123\"")
       }))
   })
 })


### PR DESCRIPTION
## Summary

Adds an HTTP response compression middleware so Effect HttpApi users don't have to roll their own. Effect-smol's `HttpMiddleware` ships logging, tracing, and CORS, but no compression — Hono, Express, Fastify, and nginx all ship one.

This is platform-agnostic: it uses the Web Standard `CompressionStream` (available in Node 18+, Bun, Deno, and browser-style runtimes) instead of `node:zlib`, so it works anywhere effect-smol runs.

## What's added

- **`HttpMiddleware.compression(options?)`** — middleware that conditionally compresses response bodies with gzip or deflate.
- **`HttpRouter.compression(options?)`** — matching `Layer<never, never, HttpRouter>` registration, mirroring the `cors` pattern.
- **`HttpServerResponse.removeHeader`** — small public addition; the compression middleware uses it to clear stale `Content-Length` after swapping in a Stream body of unknown length.

### Defaults (mirroring Hono's `compress`)

- `threshold`: 1024 bytes
- `compressibleContentType`: regex covering `text/*`, common `application/*` (json/xml/javascript/wasm/…), `image/svg+xml`, `+json`/`+xml`/`+yaml`/`+text` suffixes, etc. `text/event-stream` is always excluded so SSE chunks flow immediately.
- `encodings`: `["gzip", "deflate"]` — gzip preferred when both are accepted. `br` is intentionally not included; it would need separate handling and isn't supported by `CompressionStream` everywhere.
- `skip?: (request) => boolean` — user predicate (e.g., to bypass specific paths).

### Skip conditions

- `HEAD` requests
- Response already has `Content-Encoding`
- Response has `Cache-Control: no-transform`
- Content type not in the allowlist, or is `text/event-stream`
- Known `Content-Length` < `threshold`
- Body is `Empty` / `Raw` / `FormData` (only `Uint8Array` and `Stream` are compressed)

### When compressing

- Replaces body via `Stream` (or `Uint8Array` if the original body was `Uint8Array`)
- Sets `Content-Encoding`
- Drops stale `Content-Length` for stream bodies (compressed length unknown)
- Merges `Accept-Encoding` into any existing `Vary` header (preserving e.g. `Vary: Origin` from CORS)
- Weakens strong `ETag` to `W/...`

## Test plan

15 new unit tests covering all branches:

- [x] Compresses `Uint8Array` body with gzip; round-trip decompresses correctly
- [x] Prefers gzip when both gzip and deflate are accepted
- [x] Compresses `Stream` body and clears stale `Content-Length`
- [x] Skips when `Accept-Encoding` is missing
- [x] Skips when no encoding is supported (e.g., `br` only)
- [x] Skips bodies smaller than threshold
- [x] Skips non-compressible content types (e.g., `image/png`)
- [x] Skips `text/event-stream`
- [x] Skips when response already has `Content-Encoding`
- [x] Skips when `Cache-Control: no-transform`
- [x] Skips `HEAD` requests
- [x] Respects user `skip` predicate
- [x] Merges `Accept-Encoding` into existing `Vary` header
- [x] Weakens strong `ETag` (`"abc"` → `W/"abc"`)
- [x] Leaves weak `ETag` unchanged
- [x] `pnpm check:tsgo`, `pnpm lint-fix`, `pnpm docgen`
- [x] All 107 `test/unstable/http/` tests pass
- [x] Changeset added (`minor`)

## Open questions for the maintainers

- Naming: I went with `HttpMiddleware.compression` to match the existing module style; happy to rename to `compress` if that's preferred.
- Brotli: skipped intentionally for a first cut; `CompressionStream` doesn't accept `"br"` in Node, so it would need a Node-only path. Easy follow-up.
- Configuration shape: the `compressibleContentType` option is a single `RegExp` (matching Hono). Open to making it a predicate `(contentType) => boolean` if more flexibility is wanted.