### PR TITLE
feat(browser): add indexedDb backed KeyValueStore layer

### DIFF
--- a/.changeset/add-indexeddb-kvs-layer.md
+++ b/.changeset/add-indexeddb-kvs-layer.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Adds an IndexedDB backed implementation of `KeyValueStore` as `BrowserKeyValueStore.layerIndexedDb`. This backend allows for non-blocking `KeyValueStore` operations, unlike the existing `Storage` api backed implementations.

--- a/packages/platform-browser/src/BrowserKeyValueStore.ts
+++ b/packages/platform-browser/src/BrowserKeyValueStore.ts
@@ -1,7 +1,8 @@
 /**
  * @since 1.0.0
  */
-import type * as Layer from "effect/Layer"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
 import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
 
 /**
@@ -27,3 +28,104 @@ export const layerLocalStorage: Layer.Layer<KeyValueStore.KeyValueStore> = KeyVa
 export const layerSessionStorage: Layer.Layer<KeyValueStore.KeyValueStore> = KeyValueStore.layerStorage(() =>
   globalThis.sessionStorage
 )
+
+/**
+ * Creates a `KeyValueStore` layer backed by the runtime's `globalThis.indexedDB` implementation.
+ *
+ * Values are stored between sessions.
+ *
+ * @since 4.0.0
+ * @category Layers
+ */
+export const layerIndexedDb = (options?: {
+  readonly database?: string | undefined
+}): Layer.Layer<KeyValueStore.KeyValueStore> =>
+  Layer.effect(KeyValueStore.KeyValueStore)(
+    Effect.gen(function*() {
+      const db = yield* Effect.acquireRelease(
+        openDatabase(options?.database ?? defaultDatabase),
+        (db) => Effect.sync(() => db.close())
+      ).pipe(Effect.orDie)
+      return KeyValueStore.make({
+        clear: Effect.gen(function*() {
+          const store = getKvsEntriesStore(db, "readwrite")
+          yield* idbRequest({ method: "clear", message: "Failed to clear backing store" }, () => store.clear())
+        }),
+        get: Effect.fnUntraced(function*(key: string) {
+          const store = getKvsEntriesStore(db, "readonly")
+          const found = yield* idbRequest<{ key: string; value: string } | undefined>({
+            method: "get",
+            message: "Failed to get value from backing store",
+            key
+          }, () => store.get(key))
+          return found?.value
+        }),
+        getUint8Array: Effect.fnUntraced(function*(key: string) {
+          const store = getKvsEntriesStore(db, "readonly")
+          const found = yield* idbRequest<{ key: string; value: Uint8Array } | undefined>({
+            method: "getUint8Array",
+            message: "Failed to get value from backing store",
+            key
+          }, () => store.get(key))
+          return found?.value
+        }),
+        set: Effect.fnUntraced(function*(key: string, value: string | Uint8Array) {
+          const store = getKvsEntriesStore(db, "readwrite")
+          yield* idbRequest({ method: "set", message: "Failed to set value in backing store", key }, () =>
+            store.put({ key, value }))
+        }),
+        size: Effect.gen(function*() {
+          const store = getKvsEntriesStore(db, "readonly")
+          return yield* idbRequest<number>({ method: "size", message: "Failed to get backing store size" }, () =>
+            store.count())
+        }),
+        remove: Effect.fnUntraced(function*(key: string) {
+          const store = getKvsEntriesStore(db, "readwrite")
+          yield* idbRequest({ method: "remove", message: "Failed to remove value from backing store", key }, () =>
+            store.delete(key))
+        })
+      })
+    })
+  )
+const defaultDatabase = "effect_browser_key_value_store"
+const databaseVersion = 1
+const entriesStoreName = "entries"
+const openDatabase = Effect.fnUntraced(function*(database: string) {
+  const openRequest = yield* Effect.try({
+    try: () => globalThis.indexedDB.open(database, databaseVersion),
+    catch: (cause) =>
+      new KeyValueStore.KeyValueStoreError({
+        method: "open",
+        message: "Failed to open backing store database",
+        cause
+      })
+  })
+  openRequest.onupgradeneeded = () => {
+    const db = openRequest.result
+    if (!db.objectStoreNames.contains(entriesStoreName)) {
+      db.createObjectStore(entriesStoreName, { keyPath: "key" })
+    }
+  }
+  return yield* idbRequest({ method: "open", message: "Failed to open backing store database" }, () => openRequest)
+})
+const idbRequest = <A>(
+  failArgs: { method: string; message: string; key?: string },
+  evaluate: () => IDBRequest<A>
+): Effect.Effect<A, KeyValueStore.KeyValueStoreError> =>
+  Effect.callback<A, KeyValueStore.KeyValueStoreError>((resume) => {
+    const request = evaluate()
+    const fail = (cause: unknown) => {
+      resume(Effect.fail(new KeyValueStore.KeyValueStoreError({ ...failArgs, cause })))
+    }
+    if (request.readyState === "done") {
+      resume(Effect.succeed(request.result))
+    }
+    request.onsuccess = () => {
+      resume(Effect.succeed(request.result))
+    }
+    request.onerror = () => fail(request.error)
+  })
+const getKvsEntriesStore = (db: IDBDatabase, mode: IDBTransactionMode) => {
+  const transaction = db.transaction(entriesStoreName, mode)
+  return transaction.objectStore(entriesStoreName)
+}

