### PR TITLE
Rename platform services to context

### DIFF
--- a/.changeset/rename-platform-context.md
+++ b/.changeset/rename-platform-context.md
@@ -1,0 +1,6 @@
+---
+"@effect/platform-node": patch
+"@effect/platform-bun": patch
+---
+
+Rename platform service collection modules from `NodeServices` and `BunServices` to `NodeContext` and `BunContext`.

--- a/ai-docs/src/60_child-process/10_working-with-child-processes.ts
+++ b/ai-docs/src/60_child-process/10_working-with-child-processes.ts
@@ -3,7 +3,7 @@
  *
  * This example shows how to collect process output, compose pipelines, and stream long-running command output.
  */
-import { NodeServices } from "@effect/platform-node"
+import { NodeContext } from "@effect/platform-node"
 import { Console, Context, Effect, Layer, Schema, Stream, String } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
@@ -100,8 +100,8 @@ export class DevTools extends Context.Service<DevTools, {
       })
     })
   ).pipe(
-    // Provide the `ChildProcessSpawner` dependency from `NodeServices.layer`.
-    Layer.provide(NodeServices.layer)
+    // Provide the `ChildProcessSpawner` dependency from `NodeContext.layer`.
+    Layer.provide(NodeContext.layer)
   )
 }
 
@@ -112,6 +112,6 @@ export const program = Effect.gen(function*() {
   yield* Effect.log(`node=${version}`)
 }).pipe(
   // `ChildProcess` requires a platform implementation of
-  // `ChildProcessSpawner`. In Node.js, `NodeServices.layer` provides it.
+  // `ChildProcessSpawner`. In Node.js, `NodeContext.layer` provides it.
   Effect.provide(DevTools.layer)
 )

--- a/ai-docs/src/70_cli/10_basics.ts
+++ b/ai-docs/src/70_cli/10_basics.ts
@@ -4,7 +4,7 @@
  * Build a command-line app with typed arguments and flags, then wire subcommand
  * handlers into a single executable command.
  */
-import { NodeRuntime, NodeServices } from "@effect/platform-node"
+import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Console, Effect } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 
@@ -131,6 +131,6 @@ tasks.pipe(
   }),
   // Provide the services for the platform you are targeting. In this case,
   // Node.js
-  Effect.provide(NodeServices.layer),
+  Effect.provide(NodeContext.layer),
   NodeRuntime.runMain
 )

--- a/packages/effect/src/unstable/process/ChildProcess.ts
+++ b/packages/effect/src/unstable/process/ChildProcess.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```ts
- * import { NodeServices } from "@effect/platform-node"
+ * import { NodeContext } from "@effect/platform-node"
  * import { Effect, Stream } from "effect"
  * import { ChildProcess } from "effect/unstable/process"
  *
@@ -20,7 +20,7 @@
  *   const chunks = yield* Stream.runCollect(handle.stdout)
  *   const exitCode = yield* handle.exitCode
  *   return { chunks, exitCode }
- * }).pipe(Effect.scoped, Effect.provide(NodeServices.layer))
+ * }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
  *
  * // With options
  * const withOptions = ChildProcess.make({ cwd: "/tmp" })`ls -la`
@@ -35,7 +35,7 @@
  *   const handle = yield* pipeline
  *   const chunks = yield* Stream.runCollect(handle.stdout)
  *   return chunks
- * }).pipe(Effect.scoped, Effect.provide(NodeServices.layer))
+ * }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
  * ```
  *
  * @since 4.0.0

