### PR TITLE
feat(httpapi): allow overriding HttpApiTest groups baseUrl

### DIFF
--- a/.changeset/real-trains-ring.md
+++ b/.changeset/real-trains-ring.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow `HttpApiTest.groups` to accept an optional `baseUrl` override while preserving the existing default of `"http://localhost:3000"`.

--- a/packages/effect/src/unstable/httpapi/HttpApiTest.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiTest.ts
@@ -31,7 +31,10 @@ export const groups = Effect.fnUntraced(function*<
   SelectedGroups = HttpApiGroup.WithName<Groups, Names[number]>
 >(
   api: HttpApi.HttpApi<ApiId, Groups>,
-  groupNames: Names
+  groupNames: Names,
+  options?: {
+    readonly baseUrl?: string | URL | undefined
+  }
 ): Effect.fn.Return<
   HttpApiClient.Client<Groups>,
   never,
@@ -90,6 +93,6 @@ export const groups = Effect.fnUntraced(function*<
 
   return yield* HttpApiClient.makeWith(api, {
     httpClient,
-    baseUrl: "http://localhost:3000"
+    baseUrl: options?.baseUrl ?? "http://localhost:3000"
   })
 })


### PR DESCRIPTION
### Motivation
- Enable tests to override the default `baseUrl` used by the HTTP test client while preserving the existing default of `"http://localhost:3000"`.

### Description
- Add an optional `options` parameter with `baseUrl?: string | URL` to `HttpApiTest.groups` and pass it to `HttpApiClient.makeWith`, and add a `.changeset/real-trains-ring.md` entry describing the patch.

### Testing
- Ran the project's type check and existing automated test suite; all checks and tests passed.