### PR TITLE
fix(vitest): isolate nested layer memoization

### DIFF
--- a/.changeset/forked-memo-maps.md
+++ b/.changeset/forked-memo-maps.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/vitest": patch
+---
+
+Add forked memo maps so nested layer scopes can reuse parent allocations without leaking sibling-local layers. Update `@effect/vitest` to fork memo maps for nested `it.layer` suites, isolating sibling setup while preserving parent sharing.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ scratchpad/**/*
 
 # Codex
 .agents/
+
+# OpenCode local tooling
+.opencode/

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -174,6 +174,12 @@ export interface MemoMap {
   ) => Effect<Context.Context<ROut>, E, RIn>
 }
 
+type MemoMapEntry = {
+  observers: number
+  effect: Effect<Context.Context<any>, any>
+  readonly finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect<void>
+}
+
 /**
  * Returns `true` if the specified value is a `Layer`, `false` otherwise.
  *
@@ -298,53 +304,88 @@ export const fromBuildMemo = <ROut, E, RIn>(
   return self
 }
 
-class MemoMapImpl implements MemoMap {
+abstract class MemoMapBase implements MemoMap {
   get [MemoMapTypeId](): typeof MemoMapTypeId {
     return MemoMapTypeId
   }
 
-  readonly map = new Map<Layer<any, any, any>, {
-    observers: number
-    effect: Effect<Context.Context<any>, any>
-    readonly finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect<void>
-  }>()
+  abstract getOrElseMemoize<RIn, E, ROut>(
+    layer: Layer<ROut, E, RIn>,
+    scope: Scope.Scope,
+    build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
+  ): Effect<Context.Context<ROut>, E, RIn>
+
+  abstract unsafeGet(layer: Layer<any, any, any>): MemoMapEntry | undefined
+}
+
+const memoMapGet = (
+  memoMap: MemoMap,
+  layer: Layer<any, any, any>
+): MemoMapEntry | undefined => memoMap instanceof MemoMapBase ? memoMap.unsafeGet(layer) : undefined
+
+const memoMapBuild = <RIn, E, ROut>(
+  memoMap: MemoMap,
+  layer: Layer<ROut, E, RIn>,
+  scope: Scope.Scope,
+  build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
+): Effect<Context.Context<ROut>, E, RIn> => {
+  const layerScope = Scope.makeUnsafe()
+  const deferred = Deferred.makeUnsafe<Context.Context<ROut>, E>()
+  const entry: MemoMapEntry = {
+    observers: 1,
+    effect: Deferred.await(deferred),
+    finalizer: (exit: Exit.Exit<unknown, unknown>) =>
+      internalEffect.suspend(() => {
+        entry.observers--
+        if (entry.observers === 0) {
+          if (memoMap instanceof MemoMapImpl) {
+            memoMap.map.delete(layer)
+          }
+          return Scope.close(layerScope, exit)
+        }
+        return internalEffect.void
+      })
+  }
+  if (memoMap instanceof MemoMapImpl) {
+    memoMap.map.set(layer, entry)
+  }
+  return internalEffect.scopeAddFinalizerExit(scope, entry.finalizer).pipe(
+    internalEffect.flatMap(() => build(memoMap, layerScope)),
+    internalEffect.onExit((exit) => {
+      entry.effect = exit
+      return Deferred.done(deferred, exit)
+    })
+  )
+}
+
+class MemoMapImpl extends MemoMapBase {
+  readonly parent: MemoMap | undefined
+
+  constructor(parent?: MemoMap) {
+    super()
+    this.parent = parent
+  }
+
+  readonly map = new Map<Layer<any, any, any>, MemoMapEntry>()
+
+  unsafeGet(layer: Layer<any, any, any>): MemoMapEntry | undefined {
+    return this.map.get(layer) ?? (this.parent ? memoMapGet(this.parent, layer) : undefined)
+  }
 
   getOrElseMemoize<RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
     scope: Scope.Scope,
     build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
   ): Effect<Context.Context<ROut>, E, RIn> {
-    if (this.map.has(layer)) {
-      const entry = this.map.get(layer)!
+    const entry = this.unsafeGet(layer)
+    if (entry) {
       entry.observers++
       return internalEffect.andThen(
         internalEffect.scopeAddFinalizerExit(scope, (exit) => entry.finalizer(exit)),
         entry.effect
       )
     }
-    const layerScope = Scope.makeUnsafe()
-    const deferred = Deferred.makeUnsafe<Context.Context<ROut>, E>()
-    const entry = {
-      observers: 1,
-      effect: Deferred.await(deferred),
-      finalizer: (exit: Exit.Exit<unknown, unknown>) =>
-        internalEffect.suspend(() => {
-          entry.observers--
-          if (entry.observers === 0) {
-            this.map.delete(layer)
-            return Scope.close(layerScope, exit)
-          }
-          return internalEffect.void
-        })
-    }
-    this.map.set(layer, entry)
-    return internalEffect.scopeAddFinalizerExit(scope, entry.finalizer).pipe(
-      internalEffect.flatMap(() => build(this, layerScope)),
-      internalEffect.onExit((exit) => {
-        entry.effect = exit
-        return Deferred.done(deferred, exit)
-      })
-    )
+    return memoMapBuild(this, layer, scope, build)
   }
 }
 
@@ -379,6 +420,15 @@ class MemoMapImpl implements MemoMap {
 export const makeMemoMapUnsafe = (): MemoMap => new MemoMapImpl()
 
 /**
+ * Constructs a child `MemoMap` that can reuse layers already memoized in the
+ * parent while isolating any new layer allocations to the child map.
+ *
+ * @since 4.0.0
+ * @category memo map
+ */
+export const forkMemoMapUnsafe = (parent: MemoMap): MemoMap => new MemoMapImpl(parent)
+
+/**
  * Constructs a `MemoMap` that can be used to build additional layers.
  *
  * @example
@@ -407,6 +457,15 @@ export const makeMemoMapUnsafe = (): MemoMap => new MemoMapImpl()
  * @category memo map
  */
 export const makeMemoMap: Effect<MemoMap> = internalEffect.sync(makeMemoMapUnsafe)
