### PR TITLE
Fix RpcServer toHttpEffect lifetime

### DIFF
--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -980,6 +980,9 @@ export const makeProtocolWithHttpEffect: Effect.Effect<
     }
 
     yield* Scope.addFinalizerExit(scope, () => {
+      if (!includesFraming) {
+        return Effect.void
+      }
       clients.delete(id)
       clientIds.delete(id)
       Queue.offerUnsafe(disconnects, id)
@@ -1135,7 +1138,7 @@ export const toHttpEffect: <Rpcs extends Rpc.Any>(
   const { httpEffect, protocol } = yield* makeProtocolWithHttpEffect
   yield* make(group, options).pipe(
     Effect.provideService(Protocol, protocol),
-    Effect.forkScoped
+    Effect.forkDetach({ startImmediately: true })
   )
   // @effect-diagnostics-next-line returnEffectInGen:off
   return httpEffect

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -1,0 +1,43 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { HttpEffect } from "effect/unstable/http"
+import { Rpc, RpcGroup, RpcSerialization, RpcServer } from "effect/unstable/rpc"
+
+const TestGroup = RpcGroup.make(
+  Rpc.make("Ping", { success: Schema.String })
+)
+
+describe("RpcServer", () => {
+  it.effect("toHttpEffect keeps non-framed json-rpc server alive outside construction scope", () =>
+    Effect.gen(function*() {
+      const httpEffect = yield* RpcServer.toHttpEffect(TestGroup).pipe(
+        Effect.provide(TestGroup.toLayer({
+          Ping: () => Effect.succeed("pong")
+        })),
+        Effect.provideService(RpcSerialization.RpcSerialization, RpcSerialization.jsonRpc()),
+        Effect.scoped
+      )
+
+      const handler = HttpEffect.toWebHandler(httpEffect)
+      const response = yield* Effect.promise(() =>
+        handler(
+          new Request("http://localhost/rpc", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "Ping"
+            })
+          })
+        )
+      )
+
+      assert.strictEqual(response.status, 200)
+      assert.deepStrictEqual(yield* Effect.promise(() => response.json()), {
+        jsonrpc: "2.0",
+        id: 1,
+        result: "pong"
+      })
+    }).pipe(Effect.timeout("2 seconds")))
+})


### PR DESCRIPTION
## Summary
- Detach the `toHttpEffect` server loop from the ambient scope so the returned HTTP effect can be used after construction scope cleanup.
- Keep non-framed HTTP clients registered until the server loop writes `Exit` and `ClientEnd`, allowing `Queue.collect` to finish.
- Add a regression test for non-framed JSON-RPC where `toHttpEffect` is constructed in a short-lived scope before handling a request.

## Context
A downstream Cloudflare Worker setup using Alchemy constructs `RpcServer.toHttpEffect(...)` for `RpcSerialization.jsonRpc()`. After fixing the separate finalizer `requestIds` TDZ crash, the official adapter decoded the request and sent EOF, then hung in the non-framed `Queue.collect` path until workerd canceled the request. Runtime logs showed the server loop never emitted `Exit`/`ClientEnd` before the ambient request scope finalized.

This change makes `toHttpEffect` own the server loop lifetime independently of the construction scope and avoids treating non-framed one-shot HTTP requests as disconnects before their collected response is produced.

## Test plan
- `pnpm vitest run packages/effect/test/rpc/RpcServer.test.ts`
- `pnpm --filter effect check`