### PR TITLE
fix(HttpApi): handle empty optional JSON payloads

### DIFF
--- a/.changeset/httpapi-empty-optional-payload.md
+++ b/.changeset/httpapi-empty-optional-payload.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `HttpApiBuilder` empty JSON body decoding for optional payloads. See [#2188](https://github.com/Effect-TS/effect-smol/issues/2188).

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -497,6 +497,7 @@ type PayloadDecoder =
   }
   | {
     readonly _tag: "Json" | "FormUrlEncoded" | "Uint8Array" | "Text"
+    readonly undefinedOnEmpty: boolean
     readonly nullOnEmpty: boolean
     readonly decode: (input: unknown) => Effect.Effect<unknown, Schema.SchemaError, unknown>
   }
@@ -513,11 +514,18 @@ function buildPayloadDecoders(
       result.set(contentType, {
         _tag: encoding._tag,
         decode,
+        undefinedOnEmpty: schemas.some((s) => hasUndefined(AST.toType(s.ast))),
         nullOnEmpty: schemas.some((s) => AST.isNull(AST.toEncoded(s.ast)))
       })
     }
   })
   return result
+}
+
+function hasUndefined(ast: AST.AST): boolean {
+  if (AST.isUndefined(ast) || AST.isVoid(ast)) return true
+  if (AST.isUnion(ast)) return ast.types.some(hasUndefined)
+  return false
 }
 
 function decodePayload(
@@ -550,13 +558,13 @@ function decodePayload(
       )
     }
     case "Json":
-      const json = Effect.orDie(Effect.flatMap(httpRequest.text, (text) => {
+      return Effect.orDie(Effect.flatMap(httpRequest.text, (text) => {
         if (text === "") {
-          return existing.nullOnEmpty ? Effect.succeed(null) : Effect.undefined
+          if (existing.undefinedOnEmpty) return Effect.undefined
+          return decode(existing.nullOnEmpty ? null : undefined)
         }
-        return Effect.succeed(JSON.parse(text))
+        return Effect.flatMap(Effect.succeed(JSON.parse(text)), decode)
       }))
-      return Effect.flatMap(json, decode)
     case "Text":
       return Effect.flatMap(Effect.orDie(httpRequest.text), decode)
     case "FormUrlEncoded": {

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -812,6 +812,47 @@ describe("HttpApi", () => {
         yield* assertClientJson(client.group.a({ payload: new Uint8Array([1, 2, 3]) }), { 0: 1, 1: 2, 2: 3 })
       }).pipe(Effect.provide(ApiLive))
     })
+
+    it("optional JSON payload accepts an empty request body", async () => {
+      const Payload = Schema.Struct({
+        name: Schema.optional(Schema.String)
+      })
+
+      const Api = HttpApi.make("api").add(
+        HttpApiGroup.make("group").add(
+          HttpApiEndpoint.post("create", "/create", {
+            payload: Schema.optional(Payload),
+            success: Schema.String
+          })
+        )
+      )
+      const GroupLive = HttpApiBuilder.group(
+        Api,
+        "group",
+        (handlers) => handlers.handle("create", (ctx) => Effect.succeed(ctx.payload?.name ?? "default"))
+      )
+
+      const handler = HttpRouter.toWebHandler(
+        HttpApiBuilder.layer(Api).pipe(
+          Layer.provide(GroupLive),
+          Layer.provide(HttpServer.layerServices)
+        ),
+        { disableLogger: true }
+      )
+
+      try {
+        const response = await handler.handler(
+          new Request("http://localhost/create", {
+            method: "POST",
+            headers: { "content-type": "application/json" }
+          })
+        )
+        assert.strictEqual(response.status, 200)
+        assert.deepStrictEqual(await response.json(), "default")
+      } finally {
+        await handler.dispose()
+      }
+    })
   })
 
   describe("params option", () => {


### PR DESCRIPTION
Closes #2188.

## Summary
- Adds a regression test for an optional JSON payload endpoint receiving an empty request body.
- Includes one possible implementation: if the payload Type accepts `undefined`, decode an empty JSON body as decoded `undefined` instead of routing it through the JSON codec's encoded `null` representation.
- Adds a patch changeset.

## Notes
The reproducer is the important part; the implementation is one candidate fix and I am happy to adjust it if there is a preferred semantic/modeling approach.

## Test
- `pnpm vitest packages/platform-node/test/HttpApi.test.ts -t \"optional JSON payload accepts an empty request body\"`