+
+/**
+ * Constructs a child `MemoMap` that can reuse layers already memoized in the
+ * parent while isolating any new layer allocations to the child map.
+ *
+ * @since 4.0.0
+ * @category memo map
+ */
+export const forkMemoMap = (parent: MemoMap): Effect<MemoMap> => internalEffect.sync(() => forkMemoMapUnsafe(parent))
 
 /**
  * A service reference for the current `MemoMap` used in layer construction.

--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -167,6 +167,10 @@ const MemoMapTypeId = "~effect/Layer/MemoMap"
  */
 export interface MemoMap {
   readonly [MemoMapTypeId]: typeof MemoMapTypeId
+  readonly get: <RIn, E, ROut>(
+    layer: Layer<ROut, E, RIn>,
+    scope: Scope.Scope
+  ) => Effect<Context.Context<ROut>, E, RIn> | undefined
   readonly getOrElseMemoize: <RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
     scope: Scope.Scope,
@@ -178,6 +182,17 @@ type MemoMapEntry = {
   observers: number
   effect: Effect<Context.Context<any>, any>
   readonly finalizer: (exit: Exit.Exit<unknown, unknown>) => Effect<void>
+}
+
+const memoMapReuse = <RIn, E, ROut>(
+  entry: MemoMapEntry,
+  scope: Scope.Scope
+): Effect<Context.Context<ROut>, E, RIn> => {
+  entry.observers++
+  return internalEffect.andThen(
+    internalEffect.scopeAddFinalizerExit(scope, (exit) => entry.finalizer(exit)),
+    entry.effect
+  )
 }
 
 /**
@@ -304,27 +319,8 @@ export const fromBuildMemo = <ROut, E, RIn>(
   return self
 }
 
-abstract class MemoMapBase implements MemoMap {
-  get [MemoMapTypeId](): typeof MemoMapTypeId {
-    return MemoMapTypeId
-  }
-
-  abstract getOrElseMemoize<RIn, E, ROut>(
-    layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope,
-    build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
-  ): Effect<Context.Context<ROut>, E, RIn>
-
-  abstract unsafeGet(layer: Layer<any, any, any>): MemoMapEntry | undefined
-}
-
-const memoMapGet = (
-  memoMap: MemoMap,
-  layer: Layer<any, any, any>
-): MemoMapEntry | undefined => memoMap instanceof MemoMapBase ? memoMap.unsafeGet(layer) : undefined
-
 const memoMapBuild = <RIn, E, ROut>(
-  memoMap: MemoMap,
+  memoMap: MemoMapImpl,
   layer: Layer<ROut, E, RIn>,
   scope: Scope.Scope,
   build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
@@ -338,17 +334,13 @@ const memoMapBuild = <RIn, E, ROut>(
       internalEffect.suspend(() => {
         entry.observers--
         if (entry.observers === 0) {
-          if (memoMap instanceof MemoMapImpl) {
-            memoMap.map.delete(layer)
-          }
+          memoMap.map.delete(layer)
           return Scope.close(layerScope, exit)
         }
         return internalEffect.void
       })
   }
-  if (memoMap instanceof MemoMapImpl) {
-    memoMap.map.set(layer, entry)
-  }
+  memoMap.map.set(layer, entry)
   return internalEffect.scopeAddFinalizerExit(scope, entry.finalizer).pipe(
     internalEffect.flatMap(() => build(memoMap, layerScope)),
     internalEffect.onExit((exit) => {
@@ -358,18 +350,28 @@ const memoMapBuild = <RIn, E, ROut>(
   )
 }
 
-class MemoMapImpl extends MemoMapBase {
+class MemoMapImpl implements MemoMap {
+  get [MemoMapTypeId](): typeof MemoMapTypeId {
+    return MemoMapTypeId
+  }
+
   readonly parent: MemoMap | undefined
 
   constructor(parent?: MemoMap) {
-    super()
     this.parent = parent
   }
 
   readonly map = new Map<Layer<any, any, any>, MemoMapEntry>()
 
-  unsafeGet(layer: Layer<any, any, any>): MemoMapEntry | undefined {
-    return this.map.get(layer) ?? (this.parent ? memoMapGet(this.parent, layer) : undefined)
+  get<RIn, E, ROut>(
+    layer: Layer<ROut, E, RIn>,
+    scope: Scope.Scope
+  ): Effect<Context.Context<ROut>, E, RIn> | undefined {
+    const local = this.map.get(layer)
+    if (local) {
+      return memoMapReuse(local, scope)
+    }
+    return this.parent?.get(layer, scope)
   }
 
   getOrElseMemoize<RIn, E, ROut>(
@@ -377,13 +379,9 @@ class MemoMapImpl extends MemoMapBase {
     scope: Scope.Scope,
     build: (memoMap: MemoMap, scope: Scope.Scope) => Effect<Context.Context<ROut>, E, RIn>
   ): Effect<Context.Context<ROut>, E, RIn> {
-    const entry = this.unsafeGet(layer)
-    if (entry) {
-      entry.observers++
-      return internalEffect.andThen(
-        internalEffect.scopeAddFinalizerExit(scope, (exit) => entry.finalizer(exit)),
-        entry.effect
-      )
+    const existing = this.get(layer, scope)
+    if (existing) {
+      return existing
     }
     return memoMapBuild(this, layer, scope, build)
   }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.7.0",
+    "@vitest/runner": "4.1.4",
     "effect": "workspace:^",
     "vitest": "4.1.4"
   }

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -242,13 +242,10 @@ export const prop: Vitest.Methods["prop"] = internal.prop
  * @since 1.0.0
  */
 
-/** @ignored */
-const methods = { effect, live, flakyTest, layer, prop } as const
-
 /**
  * @since 1.0.0
  */
-export const it: Vitest.Methods = Object.assign(V.it, methods)
+export const it: Vitest.Methods = internal.makeMethods(V.it)
 
 /**
  * @since 1.0.0

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -48,6 +48,23 @@ export const addEqualityTesters = () => {
 /** @internal */
 const testOptions = (timeout?: number | V.TestOptions) => typeof timeout === "number" ? { timeout } : timeout ?? {}
 
+const makeItProxy = <Methods extends object>(
+  it: V.TestAPI,
+  overrides: Methods
+): Methods & V.TestAPI =>
+  new Proxy(it as Methods & V.TestAPI, {
+    apply(target, thisArg, argArray) {
+      return Reflect.apply(target, thisArg, argArray)
+    },
+    get(target, property, receiver) {
+      if (property in overrides) {
+        return Reflect.get(overrides, property)
+      }
+      const value = Reflect.get(target, property, receiver)
+      return typeof value === "function" ? value.bind(target) : value
+    }
+  })
+
 /** @internal */
 const makeTester = <R>(
   mapEffect: <A, E>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E, never>,
@@ -209,7 +226,7 @@ export const layer = <R, E>(
   )
 
   const makeIt = (it: V.TestAPI): Vitest.Vitest.MethodsNonLive<R> =>
-    Object.assign(it, {
+    makeItProxy(it, {
       effect: makeTester<R | Scope.Scope>(
         (effect) =>
           Effect.flatMap(contextEffect, (context) =>
@@ -282,7 +299,7 @@ export const flakyTest = <A, E, R>(
 
 /** @internal */
 export const makeMethods = (it: V.TestAPI): Vitest.Vitest.Methods =>
-  Object.assign(it, {
+  makeItProxy(it, {
     effect: makeTester<Scope.Scope>(flow(Effect.scoped, Effect.provide(TestEnv)), it),
     live: makeTester<Scope.Scope>(Effect.scoped, it),
     flakyTest,

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -2,6 +2,7 @@
  * @since 1.0.0
  */
 
+import { getCurrentSuite } from "@vitest/runner"
 import * as Cause from "effect/Cause"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -48,6 +49,9 @@ export const addEqualityTesters = () => {
 /** @internal */
 const testOptions = (timeout?: number | V.TestOptions) => typeof timeout === "number" ? { timeout } : timeout ?? {}
 
+const hookTimeout = (timeout?: Duration.Input) =>
+  timeout === undefined ? undefined : Duration.toMillis(Duration.fromInputUnsafe(timeout))
+
 const makeItProxy = <Methods extends object>(
   it: V.TestAPI,
   overrides: Methods
@@ -64,6 +68,24 @@ const makeItProxy = <Methods extends object>(
       return typeof value === "function" ? value.bind(target) : value
     }
   })
+
+type CollectedTask = {
+  readonly type: string
+  readonly mode?: string
+  readonly tasks?: ReadonlyArray<CollectedTask>
+}
+
+const collectTasks = (tasks: ReadonlyArray<CollectedTask>, acc: Array<V.TestContext["task"]> = []) => {
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i]
+    if (task.type === "test" && task.mode !== "skip" && task.mode !== "todo") {
+      acc.push(task as V.TestContext["task"])
+    } else if (task.tasks !== undefined) {
+      collectTasks(task.tasks, acc)
+    }
+  }
+  return acc
+}
 
 /** @internal */
 const makeTester = <R>(
@@ -224,6 +246,14 @@ export const layer = <R, E>(
     Effect.cached,
     Effect.runSync
   )
+  let closed = false
+  const closeScope = (ctx?: Vitest.TestContext) => {
+    if (closed) {
+      return Promise.resolve()
+    }
+    closed = true
+    return runPromise(Scope.close(scope, Exit.void), ctx)
+  }
 
   const makeIt = (it: V.TestAPI): Vitest.Vitest.MethodsNonLive<R> =>
     makeItProxy(it, {
@@ -250,25 +280,49 @@ export const layer = <R, E>(
     })
 
   if (args.length === 1) {
-    V.beforeAll(
-      () => runPromise(Effect.asVoid(contextEffect)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+    const currentSuite = getCurrentSuite()
+    const previousTasks = new Set(currentSuite.tasks)
+
+    args[0](makeIt(V.it))
+
+    const blockTasks = collectTasks(
+      currentSuite.tasks.filter((task) => !previousTasks.has(task)) as ReadonlyArray<CollectedTask>
     )
-    V.afterAll(
-      () => runPromise(Scope.close(scope, Exit.void)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+    if (blockTasks.length === 0) {
+      V.afterAll(() => closeScope(), hookTimeout(options?.timeout))
+      return
+    }
+
+    const blockTaskSet = new Set(blockTasks)
+    let remaining = blockTasks.length
+
+    V.beforeEach(
+      (ctx) => {
+        if (!blockTaskSet.has(ctx.task)) {
+          return
+        }
+        ctx.onTestFinished(() => {
+          remaining--
+          if (remaining === 0) {
+            return closeScope(ctx)
+          }
+        })
+        return runPromise(Effect.asVoid(contextEffect), ctx)
+      },
+      hookTimeout(options?.timeout)
     )
-    return args[0](makeIt(V.it))
+    V.afterAll(() => closeScope(), hookTimeout(options?.timeout))
+    return
   }
 
   return V.describe(args[0], () => {
     V.beforeAll(
       () => runPromise(Effect.asVoid(contextEffect)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      hookTimeout(options?.timeout)
     )
     V.afterAll(
-      () => runPromise(Scope.close(scope, Exit.void)),
-      options?.timeout ? Duration.toMillis(Duration.fromInputUnsafe(options.timeout)) : undefined
+      () => closeScope(),
+      hookTimeout(options?.timeout)
     )
     return args[1](makeIt(V.it))
   })

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -224,7 +224,11 @@ export const layer = <R, E>(
       layer<R2, E2>(nestedLayer: Layer.Layer<R2, E2, R>, options?: {
         readonly timeout?: Duration.Input
       }) {
-        return layer(Layer.provideMerge(nestedLayer, withTestEnv), { ...options, memoMap, excludeTestServices })
+        return layer(Layer.provideMerge(nestedLayer, withTestEnv), {
+          ...options,
+          memoMap: Layer.forkMemoMapUnsafe(memoMap),
+          excludeTestServices
+        })
       }
     })
 

--- a/packages/vitest/test/isolation.test.ts
+++ b/packages/vitest/test/isolation.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Layer, Ref } from "effect"
+
+interface StateShape {
+  readonly id: number
+  readonly todos: Ref.Ref<Array<string>>
+  readonly migrated: Ref.Ref<boolean>
+}
+
+class State extends Context.Service<State, StateShape>()("State") {}
+
+class TodoService extends Context.Service<TodoService, {
+  readonly stateId: Effect.Effect<number>
+  readonly migrated: Effect.Effect<boolean>
+  readonly add: (title: string) => Effect.Effect<void>
+  readonly list: Effect.Effect<Array<string>>
+}>()("TodoService") {}
+
+describe("top-level it.layer isolation", () => {
+  let nextId = 0
+  const observedStateIds: Array<number> = []
+
+  const baseLayer = Layer.effect(State)(
+    Effect.gen(function*() {
+      const id = ++nextId
+      const todos = yield* Ref.make<Array<string>>([])
+      const migrated = yield* Ref.make(false)
+      return { id, todos, migrated }
+    })
+  )
+
+  const migrationLayer = Layer.effectDiscard(
+    Effect.gen(function*() {
+      const state = yield* State
+      yield* Ref.set(state.migrated, true)
+    })
+  )
+
+  const migratedLayer = Layer.merge(
+    baseLayer,
+    migrationLayer.pipe(Layer.provide(baseLayer))
+  )
+
+  const inMemoryLayer = Layer.effect(TodoService)(
+    Effect.gen(function*() {
+      const state = yield* State
+      return {
+        stateId: Effect.succeed(state.id),
+        migrated: Ref.get(state.migrated),
+        add: (title: string) => Ref.update(state.todos, (todos) => [...todos, title]),
+        list: Ref.get(state.todos)
+      } as const
+    })
+  ).pipe(Layer.provide(migratedLayer))
+
+  it.layer(inMemoryLayer)((it) => {
+    it.effect("first block mutates isolated state", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const stateId = yield* service.stateId
+        const migrated = yield* service.migrated
+
+        observedStateIds.push(stateId)
+        yield* service.add("write tests")
+
+        assert.isTrue(migrated)
+        assert.deepStrictEqual(yield* service.list, ["write tests"])
+      }))
+  })
+
+  it.layer(inMemoryLayer)((it) => {
+    it.effect("second block starts fresh", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const stateId = yield* service.stateId
+        const migrated = yield* service.migrated
+
+        observedStateIds.push(stateId)
+
+        assert.isTrue(migrated)
+        assert.deepStrictEqual(yield* service.list, [])
+
+        yield* service.add("ship feature")
+        assert.deepStrictEqual(yield* service.list, ["ship feature"])
+      }))
+  })
+
+  it.layer(inMemoryLayer)((it) => {
+    it.effect("third block also starts fresh", () =>
+      Effect.gen(function*() {
+        const service = yield* TodoService
+        const stateId = yield* service.stateId
+        const migrated = yield* service.migrated
+
+        observedStateIds.push(stateId)
+
+        assert.isTrue(migrated)
+        assert.deepStrictEqual(yield* service.list, [])
+      }))
+  })
+
+  afterAll(() => {
+    assert.deepStrictEqual(observedStateIds, [1, 2, 3])
+  })
+})

--- a/packages/vitest/test/nested-isolation.test.ts
+++ b/packages/vitest/test/nested-isolation.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, assert, beforeAll, describe, expect, layer } from "@effect/vitest"
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Ref } from "effect"
 
 describe("nested sibling layers", () => {
   let nextChildId = 0
@@ -76,8 +76,6 @@ describe.concurrent("nested sibling layers in concurrent suites", () => {
     static readonly Live = Layer.effect(SharedChild)(
       Effect.flatMap(Parent, () =>
         Effect.gen(function*() {
-          // Keep the first build pending long enough for the sibling suite to
-          // attach to the same memoized layer when run under describe.concurrent.
           yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 50)))
 
           const id = ++nextSharedId
@@ -117,6 +115,98 @@ describe.concurrent("nested sibling layers in concurrent suites", () => {
       expect(firstSharedId).not.toEqual(secondSharedId)
       expect(nextSharedId).toEqual(2)
       expect([...releasedSharedIds].sort((a, b) => a - b)).toEqual([1, 2])
+    })
+  })
+})
+
+describe("nested sibling isolation with provided state graph", () => {
+  interface StateShape {
+    readonly id: number
+    readonly todos: Ref.Ref<Array<string>>
+    readonly migrated: Ref.Ref<boolean>
+  }
+
+  class Parent extends Context.Service<Parent, "parent">()("ProvidedParent") {
+    static readonly Live = Layer.succeed(Parent)("parent")
+  }
+
+  class State extends Context.Service<State, StateShape>()("ProvidedState") {}
+
+  class TodoService extends Context.Service<TodoService, {
+    readonly stateId: Effect.Effect<number>
+    readonly migrated: Effect.Effect<boolean>
+    readonly add: (title: string) => Effect.Effect<void>
+    readonly list: Effect.Effect<Array<string>>
+  }>()("ProvidedTodoService") {}
+
+  let nextId = 0
+  let firstStateId = -1
+  let secondStateId = -1
+
+  const baseLayer = Layer.effect(State)(
+    Effect.gen(function*() {
+      const id = ++nextId
+      const todos = yield* Ref.make<Array<string>>([])
+      const migrated = yield* Ref.make(false)
+      return { id, todos, migrated }
+    })
+  )
+
+  const migrationLayer = Layer.effectDiscard(
+    Effect.gen(function*() {
+      const state = yield* State
+      yield* Ref.set(state.migrated, true)
+    })
+  )
+
+  const migratedLayer = Layer.merge(
+    baseLayer,
+    migrationLayer.pipe(Layer.provide(baseLayer))
+  )
+
+  const inMemoryLayer = Layer.effect(TodoService)(
+    Effect.gen(function*() {
+      const state = yield* State
+      return {
+        stateId: Effect.succeed(state.id),
+        migrated: Ref.get(state.migrated),
+        add: (title: string) => Ref.update(state.todos, (todos) => [...todos, title]),
+        list: Ref.get(state.todos)
+      } as const
+    })
+  ).pipe(Layer.provide(migratedLayer))
+
+  layer(Parent.Live)("parent", (it) => {
+    it.layer(inMemoryLayer)("first sibling", (it) => {
+      it.effect("mutates isolated provided state", () =>
+        Effect.gen(function*() {
+          const service = yield* TodoService
+          firstStateId = yield* service.stateId
+
+          assert.isTrue(yield* service.migrated)
+          yield* service.add("write tests")
+          assert.deepStrictEqual(yield* service.list, ["write tests"])
+        }))
+    })
+
+    it.layer(inMemoryLayer)("second sibling", (it) => {
+      it.effect("starts fresh with a new provided state", () =>
+        Effect.gen(function*() {
+          const service = yield* TodoService
+          secondStateId = yield* service.stateId
+
+          assert.isTrue(yield* service.migrated)
+          assert.deepStrictEqual(yield* service.list, [])
+
+          yield* service.add("ship feature")
+          assert.deepStrictEqual(yield* service.list, ["ship feature"])
+        }))
+    })
+
+    afterAll(() => {
+      expect(firstStateId).toEqual(1)
+      expect(secondStateId).toEqual(2)
+      expect(nextId).toEqual(2)
     })
   })
 })

--- a/packages/vitest/test/siblings.test.ts
+++ b/packages/vitest/test/siblings.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, assert, beforeAll, describe, expect, layer } from "@effect/vitest"
+import { Context, Effect, Layer } from "effect"
+
+describe("nested sibling layers", () => {
+  let nextChildId = 0
+  let firstChildId = -1
+  let secondChildId = -1
+  const releasedChildIds: Array<number> = []
+
+  class Parent extends Context.Service<Parent, "parent">()("Parent") {
+    static readonly Live = Layer.succeed(Parent)("parent")
+  }
+
+  class Child extends Context.Service<Child, { readonly id: number }>()("Child") {
+    static readonly Live = Layer.effect(Child)(
+      Effect.flatMap(Parent, () => {
+        const id = ++nextChildId
+        return Effect.acquireRelease(
+          Effect.succeed({ id }),
+          () =>
+            Effect.sync(() => {
+              releasedChildIds.push(id)
+            })
+        )
+      })
+    )
+  }
+
+  layer(Parent.Live)("parent", (it) => {
+    it.layer(Child.Live)("first sibling", (it) => {
+      it.effect("allocates child", () =>
+        Effect.gen(function*() {
+          const child = yield* Child
+          firstChildId = child.id
+
+          assert.strictEqual(child.id, 1)
+          assert.deepStrictEqual(releasedChildIds, [])
+        }))
+    })
+
+    it.layer(Child.Live)("second sibling", (it) => {
+      beforeAll(() => {
+        expect(releasedChildIds).toEqual([firstChildId])
+      })
+
+      it.effect("allocates a fresh child", () =>
+        Effect.gen(function*() {
+          const child = yield* Child
+          secondChildId = child.id
+
+          assert.strictEqual(child.id, 2)
+          assert.isTrue(child.id !== firstChildId)
+          assert.deepStrictEqual(releasedChildIds, [firstChildId])
+        }))
+    })
+
+    afterAll(() => {
+      expect(firstChildId).toEqual(1)
+      expect(secondChildId).toEqual(2)
+      expect(releasedChildIds).toEqual([1, 2])
+    })
+  })
+})
+
+describe.concurrent("nested sibling layers in concurrent suites", () => {
+  let nextSharedId = 0
+  let firstSharedId: number | undefined
+  let secondSharedId: number | undefined
+  const releasedSharedIds: Array<number> = []
+
+  class Parent extends Context.Service<Parent, "parent">()("ConcurrentParent") {
+    static readonly Live = Layer.succeed(Parent)("parent")
+  }
+
+  class SharedChild extends Context.Service<SharedChild, { readonly id: number }>()("SharedChild") {
+    static readonly Live = Layer.effect(SharedChild)(
+      Effect.flatMap(Parent, () =>
+        Effect.gen(function*() {
+          // Keep the first build pending long enough for the sibling suite to
+          // attach to the same memoized layer when run under describe.concurrent.
+          yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 50)))
+
+          const id = ++nextSharedId
+          return yield* Effect.acquireRelease(
+            Effect.succeed({ id }),
+            () =>
+              Effect.sync(() => {
+                releasedSharedIds.push(id)
+              })
+          )
+        }))
+    )
+  }
+
+  layer(Parent.Live)("parent", (it) => {
+    describe.concurrent("concurrent siblings", () => {
+      it.layer(SharedChild.Live)("first sibling", (it) => {
+        it.effect("captures shared child", () =>
+          Effect.gen(function*() {
+            const child = yield* SharedChild
+            firstSharedId = child.id
+            assert.isTrue(child.id === 1 || child.id === 2)
+          }))
+      })
+
+      it.layer(SharedChild.Live)("second sibling", (it) => {
+        it.effect("allocates an isolated child", () =>
+          Effect.gen(function*() {
+            const child = yield* SharedChild
+            secondSharedId = child.id
+            assert.isTrue(child.id === 1 || child.id === 2)
+          }))
+      })
+    })
+
+    afterAll(() => {
+      expect(firstSharedId).not.toEqual(secondSharedId)
+      expect(nextSharedId).toEqual(2)
+      expect([...releasedSharedIds].sort((a, b) => a - b)).toEqual([1, 2])
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,6 +804,9 @@ importers:
       '@types/node':
         specifier: ^25.7.0
         version: 25.7.0
+      '@vitest/runner':
+        specifier: 4.1.4
+        version: 4.1.4
       effect:
         specifier: workspace:^
         version: link:../effect


### PR DESCRIPTION
## Summary
- add forked `Layer` memo maps so nested layer scopes can reuse parent allocations without leaking sibling-local layers
- update `@effect/vitest` to stop mutating the shared Vitest test API by using proxy-based wrappers instead, preserving plugin-added methods while isolating per-block overrides
- isolate unnamed `it.layer(...)` blocks by tracking the tests they register via Vitest's runner collector and managing their shared layer lifecycle independently of the parent suite
- add top-level and nested isolation regressions covering both simple layers and shared `Layer.provide(...)` state graphs