--- a/packages/platform-browser/src/BrowserKeyValueStore.ts
+++ b/packages/platform-browser/src/BrowserKeyValueStore.ts
@@ -4,6 +4,7 @@
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
+import { IndexedDb } from "./IndexedDb.ts"
 
 /**
  * Creates a `KeyValueStore` layer that uses the browser's `localStorage` api.
@@ -30,69 +31,83 @@ export const layerSessionStorage: Layer.Layer<KeyValueStore.KeyValueStore> = Key
 )
 
 /**
- * Creates a `KeyValueStore` layer backed by the runtime's `globalThis.indexedDB` implementation.
- *
- * Values are stored between sessions.
+ * Creates a `KeyValueStore` layer backed by IndexedDB.
  *
  * @since 4.0.0
  * @category Layers
  */
 export const layerIndexedDb = (options?: {
   readonly database?: string | undefined
-}): Layer.Layer<KeyValueStore.KeyValueStore> =>
+}): Layer.Layer<KeyValueStore.KeyValueStore, never, IndexedDb> =>
   Layer.effect(KeyValueStore.KeyValueStore)(
     Effect.gen(function*() {
       const db = yield* Effect.acquireRelease(
-        openDatabase(options?.database ?? defaultDatabase),
+        openDatabase(options?.database ?? "effect_key_value_store"),
         (db) => Effect.sync(() => db.close())
       ).pipe(Effect.orDie)
+
       return KeyValueStore.make({
-        clear: Effect.gen(function*() {
+        clear: Effect.suspend(() => {
           const store = getKvsEntriesStore(db, "readwrite")
-          yield* idbRequest({ method: "clear", message: "Failed to clear backing store" }, () => store.clear())
+          return idbRequest({ method: "clear", message: "Failed to clear backing store" }, () => store.clear())
         }),
-        get: Effect.fnUntraced(function*(key: string) {
+        get: (key: string) =>
+          Effect.map(
+            Effect.suspend(() => {
+              const store = getKvsEntriesStore(db, "readonly")
+              return idbRequest<{ key: string; value: string } | undefined>({
+                method: "get",
+                message: "Failed to get value from backing store",
+                key
+              }, () => store.get(key))
+            }),
+            (found) => typeof found?.value === "string" ? found.value : undefined
+          ),
+        getUint8Array: (key: string) =>
+          Effect.map(
+            Effect.suspend(() => {
+              const store = getKvsEntriesStore(db, "readonly")
+              return idbRequest<{ key: string; value: Uint8Array } | undefined>({
+                method: "getUint8Array",
+                message: "Failed to get value from backing store",
+                key
+              }, () => store.get(key))
+            }),
+            (found) => found?.value && found.value instanceof Uint8Array ? found.value : undefined
+          ),
+        set: (key: string, value: string | Uint8Array) =>
+          Effect.asVoid(Effect.suspend(() => {
+            const store = getKvsEntriesStore(db, "readwrite")
+            return idbRequest(
+              { method: "set", message: "Failed to set value in backing store", key },
+              () => store.put({ key, value })
+            )
+          })),
+        size: Effect.suspend(() => {
           const store = getKvsEntriesStore(db, "readonly")
-          const found = yield* idbRequest<{ key: string; value: string } | undefined>({
-            method: "get",
-            message: "Failed to get value from backing store",
-            key
-          }, () => store.get(key))
-          return found?.value
+          return idbRequest<number>(
+            { method: "size", message: "Failed to get backing store size" },
+            () => store.count()
+          )
         }),
-        getUint8Array: Effect.fnUntraced(function*(key: string) {
-          const store = getKvsEntriesStore(db, "readonly")
-          const found = yield* idbRequest<{ key: string; value: Uint8Array } | undefined>({
-            method: "getUint8Array",
-            message: "Failed to get value from backing store",
-            key
-          }, () => store.get(key))
-          return found?.value
-        }),
-        set: Effect.fnUntraced(function*(key: string, value: string | Uint8Array) {
-          const store = getKvsEntriesStore(db, "readwrite")
-          yield* idbRequest({ method: "set", message: "Failed to set value in backing store", key }, () =>
-            store.put({ key, value }))
-        }),
-        size: Effect.gen(function*() {
-          const store = getKvsEntriesStore(db, "readonly")
-          return yield* idbRequest<number>({ method: "size", message: "Failed to get backing store size" }, () =>
-            store.count())
-        }),
-        remove: Effect.fnUntraced(function*(key: string) {
-          const store = getKvsEntriesStore(db, "readwrite")
-          yield* idbRequest({ method: "remove", message: "Failed to remove value from backing store", key }, () =>
-            store.delete(key))
-        })
+        remove: (key: string) =>
+          Effect.asVoid(Effect.suspend(() => {
+            const store = getKvsEntriesStore(db, "readwrite")
+            return idbRequest(
+              { method: "remove", message: "Failed to remove value from backing store", key },
+              () => store.delete(key)
+            )
+          }))
       })
     })
   )
-const defaultDatabase = "effect_browser_key_value_store"
+
 const databaseVersion = 1
 const entriesStoreName = "entries"
 const openDatabase = Effect.fnUntraced(function*(database: string) {
+  const idb = (yield* IndexedDb).indexedDB
   const openRequest = yield* Effect.try({
-    try: () => globalThis.indexedDB.open(database, databaseVersion),
+    try: () => idb.open(database, databaseVersion),
     catch: (cause) =>
       new KeyValueStore.KeyValueStoreError({
         method: "open",
@@ -108,23 +123,28 @@ const openDatabase = Effect.fnUntraced(function*(database: string) {
   }
   return yield* idbRequest({ method: "open", message: "Failed to open backing store database" }, () => openRequest)
 })
+
 const idbRequest = <A>(
   failArgs: { method: string; message: string; key?: string },
   evaluate: () => IDBRequest<A>
 ): Effect.Effect<A, KeyValueStore.KeyValueStoreError> =>
   Effect.callback<A, KeyValueStore.KeyValueStoreError>((resume) => {
     const request = evaluate()
-    const fail = (cause: unknown) => {
-      resume(Effect.fail(new KeyValueStore.KeyValueStoreError({ ...failArgs, cause })))
-    }
     if (request.readyState === "done") {
-      resume(Effect.succeed(request.result))
+      return resume(Effect.succeed(request.result))
     }
     request.onsuccess = () => {
       resume(Effect.succeed(request.result))
     }
-    request.onerror = () => fail(request.error)
+    request.onerror = () =>
+      resume(Effect.fail(
+        new KeyValueStore.KeyValueStoreError({
+          ...failArgs,
+          cause: request.error
+        })
+      ))
   })
+
 const getKvsEntriesStore = (db: IDBDatabase, mode: IDBTransactionMode) => {
   const transaction = db.transaction(entriesStoreName, mode)
   return transaction.objectStore(entriesStoreName)

--- a/packages/platform-browser/src/IndexedDb.ts
+++ b/packages/platform-browser/src/IndexedDb.ts
@@ -1,12 +1,10 @@
 /**
  * @since 4.0.0
  */
-import * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import * as Schema from "effect/Schema"
-import * as SchemaIssue from "effect/SchemaIssue"
 
 const TypeId = "~@effect/platform-browser/IndexedDb"
 
@@ -72,7 +70,7 @@ export const make = (impl: Omit<IndexedDb, typeof TypeId>): IndexedDb => Indexed
  * @since 4.0.0
  * @category constructors
  */
-export const layerWindow: Layer.Layer<IndexedDb, Config.ConfigError> = Layer.effect(
+export const layerWindow: Layer.Layer<IndexedDb> = Layer.effect(
   IndexedDb,
   Effect.suspend(() => {
     if (window.indexedDB && window.IDBKeyRange) {
@@ -83,15 +81,7 @@ export const layerWindow: Layer.Layer<IndexedDb, Config.ConfigError> = Layer.eff
         })
       )
     } else {
-      return Effect.fail(
-        new Config.ConfigError(
-          new Schema.SchemaError(
-            new SchemaIssue.MissingKey({
-              messageMissingKey: "window.indexedDB is not available"
-            })
-          )
-        )
-      )
+      return Effect.die(new Error("window.indexedDB is not available"))
     }
   })
 )

--- a/packages/platform-browser/test/BrowserKeyValueStore.test.ts
+++ b/packages/platform-browser/test/BrowserKeyValueStore.test.ts
@@ -1,7 +1,13 @@
 import * as BrowserKeyValueStore from "@effect/platform-browser/BrowserKeyValueStore"
 import { describe } from "@effect/vitest"
 import { testLayer } from "effect-test/unstable/persistence/KeyValueStore.test"
+import { indexedDB as fakeIndexedDb } from "fake-indexeddb"
 
 describe("KeyValueStore / layerLocalStorage", () => testLayer(BrowserKeyValueStore.layerLocalStorage))
 
 describe("KeyValueStore / layerSessionStorage", () => testLayer(BrowserKeyValueStore.layerSessionStorage))
+
+describe("KeyValueStore / layerIndexedDb", () => {
+  Reflect.set(globalThis, "indexedDB", fakeIndexedDb)
+  testLayer(BrowserKeyValueStore.layerIndexedDb({ database: "kvs_test_db" }))
+})

--- a/packages/platform-browser/test/BrowserKeyValueStore.test.ts
+++ b/packages/platform-browser/test/BrowserKeyValueStore.test.ts
@@ -1,13 +1,23 @@
 import * as BrowserKeyValueStore from "@effect/platform-browser/BrowserKeyValueStore"
+import * as IndexedDb from "@effect/platform-browser/IndexedDb"
 import { describe } from "@effect/vitest"
+import { Layer } from "effect"
 import { testLayer } from "effect-test/unstable/persistence/KeyValueStore.test"
-import { indexedDB as fakeIndexedDb } from "fake-indexeddb"
+import { IDBKeyRange, indexedDB } from "fake-indexeddb"
 
 describe("KeyValueStore / layerLocalStorage", () => testLayer(BrowserKeyValueStore.layerLocalStorage))
 
 describe("KeyValueStore / layerSessionStorage", () => testLayer(BrowserKeyValueStore.layerSessionStorage))
 
 describe("KeyValueStore / layerIndexedDb", () => {
-  Reflect.set(globalThis, "indexedDB", fakeIndexedDb)
-  testLayer(BrowserKeyValueStore.layerIndexedDb({ database: "kvs_test_db" }))
+  const layerFakeIndexedDb = Layer.succeed(
+    IndexedDb.IndexedDb,
+    IndexedDb.make({ indexedDB, IDBKeyRange })
+  )
+
+  testLayer(
+    BrowserKeyValueStore.layerIndexedDb({ database: "kvs_test_db" }).pipe(
+      Layer.provide(layerFakeIndexedDb)
+    )
+  )
 })


### PR DESCRIPTION
## Summary

Adds `BrowserKeyValueStore.layerIndexedDb`, an IndexedDB-backed `KeyValueStore` implementation in `@effect/platform-browser`.

Provides an async persistent storage option alongside the existing `Storage`-backed browser layers. Particularly useful for render flows where the synchronous/blocking `Storage` APIs would degrade performance.

## Notes

- Patterns largely based on those in `packages/platform-browser/src/BrowserPersistence.ts`
  - I noticed that in the `BrowserPersisted` and `IndexedDb*` modules there is no accounting for any [exceptions raised from calling the  `IDBDatabase.transaction`](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/transaction#exceptions) method. Im assuming you guys are just treating these as invariant breaks and letting them turn into defects. 
- Unsure if any more steps are needed to correctly manage the in-memory `fakeIndexedDb`  for `BrowserKeyValueStore.test.ts`
- Unsure if the `IndexedDb*` modules should/could be used in place of the internal helpers like in the `BrowserPersistence` IDB implementation.