### PR TITLE
feat(Schema): allow decoding defaults to require services

### DIFF
--- a/.changeset/schema-decoding-defaults-services.md
+++ b/.changeset/schema-decoding-defaults-services.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Allow Schema decoding defaults to require Effect services.
+
+The `Effect` passed to `Schema.withDecodingDefault`, `Schema.withDecodingDefaultKey`, `Schema.withDecodingDefaultType`, and `Schema.withDecodingDefaultTypeKey` now accepts a context `R` in its third type parameter. The required services are propagated into the resulting schema's `DecodingServices`. `SchemaGetter.withDefault` is widened in the same way.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -4319,8 +4319,8 @@ export function withConstructorDefault<S extends Top & WithoutConstructorDefault
  * @see {@link withDecodingDefaultKey} for the constructor
  * @since 4.0.0
  */
-export interface withDecodingDefaultKey<S extends Top> extends decodeTo<S, optionalKey<toEncoded<S>>> {
-  readonly "Rebuild": withDecodingDefaultKey<S>
+export interface withDecodingDefaultKey<S extends Top, R = never> extends decodeTo<S, optionalKey<toEncoded<S>>, R> {
+  readonly "Rebuild": withDecodingDefaultKey<S, R>
 }
 
 /**
@@ -4367,12 +4367,12 @@ export type DecodingDefaultOptions = {
  * @see {@link withDecodingDefaultTypeKey} for the variant where the default is a `Type` value
  * @since 4.0.0
  */
-export function withDecodingDefaultKey<S extends Top>(
-  defaultValue: Effect.Effect<S["Encoded"], SchemaError>,
+export function withDecodingDefaultKey<S extends Top, R = never>(
+  defaultValue: Effect.Effect<S["Encoded"], SchemaError, R>,
   options?: DecodingDefaultOptions
 ) {
   const encode = options?.encodingStrategy === "omit" ? Getter.omit() : Getter.passthrough()
-  return (self: S): withDecodingDefaultKey<S> => {
+  return (self: S): withDecodingDefaultKey<S, R> => {
     return optionalKey(toEncoded(self)).pipe(decodeTo(self, {
       decode: Getter.withDefault(Effect.mapErrorEager(defaultValue, (e) => e.issue)),
       encode
@@ -4388,10 +4388,10 @@ export function withDecodingDefaultKey<S extends Top>(
  * @see {@link withDecodingDefaultTypeKey} for the constructor
  * @since 4.0.0
  */
-export interface withDecodingDefaultTypeKey<S extends Top>
-  extends decodeTo<withDecodingDefaultKey<toType<S>>, optionalKey<S>>
+export interface withDecodingDefaultTypeKey<S extends Top, R = never>
+  extends decodeTo<withDecodingDefaultKey<toType<S>, R>, optionalKey<S>>
 {
-  readonly "Rebuild": withDecodingDefaultTypeKey<S>
+  readonly "Rebuild": withDecodingDefaultTypeKey<S, R>
 }
 
 /**
@@ -4413,13 +4413,13 @@ export interface withDecodingDefaultTypeKey<S extends Top>
  * @see {@link withDecodingDefaultType} for the value-level variant
  * @since 4.0.0
  */
-export function withDecodingDefaultTypeKey<S extends Top>(
-  defaultValue: Effect.Effect<S["Type"], SchemaError>,
+export function withDecodingDefaultTypeKey<S extends Top, R = never>(
+  defaultValue: Effect.Effect<S["Type"], SchemaError, R>,
   options?: DecodingDefaultOptions
 ) {
-  return (self: S): withDecodingDefaultTypeKey<S> => {
+  return (self: S): withDecodingDefaultTypeKey<S, R> => {
     return toType(self).pipe(
-      withDecodingDefaultKey<toType<S>>(defaultValue, options),
+      withDecodingDefaultKey<toType<S>, R>(defaultValue, options),
       encodeTo(optionalKey(self))
     )
   }
@@ -4432,8 +4432,8 @@ export function withDecodingDefaultTypeKey<S extends Top>(
  * @see {@link withDecodingDefault} for the constructor
  * @since 4.0.0
  */
-export interface withDecodingDefault<S extends Top> extends decodeTo<S, optional<toEncoded<S>>> {
-  readonly "Rebuild": withDecodingDefault<S>
+export interface withDecodingDefault<S extends Top, R = never> extends decodeTo<S, optional<toEncoded<S>>, R> {
+  readonly "Rebuild": withDecodingDefault<S, R>
 }
 
 /**
@@ -4467,12 +4467,12 @@ export interface withDecodingDefault<S extends Top> extends decodeTo<S, optional
  * @see {@link withDecodingDefaultType} for the variant where the default is a `Type` value
  * @since 4.0.0
  */
-export function withDecodingDefault<S extends Top>(
-  defaultValue: Effect.Effect<S["Encoded"], SchemaError>,
+export function withDecodingDefault<S extends Top, R = never>(
+  defaultValue: Effect.Effect<S["Encoded"], SchemaError, R>,
   options?: DecodingDefaultOptions
 ) {
   const encode = options?.encodingStrategy === "omit" ? Getter.omit() : Getter.passthrough()
-  return (self: S): withDecodingDefault<S> => {
+  return (self: S): withDecodingDefault<S, R> => {
     return optional(toEncoded(self)).pipe(decodeTo(self, {
       decode: Getter.withDefault(Effect.mapErrorEager(defaultValue, (e) => e.issue)),
       encode
@@ -4488,8 +4488,10 @@ export function withDecodingDefault<S extends Top>(
  * @see {@link withDecodingDefaultType} for the constructor
  * @since 4.0.0
  */
-export interface withDecodingDefaultType<S extends Top> extends decodeTo<withDecodingDefault<toType<S>>, optional<S>> {
-  readonly "Rebuild": withDecodingDefaultType<S>
+export interface withDecodingDefaultType<S extends Top, R = never>
+  extends decodeTo<withDecodingDefault<toType<S>, R>, optional<S>>
+{
+  readonly "Rebuild": withDecodingDefaultType<S, R>
 }
 
 /**
@@ -4511,13 +4513,13 @@ export interface withDecodingDefaultType<S extends Top> extends decodeTo<withDec
  * @see {@link withDecodingDefaultTypeKey} for the key-level variant
  * @since 4.0.0
  */
-export function withDecodingDefaultType<S extends Top>(
-  defaultValue: Effect.Effect<S["Type"], SchemaError>,
+export function withDecodingDefaultType<S extends Top, R = never>(
+  defaultValue: Effect.Effect<S["Type"], SchemaError, R>,
   options?: DecodingDefaultOptions
 ) {
-  return (self: S): withDecodingDefaultType<S> => {
+  return (self: S): withDecodingDefaultType<S, R> => {
     return toType(self).pipe(
-      withDecodingDefault<toType<S>>(defaultValue, options),
+      withDecodingDefault<toType<S>, R>(defaultValue, options),
       encodeTo(optional(self))
     )
   }

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -689,7 +689,9 @@ export function omit<T>(): Getter<never, T> {
  * @category Constructors
  * @since 4.0.0
  */
-export function withDefault<T>(defaultValue: Effect.Effect<T, Issue.Issue>): Getter<T, T | undefined> {
+export function withDefault<T, R = never>(
+  defaultValue: Effect.Effect<T, Issue.Issue, R>
+): Getter<T, T | undefined, R> {
   return new Getter((o) => {
     const filtered = Option.filter(o, Predicate.isNotUndefined)
     return Option.isSome(filtered) ? Effect.succeed(filtered) : Effect.mapEager(defaultValue, Option.some)

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -7692,6 +7692,24 @@ pointed message
   at ["a"]`
       )
     })
+
+    it("default Effect can require a service", async () => {
+      class Service extends Context.Service<Service, { fallback: Effect.Effect<string> }>()("Service") {}
+
+      const schema = Schema.Struct({
+        a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultKey(
+          Effect.gen(function*() {
+            const service = yield* Service
+            return yield* service.fallback
+          })
+        ))
+      })
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding().provide(Service, { fallback: Effect.succeed("3") })
+      await decoding.succeed({ a: "2" }, { a: 2 })
+      await decoding.succeed({}, { a: 3 })
+    })
   })
 
   describe("withDecodingDefault", () => {
@@ -7750,6 +7768,25 @@ pointed message
       await decoding.succeed({ a: undefined }, { a: { b: 1 } })
       await decoding.succeed({ a: { b: undefined } }, { a: { b: 1 } })
       await decoding.succeed({ a: { b: "2" } }, { a: { b: 2 } })
+    })
+
+    it("default Effect can require a service", async () => {
+      class Service extends Context.Service<Service, { fallback: Effect.Effect<string> }>()("Service") {}
+
+      const schema = Schema.Struct({
+        a: Schema.FiniteFromString.pipe(Schema.withDecodingDefault(
+          Effect.gen(function*() {
+            const service = yield* Service
+            return yield* service.fallback
+          })
+        ))
+      })
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding().provide(Service, { fallback: Effect.succeed("3") })
+      await decoding.succeed({ a: "2" }, { a: 2 })
+      await decoding.succeed({}, { a: 3 })
+      await decoding.succeed({ a: undefined }, { a: 3 })
     })
   })
 
@@ -7828,6 +7865,24 @@ pointed message
         `decoding default failed
   at ["a"]`
       )
+    })
+
+    it("default Effect can require a service", async () => {
+      class Service extends Context.Service<Service, { fallback: Effect.Effect<number> }>()("Service") {}
+
+      const schema = Schema.Struct({
+        a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultTypeKey(
+          Effect.gen(function*() {
+            const service = yield* Service
+            return yield* service.fallback
+          })
+        ))
+      })
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding().provide(Service, { fallback: Effect.succeed(3) })
+      await decoding.succeed({ a: "2" }, { a: 2 })
+      await decoding.succeed({}, { a: 3 })
     })
   })
 
@@ -7908,6 +7963,25 @@ pointed message
         `decoding default failed
   at ["a"]`
       )
+    })
+
+    it("default Effect can require a service", async () => {
+      class Service extends Context.Service<Service, { fallback: Effect.Effect<number> }>()("Service") {}
+
+      const schema = Schema.Struct({
+        a: Schema.FiniteFromString.pipe(Schema.withDecodingDefaultType(
+          Effect.gen(function*() {
+            const service = yield* Service
+            return yield* service.fallback
+          })
+        ))
+      })
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding().provide(Service, { fallback: Effect.succeed(3) })
+      await decoding.succeed({ a: "2" }, { a: 2 })
+      await decoding.succeed({}, { a: 3 })
+      await decoding.succeed({ a: undefined }, { a: 3 })
     })
   })
 


### PR DESCRIPTION
Widen the `Effect` passed to `Schema.withDecodingDefault`, `Schema.withDecodingDefaultKey`, `Schema.withDecodingDefaultType`, and `Schema.withDecodingDefaultTypeKey` (and the underlying `SchemaGetter.withDefault`) to accept a context `R` in its third type parameter. The required services are propagated into the resulting schema's `DecodingServices`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
