### PR TITLE
Fix RpcServer HTTP finalizer request IDs

### DIFF
--- a/.changeset/fix-rpc-http-requestids-finalizer.md
+++ b/.changeset/fix-rpc-http-requestids-finalizer.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix request ID tracking in the RPC server HTTP protocol finalizer.

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -961,6 +961,7 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
     const id = clientId++
     const queue = yield* Queue.make<Uint8Array | FromServerEncoded, Cause.Done>()
     const parser = serialization.makeUnsafe()
+    const requestIds: Array<RequestId> = []
 
     const offer = (data: Uint8Array | string) =>
       typeof data === "string" ? Queue.offer(queue, encoder.encode(data)) : Queue.offer(queue, data)
@@ -992,8 +993,6 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
     })
     clients.set(id, client)
     clientIds.add(id)
-
-    const requestIds: Array<RequestId> = []
 
     // @effect-diagnostics-next-line tryCatchInEffectGen:off
     try {


### PR DESCRIPTION
## Summary
- Move `requestIds` initialization before the HTTP protocol request finalizer closes over it.
- Prevent an early request-scope finalizer from throwing a temporal dead zone error before request decoding starts.

## Context
While using `RpcServer.toHttpEffect(...)` with JSON-RPC in a Cloudflare Worker runtime, the request scope finalizer can run before the generator reaches the later `requestIds` declaration. In the built output this surfaced as `Cannot access 'oe' before initialization`.