--- a/packages/effect/src/unstable/process/ChildProcessSpawner.ts
+++ b/packages/effect/src/unstable/process/ChildProcessSpawner.ts
@@ -137,7 +137,7 @@ export interface ChildProcessHandle {
    *
    * @example
    * ```ts
-   * import { NodeServices } from "@effect/platform-node"
+   * import { NodeContext } from "@effect/platform-node"
    * import { Effect } from "effect"
    * import { ChildProcess } from "effect/unstable/process"
    *
@@ -149,7 +149,7 @@ export interface ChildProcessHandle {
    *
    *   yield* reref
    *   return yield* handle.exitCode
-   * }).pipe(Effect.scoped, Effect.provide(NodeServices.layer))
+   * }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
    * ```
    */
   readonly unref: Effect.Effect<Reref, PlatformError.PlatformError>

--- a/packages/effect/src/unstable/process/index.ts
+++ b/packages/effect/src/unstable/process/index.ts
@@ -12,7 +12,7 @@
  *
  * @example
  * ```ts
- * import { NodeServices } from "@effect/platform-node"
+ * import { NodeContext } from "@effect/platform-node"
  * import { Effect, Stream } from "effect"
  * import { ChildProcess } from "effect/unstable/process"
  *
@@ -26,7 +26,7 @@
  *   const chunks = yield* Stream.runCollect(handle.stdout)
  *   const exitCode = yield* handle.exitCode
  *   return { chunks, exitCode }
- * }).pipe(Effect.scoped, Effect.provide(NodeServices.layer))
+ * }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
  *
  * // With options
  * const withOptions = ChildProcess.make({ cwd: "/tmp" })`ls -la`
@@ -41,7 +41,7 @@
  *   const handle = yield* pipeline
  *   const chunks = yield* Stream.runCollect(handle.stdout)
  *   return chunks
- * }).pipe(Effect.scoped, Effect.provide(NodeServices.layer))
+ * }).pipe(Effect.scoped, Effect.provide(NodeContext.layer))
  * ```
  *
  * @since 4.0.0

--- a/packages/platform-bun/src/BunClusterHttp.ts
+++ b/packages/platform-bun/src/BunClusterHttp.ts
@@ -22,9 +22,9 @@ import type { ServeError } from "effect/unstable/http/HttpServerError"
 import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization"
 import type { SqlClient } from "effect/unstable/sql/SqlClient"
 import { layerK8sHttpClient } from "./BunClusterSocket.ts"
+import type { BunContext } from "./BunContext.ts"
 import * as BunFileSystem from "./BunFileSystem.ts"
 import * as BunHttpServer from "./BunHttpServer.ts"
-import type { BunServices } from "./BunServices.ts"
 import * as BunSocket from "./BunSocket.ts"
 
 export {
@@ -42,7 +42,7 @@ export {
 export const layerHttpServer: Layer.Layer<
   | HttpPlatform
   | Etag.Generator
-  | BunServices
+  | BunContext
   | HttpServer,
   ServeError,
   ShardingConfig.ShardingConfig

--- a/packages/platform-bun/src/BunContext.ts
+++ b/packages/platform-bun/src/BunContext.ts
@@ -17,13 +17,13 @@ import * as BunTerminal from "./BunTerminal.ts"
  * @since 1.0.0
  * @category models
  */
-export type BunServices = ChildProcessSpawner | FileSystem | Path | Terminal | Stdio
+export type BunContext = ChildProcessSpawner | FileSystem | Path | Terminal | Stdio
 
 /**
  * @since 1.0.0
  * @category layer
  */
-export const layer: Layer.Layer<BunServices> = BunChildProcessSpawner.layer.pipe(
+export const layer: Layer.Layer<BunContext> = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(
     BunFileSystem.layer,
     BunPath.layer,

--- a/packages/platform-bun/src/BunHttpServer.ts
+++ b/packages/platform-bun/src/BunHttpServer.ts
@@ -38,9 +38,9 @@ import type * as ServerResponse from "effect/unstable/http/HttpServerResponse"
 import type * as Multipart from "effect/unstable/http/Multipart"
 import * as UrlParams from "effect/unstable/http/UrlParams"
 import * as Socket from "effect/unstable/socket/Socket"
+import * as BunContext from "./BunContext.ts"
 import * as Platform from "./BunHttpPlatform.ts"
 import * as BunMultipart from "./BunMultipart.ts"
-import * as BunServices from "./BunServices.ts"
 import * as BunStream from "./BunStream.ts"
 
 /**
@@ -227,11 +227,11 @@ export const layerServer: <R extends string>(
 export const layerHttpServices: Layer.Layer<
   | HttpPlatform
   | Etag.Generator
-  | BunServices.BunServices
+  | BunContext.BunContext
 > = Layer.mergeAll(
   Platform.layer,
   Etag.layerWeak,
-  BunServices.layer
+  BunContext.layer
 )
 
 /**
@@ -247,7 +247,7 @@ export const layer = <R extends string>(
   | Server.HttpServer
   | HttpPlatform
   | Etag.Generator
-  | BunServices.BunServices
+  | BunContext.BunContext
 > => Layer.mergeAll(layerServer(options), layerHttpServices)
 
 /**

--- a/packages/platform-bun/src/index.ts
+++ b/packages/platform-bun/src/index.ts
@@ -24,6 +24,11 @@ export * as BunClusterSocket from "./BunClusterSocket.ts"
 /**
  * @since 1.0.0
  */
+export * as BunContext from "./BunContext.ts"
+
+/**
+ * @since 1.0.0
+ */
 export * as BunFileSystem from "./BunFileSystem.ts"
 
 /**
@@ -65,11 +70,6 @@ export * as BunRedis from "./BunRedis.ts"
  * @since 1.0.0
  */
 export * as BunRuntime from "./BunRuntime.ts"
-
-/**
- * @since 1.0.0
- */
-export * as BunServices from "./BunServices.ts"
 
 /**
  * @since 1.0.0

--- a/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
+++ b/packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts
@@ -15,7 +15,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
 const TEST_BASH_SCRIPTS_PATH = [__dirname, "fixtures", "bash"]
 
-const NodeServices = NodeChildProcessSpawner.layer.pipe(
+const NodeContext = NodeChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(
     NodeFileSystem.layer,
     NodePath.layer
@@ -41,7 +41,7 @@ const decodeByteStream = Effect.fnUntraced(
 )
 
 describe("NodeChildProcessSpawner", () => {
-  it.layer(NodeServices)((it) => {
+  it.layer(NodeContext)((it) => {
     describe("spawn", () => {
       describe("basic spawning", () => {
         it.effect("should spawn a simple command and collect output", () =>
@@ -925,10 +925,10 @@ describe("NodeChildProcessSpawner", () => {
           const handle = yield* Scope.provide(scope)(Effect.gen(function*() {
             return yield* longRunningCommand()
           })).pipe(
-            Effect.provide(NodeServices)
+            Effect.provide(NodeContext)
           )
 
-          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeServices))
+          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeContext))
           yield* Scope.close(scope, Exit.void)
           yield* TestClock.withLive(Effect.sleep("100 millis"))
 
@@ -936,7 +936,7 @@ describe("NodeChildProcessSpawner", () => {
           assert.isTrue(isRunning)
 
           yield* handle.kill({ killSignal: "SIGKILL" })
-        }).pipe(Effect.provide(NodeServices)))
+        }).pipe(Effect.provide(NodeContext)))
 
       it.effect("should kill a restored process when scope closes", () =>
         Effect.gen(function*() {
@@ -944,17 +944,17 @@ describe("NodeChildProcessSpawner", () => {
           const handle = yield* Scope.provide(scope)(Effect.gen(function*() {
             return yield* longRunningCommand()
           })).pipe(
-            Effect.provide(NodeServices)
+            Effect.provide(NodeContext)
           )
 
-          const reref = yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeServices))
+          const reref = yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeContext))
           yield* reref
           yield* Scope.close(scope, Exit.void)
           yield* TestClock.withLive(Effect.sleep("100 millis"))
 
           const isRunning = yield* handle.isRunning
           assert.isFalse(isRunning)
-        }).pipe(Effect.provide(NodeServices)))
+        }).pipe(Effect.provide(NodeContext)))
 
       it.effect("should resolve exitCode after closing the original scope of an unrefed process", () =>
         Effect.gen(function*() {
@@ -965,14 +965,14 @@ describe("NodeChildProcessSpawner", () => {
               stdout: "ignore",
               stderr: "ignore"
             })
-          })).pipe(Effect.provide(NodeServices))
+          })).pipe(Effect.provide(NodeContext))
 
-          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeServices))
+          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeContext))
           yield* Scope.close(scope, Exit.void)
 
           const exitCode = yield* handle.exitCode
           assert.strictEqual(exitCode, ChildProcessSpawner.ExitCode(0))
-        }).pipe(Effect.provide(NodeServices)))
+        }).pipe(Effect.provide(NodeContext)))
 
       it.effect("should cleanup descendants after an unrefed parent exits non-zero", () =>
         Effect.gen(function*() {
@@ -982,9 +982,9 @@ describe("NodeChildProcessSpawner", () => {
 
           const handle = yield* Scope.provide(scope)(Effect.gen(function*() {
             return yield* ChildProcess.make({ cwd })`./parent-exits-early.sh`
-          })).pipe(Effect.provide(NodeServices))
+          })).pipe(Effect.provide(NodeContext))
 
-          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeServices))
+          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeContext))
           yield* Scope.close(scope, Exit.void)
 
           const exitCode = yield* handle.exitCode
@@ -994,7 +994,7 @@ describe("NodeChildProcessSpawner", () => {
 
           const remaining = yield* countMatchingProcesses("sleep 30")
           assert.strictEqual(remaining, 0)
-        }).pipe(Effect.provide(NodeServices)))
+        }).pipe(Effect.provide(NodeContext)))
 
       it.effect("should unref every process in a pipeline", () =>
         Effect.gen(function*() {
@@ -1016,9 +1016,9 @@ describe("NodeChildProcessSpawner", () => {
                 })
               )
             )
-          })).pipe(Effect.provide(NodeServices))
+          })).pipe(Effect.provide(NodeContext))
 
-          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeServices))
+          yield* Scope.provide(scope)(handle.unref).pipe(Effect.provide(NodeContext))
           yield* Scope.close(scope, Exit.void)
           yield* TestClock.withLive(Effect.sleep("100 millis"))
 
@@ -1029,7 +1029,7 @@ describe("NodeChildProcessSpawner", () => {
 
           yield* killMatchingProcesses(rootMarker)
           yield* killMatchingProcesses(tailMarker)
-        }).pipe(Effect.provide(NodeServices)))
+        }).pipe(Effect.provide(NodeContext)))
     })
 
     it.effect("should not deadlock on large stdout output", () =>

--- a/packages/platform-node/src/NodeClusterHttp.ts
+++ b/packages/platform-node/src/NodeClusterHttp.ts
@@ -22,9 +22,9 @@ import * as RpcSerialization from "effect/unstable/rpc/RpcSerialization"
 import type { SqlClient } from "effect/unstable/sql/SqlClient"
 import { createServer } from "node:http"
 import { layerK8sHttpClient } from "./NodeClusterSocket.ts"
+import type { NodeContext } from "./NodeContext.ts"
 import * as NodeHttpClient from "./NodeHttpClient.ts"
 import * as NodeHttpServer from "./NodeHttpServer.ts"
-import type { NodeServices } from "./NodeServices.ts"
 import * as NodeSocket from "./NodeSocket.ts"
 
 export {
@@ -123,7 +123,7 @@ export const layer = <
 export const layerHttpServer: Layer.Layer<
   | HttpPlatform
   | Etag.Generator
-  | NodeServices
+  | NodeContext
   | HttpServer,
   ServeError,
   ShardingConfig.ShardingConfig

--- a/packages/platform-node/src/NodeContext.ts
+++ b/packages/platform-node/src/NodeContext.ts
@@ -17,13 +17,13 @@ import * as NodeTerminal from "./NodeTerminal.ts"
  * @since 1.0.0
  * @category models
  */
-export type NodeServices = ChildProcessSpawner | FileSystem | Path | Stdio | Terminal
+export type NodeContext = ChildProcessSpawner | FileSystem | Path | Stdio | Terminal
 
 /**
  * @since 1.0.0
  * @category layer
  */
-export const layer: Layer.Layer<NodeServices> = Layer.provideMerge(
+export const layer: Layer.Layer<NodeContext> = Layer.provideMerge(
   NodeChildProcessSpawner.layer,
   Layer.mergeAll(
     NodeFileSystem.layer,

--- a/packages/platform-node/src/NodeHttpServer.ts
+++ b/packages/platform-node/src/NodeHttpServer.ts
@@ -45,10 +45,10 @@ import type * as Net from "node:net"
 import type { Duplex } from "node:stream"
 import { Readable } from "node:stream"
 import { pipeline } from "node:stream/promises"
+import * as NodeContext from "./NodeContext.ts"
 import { NodeHttpIncomingMessage } from "./NodeHttpIncomingMessage.ts"
 import * as NodeHttpPlatform from "./NodeHttpPlatform.ts"
 import * as NodeMultipart from "./NodeMultipart.ts"
-import * as NodeServices from "./NodeServices.ts"
 import { NodeWS } from "./NodeSocket.ts"
 
 /**
@@ -382,11 +382,11 @@ export const layerServer: (
  * @category Layers
  */
 export const layerHttpServices: Layer.Layer<
-  NodeServices.NodeServices | HttpPlatform.HttpPlatform | Etag.Generator
+  NodeContext.NodeContext | HttpPlatform.HttpPlatform | Etag.Generator
 > = Layer.mergeAll(
   NodeHttpPlatform.layer,
   Etag.layerWeak,
-  NodeServices.layer
+  NodeContext.layer
 )
 
 /**
@@ -400,7 +400,7 @@ export const layer = (
     readonly gracefulShutdownTimeout?: Duration.Input | undefined
   }
 ): Layer.Layer<
-  HttpServer.HttpServer | NodeServices.NodeServices | HttpPlatform.HttpPlatform | Etag.Generator,
+  HttpServer.HttpServer | NodeContext.NodeContext | HttpPlatform.HttpPlatform | Etag.Generator,
   ServeError
 > =>
   Layer.mergeAll(

--- a/packages/platform-node/src/index.ts
+++ b/packages/platform-node/src/index.ts
@@ -29,6 +29,11 @@ export * as NodeClusterSocket from "./NodeClusterSocket.ts"
 /**
  * @since 1.0.0
  */
+export * as NodeContext from "./NodeContext.ts"
+
+/**
+ * @since 1.0.0
+ */
 export * as NodeFileSystem from "./NodeFileSystem.ts"
 
 /**
@@ -75,11 +80,6 @@ export * as NodeRedis from "./NodeRedis.ts"
  * @since 1.0.0
  */
 export * as NodeRuntime from "./NodeRuntime.ts"
-
-/**
- * @since 1.0.0
- */
-export * as NodeServices from "./NodeServices.ts"
 
 /**
  * @since 1.0.0

--- a/packages/tools/ai-codegen/src/bin.ts
+++ b/packages/tools/ai-codegen/src/bin.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
-import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import { run } from "./main.ts"
 
 run.pipe(
-  Effect.provide(NodeServices.layer),
+  Effect.provide(NodeContext.layer),
   NodeRuntime.runMain
 )

--- a/packages/tools/ai-docgen/src/main.ts
+++ b/packages/tools/ai-docgen/src/main.ts
@@ -2,8 +2,8 @@
 /**
  * @since 1.0.0
  */
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
-import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
 import * as FileSystem from "effect/FileSystem"
@@ -55,7 +55,7 @@ Command.make("effect-ai-docgen", { directory, output, watch }).pipe(
   Command.run({
     version: "0.0.0"
   }),
-  Effect.provide(NodeServices.layer),
+  Effect.provide(NodeContext.layer),
   NodeRuntime.runMain
 )
 

--- a/packages/tools/bundle/src/bin.ts
+++ b/packages/tools/bundle/src/bin.ts
@@ -2,8 +2,8 @@
 /**
  * @since 1.0.0
  */
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
-import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Command from "effect/unstable/cli/Command"
@@ -15,7 +15,7 @@ import { Reporter } from "./Reporter.ts"
 const MainLayer = Layer.mergeAll(
   Fixtures.layer,
   Reporter.layer
-).pipe(Layer.provideMerge(NodeServices.layer))
+).pipe(Layer.provideMerge(NodeContext.layer))
 
 Command.run(cli, { version: PackageJson["version"] }).pipe(
   Effect.provide(MainLayer),

--- a/packages/tools/openapi-generator/src/bin.ts
+++ b/packages/tools/openapi-generator/src/bin.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
-import * as NodeServices from "@effect/platform-node/NodeServices"
 import * as Effect from "effect/Effect"
 import { run } from "./main.ts"
 
 run.pipe(
-  Effect.provide(NodeServices.layer),
+  Effect.provide(NodeContext.layer),
   NodeRuntime.runMain
 )

--- a/packages/tools/openapi-generator/test/OpenApiGeneratorCli.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGeneratorCli.test.ts
@@ -1,4 +1,4 @@
-import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Stdio, Stream } from "effect"
 import * as Exit from "effect/Exit"
@@ -10,7 +10,7 @@ const makeLayer = (args: ReadonlyArray<string>) =>
   Layer.mergeAll(
     TestConsole.layer,
     CliOutput.layer(CliOutput.defaultFormatter({ colors: false })),
-    NodeServices.layer,
+    NodeContext.layer,
     Stdio.layerTest({ args: Effect.succeed(args) })
   )
 
@@ -143,5 +143,5 @@ describe("openapigen CLI", () => {
         "WARNING [cookie-parameter-dropped] GET /users/{id} (getUser): Cookie parameter \"session\" was dropped because non-security cookie parameters are not supported."
       )
       assert.notInclude(result.stderr, "export const make = (")
-    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)))
+    }).pipe(Effect.scoped, Effect.provide(NodeContext.layer)))
 })

