### PR TITLE
EFF-802 Remove HTTP server log span counter

### DIFF
--- a/.changeset/remove-http-span-counter.md
+++ b/.changeset/remove-http-span-counter.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove the auto-incrementing suffix from HTTP server logger log span names.

--- a/packages/effect/HTTPAPI.md
+++ b/packages/effect/HTTPAPI.md
@@ -197,7 +197,7 @@ Effect.runFork(program.pipe(Effect.provide(FetchHttpClient.layer)))
 /*
 Output:
 [18:55:26.051] INFO (#2): Listening on http://0.0.0.0:3000
-[18:55:26.057] INFO (#12) http.span.1=2ms: Sent HTTP response { 'http.method': 'GET', 'http.url': '/', 'http.status': 200 }
+[18:55:26.057] INFO (#12) http.span=2ms: Sent HTTP response { 'http.method': 'GET', 'http.url': '/', 'http.status': 200 }
 Hello, World!
 */
 ```
@@ -3094,7 +3094,7 @@ Effect.runFork(program.pipe(Effect.provide(FetchHttpClient.layer)))
 /*
 Output:
 [18:55:26.051] INFO (#2): Listening on http://0.0.0.0:3000
-[18:55:26.057] INFO (#12) http.span.1=2ms: Sent HTTP response { 'http.method': 'GET', 'http.url': '/', 'http.status': 200 }
+[18:55:26.057] INFO (#12) http.span=2ms: Sent HTTP response { 'http.method': 'GET', 'http.url': '/', 'http.status': 200 }
 Hello, World!
 */
 ```

--- a/packages/effect/src/unstable/http/HttpMiddleware.ts
+++ b/packages/effect/src/unstable/http/HttpMiddleware.ts
@@ -105,9 +105,8 @@ export const SpanNameGenerator = Context.Reference<(request: HttpServerRequest) 
  */
 export const logger: <E, R>(
   httpApp: Effect.Effect<HttpServerResponse, E, HttpServerRequest | R>
-) => Effect.Effect<HttpServerResponse, E, HttpServerRequest | R> = make((httpApp) => {
-  let counter = 0
-  return Effect.withFiber((fiber) => {
+) => Effect.Effect<HttpServerResponse, E, HttpServerRequest | R> = make((httpApp) =>
+  Effect.withFiber((fiber) => {
     const request = Context.getUnsafe(fiber.context, HttpServerRequest)
     const path = stripSearchAndHash(request.url)
     return Effect.withLogSpan(
@@ -134,10 +133,10 @@ export const logger: <E, R>(
           exit
         )
       }),
-      `http.span.${++counter}`
+      "http.span"
     )
   })
-})
+)
 
 /**
  * @since 4.0.0

--- a/packages/effect/test/unstable/http/HttpMiddleware.test.ts
+++ b/packages/effect/test/unstable/http/HttpMiddleware.test.ts
@@ -33,5 +33,25 @@ describe("HttpMiddleware", () => {
         assert.strictEqual(annotations[0]?.["http.url"], "/todos/1")
         assert.strictEqual(annotations[0]?.["http.status"], 204)
       }))
+
+    it.effect("uses a stable http.span log span name", () =>
+      Effect.gen(function*() {
+        const spans: Array<Array<string>> = []
+        const logger = Logger.make<unknown, void>((options) => {
+          spans.push(options.fiber.getRef(References.CurrentLogSpans).map(([label]) => label))
+        })
+
+        const loggedApp = HttpMiddleware.logger(
+          Effect.succeed(HttpServerResponse.empty({ status: 204 }))
+        ).pipe(Effect.provide(Logger.layer([logger])))
+
+        const request1 = HttpServerRequest.fromWeb(new Request("http://localhost:3000/one"))
+        const request2 = HttpServerRequest.fromWeb(new Request("http://localhost:3000/two"))
+
+        yield* loggedApp.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request1))
+        yield* loggedApp.pipe(Effect.provideService(HttpServerRequest.HttpServerRequest, request2))
+
+        assert.deepStrictEqual(spans, [["http.span"], ["http.span"]])
+      }))
   })
 })


### PR DESCRIPTION
## Summary
- Removed the auto-incrementing suffix from HTTP server logger log span names so requests emit `http.span` instead of `http.span.N`.
- Added regression coverage for repeated HTTP logger requests using a stable log span label.
- Updated HTTP API documentation examples and added a changeset.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/http/HttpMiddleware.test.ts`
- `pnpm check:tsgo`
- `cd packages/effect && pnpm docgen`