### PR TITLE
refactor: add rows to Terminal

### DIFF
--- a/.changeset/busy-maps-attend.md
+++ b/.changeset/busy-maps-attend.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+"@effect/platform-bun": patch
+"@effect/platform-node": patch
+---
+
+add rows to Terminal

--- a/packages/effect/src/Terminal.ts
+++ b/packages/effect/src/Terminal.ts
@@ -28,6 +28,11 @@ export interface Terminal {
    */
   readonly columns: Effect.Effect<number>
   /**
+   * The number of rows available on the platform's terminal interface.
+   */
+
+  readonly rows: Effect.Effect<number>
+  /**
    * Reads input events from the default standard input.
    */
   readonly readInput: Effect.Effect<Queue.Dequeue<UserInput, Cause.Done>, never, Scope.Scope>

--- a/packages/effect/test/unstable/cli/services/MockTerminal.ts
+++ b/packages/effect/test/unstable/cli/services/MockTerminal.ts
@@ -63,6 +63,7 @@ export const make = Effect.gen(function*() {
 
   const terminal = Terminal.make({
     columns: Effect.succeed(80),
+    rows: Effect.succeed(24),
     display,
     readInput,
     readLine: Effect.succeed("")

--- a/packages/platform-node-shared/src/NodeTerminal.ts
+++ b/packages/platform-node-shared/src/NodeTerminal.ts
@@ -47,6 +47,7 @@ export const make: (
     })
 
     const columns = Effect.sync(() => stdout.columns ?? 0)
+    const rows = Effect.sync(() => stdout.rows ?? 0)
 
     const readInput = Effect.gen(function*() {
       yield* RcRef.get(rlRef)
@@ -94,6 +95,7 @@ export const make: (
 
     return Terminal.make({
       columns,
+      rows,
       readInput,
       readLine,
       display


### PR DESCRIPTION
## Type

- [x] Refactor

## Description

I've found a need to use the `process.stdout.rows` when building ClI applications using `Prompt` for contrained or responsive layout.  At the moment `Terminal` only exposes the columns so here I want to use the same implementation but to expose the rows

## Related

- Was mentioned in Effect Office Hours (May 13th) while reviewing `stack-effect`