--- a/packages/tools/openapi-generator/test/OpenApiPatch.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiPatch.test.ts
@@ -1,11 +1,11 @@
 import * as OpenApiPatch from "@effect/openapi-generator/OpenApiPatch"
-import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import { assert, describe, it } from "@effect/vitest"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Path from "effect/Path"
 
-const testLayer = NodeServices.layer
+const testLayer = NodeContext.layer
 
 describe("OpenApiPatch", () => {
   describe("parsePatchInput", () => {

--- a/packages/tools/utils/src/bin.ts
+++ b/packages/tools/utils/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as NodeServices from "@effect/platform-node/NodeServices"
+import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as Effect from "effect/Effect"
 import * as Command from "effect/unstable/cli/Command"
 import { codegen } from "./commands/codegen.ts"
@@ -10,7 +10,7 @@ const cli = Command.make("effect-utils").pipe(
 )
 
 const main = Command.run(cli, { version: "0.0.0" }).pipe(
-  Effect.provide(NodeServices.layer)
+  Effect.provide(NodeContext.layer)
 )
 
 Effect.runPromise(main)


### PR DESCRIPTION
## Summary
- Rename `NodeServices` / `BunServices` modules and types to `NodeContext` / `BunContext`.
- Update public exports, platform internals, tool imports, tests, JSDoc examples, and AI docs.
- Add a patch changeset for `@effect/platform-node` and `@effect/platform-bun`.

## Verification
- `pnpm codegen`
- `pnpm docgen` in `packages/effect`
- Built affected packages
- `pnpm lint-fix`
- `pnpm test packages/platform-node/test/HttpApi.test.ts packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts packages/tools/openapi-generator/test/OpenApiPatch.test.ts packages/tools/openapi-generator/test/OpenApiGeneratorCli.test.ts`
- `pnpm test packages/platform-node-shared/test/NodeChildProcessSpawner.test.ts`
- `pnpm check:tsgo`