### PR TITLE
fix(schema): preserve symbol link of obj made by Schema Struct, enable VSCode "Go to definitions"(F12) jump

### DIFF
--- a/.changeset/floppy-items-admire.md
+++ b/.changeset/floppy-items-admire.md
@@ -1,5 +1,5 @@
 ---
-"effect": major
+"effect": patch
 ---
 
 Change `Type_<>` implementation, from using `Exclude<F, O | M>` type util to `keyof F as xx`, this implementation keeps IDE provenance link. This enables clicking "Go to definition (F12)" in VSCode on an object made from Schema Struct jumps to the correct Struct field definition.

--- a/.changeset/floppy-items-admire.md
+++ b/.changeset/floppy-items-admire.md
@@ -1,0 +1,5 @@
+---
+"effect": major
+---
+
+Change `Type_<>` implementation, from using `Exclude<F, O | M>` type util to `keyof F as xx`, this implementation keeps IDE provenance link. This enables clicking "Go to definition (F12)" in VSCode on an object made from Schema Struct jumps to the correct Struct field definition.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2298,10 +2298,10 @@ export declare namespace Struct {
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
   > =
-    & { readonly [K in Exclude<keyof F, M | O>]: F[K]["Type"] }
-    & { readonly [K in Exclude<O, M>]?: F[K]["Type"] }
-    & { [K in Exclude<M, O>]: F[K]["Type"] }
-    & { [K in M & O]?: F[K]["Type"] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Type'] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Type'] }
+    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Type'] }
+    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Type'] }
 
   /**
    * @since 4.0.0
@@ -2313,10 +2313,10 @@ export declare namespace Struct {
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
   > =
-    & { readonly [K in Exclude<keyof F, M | O>]: F[K]["Iso"] }
-    & { readonly [K in Exclude<O, M>]?: F[K]["Iso"] }
-    & { [K in Exclude<M, O>]: F[K]["Iso"] }
-    & { [K in M & O]?: F[K]["Iso"] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Iso'] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Iso'] }
+    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Iso'] }
+    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Iso'] }
 
   /**
    * @since 4.0.0
@@ -2338,10 +2338,10 @@ export declare namespace Struct {
     O extends keyof F = EncodedOptionalKeys<F>,
     M extends keyof F = EncodedMutableKeys<F>
   > =
-    & { readonly [K in Exclude<keyof F, M | O>]: F[K]["Encoded"] }
-    & { readonly [K in Exclude<O, M>]?: F[K]["Encoded"] }
-    & { [K in Exclude<M, O>]: F[K]["Encoded"] }
-    & { [K in M & O]?: F[K]["Encoded"] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Encoded'] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Encoded'] }
+    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Encoded'] }
+    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Encoded'] }
 
   /**
    * @since 4.0.0
@@ -10738,13 +10738,14 @@ export const TaggedClass: {
     schema: Struct.Fields | Struct<Struct.Fields>,
     annotations?: Annotations.Declaration<any, readonly [Struct<Struct.Fields>]>
   ): any => {
-    return Class<any, {}>(identifier ?? tagValue)(
-      isStruct(schema) ?
+    const struct = isStruct(schema) ?
         schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
           unsafePreserveChecks: true
         }) :
-        TaggedStruct(tagValue, schema),
-      annotations
+        TaggedStruct(tagValue, schema)
+    return Class<any, {}>(identifier ?? tagValue)(
+      struct,
+      annotations as Annotations.Declaration<any, readonly [typeof struct]>
     )
   }
 }
@@ -10850,13 +10851,14 @@ export const TaggedErrorClass: {
     schema: Struct.Fields | Struct<Struct.Fields>,
     annotations?: Annotations.Declaration<any, readonly [Struct<Struct.Fields>]>
   ): any => {
-    return ErrorClass<any, {}>(identifier ?? tagValue)(
-      isStruct(schema) ?
+    const struct = isStruct(schema) ?
         schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
           unsafePreserveChecks: true
         }) :
-        TaggedStruct(tagValue, schema),
-      annotations
+        TaggedStruct(tagValue, schema)
+    return ErrorClass<any, {}>(identifier ?? tagValue)(
+      struct,
+      annotations as Annotations.Declaration<any, readonly [typeof struct]>
     )
   }
 }

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -2298,10 +2298,10 @@ export declare namespace Struct {
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
   > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Type'] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Type'] }
-    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Type'] }
-    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Type'] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Type"] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Type"] }
+    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Type"] }
+    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Type"] }
 
   /**
    * @since 4.0.0
@@ -2313,10 +2313,10 @@ export declare namespace Struct {
     O extends keyof F = TypeOptionalKeys<F>,
     M extends keyof F = TypeMutableKeys<F>
   > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Iso'] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Iso'] }
-    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Iso'] }
-    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Iso'] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Iso"] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Iso"] }
+    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Iso"] }
+    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Iso"] }
 
   /**
    * @since 4.0.0
@@ -2338,10 +2338,10 @@ export declare namespace Struct {
     O extends keyof F = EncodedOptionalKeys<F>,
     M extends keyof F = EncodedMutableKeys<F>
   > =
-    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]['Encoded'] }
-    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]['Encoded'] }
-    & {-readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]['Encoded'] }
-    & {-readonly [K in keyof F as K extends M & O ? K : never]?: F[K]['Encoded'] }
+    & { readonly [K in keyof F as K extends M | O ? never : K]: F[K]["Encoded"] }
+    & { readonly [K in keyof F as K extends O ? K extends M ? never : K : never]?: F[K]["Encoded"] }
+    & { -readonly [K in keyof F as K extends M ? K extends O ? never : K : never]: F[K]["Encoded"] }
+    & { -readonly [K in keyof F as K extends M & O ? K : never]?: F[K]["Encoded"] }
 
   /**
    * @since 4.0.0
@@ -10739,10 +10739,10 @@ export const TaggedClass: {
     annotations?: Annotations.Declaration<any, readonly [Struct<Struct.Fields>]>
   ): any => {
     const struct = isStruct(schema) ?
-        schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
-          unsafePreserveChecks: true
-        }) :
-        TaggedStruct(tagValue, schema)
+      schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
+        unsafePreserveChecks: true
+      }) :
+      TaggedStruct(tagValue, schema)
     return Class<any, {}>(identifier ?? tagValue)(
       struct,
       annotations as Annotations.Declaration<any, readonly [typeof struct]>
@@ -10852,10 +10852,10 @@ export const TaggedErrorClass: {
     annotations?: Annotations.Declaration<any, readonly [Struct<Struct.Fields>]>
   ): any => {
     const struct = isStruct(schema) ?
-        schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
-          unsafePreserveChecks: true
-        }) :
-        TaggedStruct(tagValue, schema)
+      schema.mapFields((fields) => ({ _tag: tag(tagValue), ...fields }), {
+        unsafePreserveChecks: true
+      }) :
+      TaggedStruct(tagValue, schema)
     return ErrorClass<any, {}>(identifier ?? tagValue)(
       struct,
       annotations as Annotations.Declaration<any, readonly [typeof struct]>


### PR DESCRIPTION
## Type
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Change `Type_<>` implementation, from using `Exclude<F, O | M>` type util to `keyof F as xx`. 

This keeps IDE provenance link andenables clicking "Go to definition (F12)" in VSCode on an object made from Schema Struct jumps to the correct Struct field definition. `keyof` is a must because this ensures all field keys are derived from input thus holds the correct reference.

Also Fixed type error of `TaggedClass` and `TaggedErrorClass` that appears after the above change applied.

There is another PR #1862 mentioned this fix but no further response. But implementation in this PR seems more straight forward and can be another option.

## Related

- Closes #2141 
