### PR TITLE
Fix MutableList length after filter and remove

### DIFF
--- a/.changeset/fix-mutable-list-filter-length.md
+++ b/.changeset/fix-mutable-list-filter-length.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `MutableList.filter` and `MutableList.remove` length updates.

--- a/packages/effect/src/MutableList.ts
+++ b/packages/effect/src/MutableList.ts
@@ -908,6 +908,7 @@ export const filter = <A>(self: MutableList<A>, f: (value: A, i: number) => bool
     offset: 0,
     next: undefined
   }
+  self.length = array.length
 }
 
 /**

--- a/packages/effect/test/MutableList.test.ts
+++ b/packages/effect/test/MutableList.test.ts
@@ -35,4 +35,24 @@ describe("MutableList", () => {
     deepStrictEqual(MutableList.takeAll(list), [1, 2])
     strictEqual(MutableList.take(list), MutableList.Empty)
   })
+
+  it("filter updates length to the number of retained elements", () => {
+    const list = MutableList.make<number>()
+    MutableList.appendAll(list, [1, 2, 3, 4, 5])
+
+    MutableList.filter(list, (n) => n % 2 === 0)
+
+    deepStrictEqual(MutableList.toArrayN(list, 2), [2, 4])
+    strictEqual(list.length, 2)
+  })
+
+  it("remove updates length after deleting matching values", () => {
+    const list = MutableList.make<string>()
+    MutableList.appendAll(list, ["apple", "banana", "apple", "cherry", "apple"])
+
+    MutableList.remove(list, "apple")
+
+    deepStrictEqual(MutableList.toArrayN(list, 2), ["banana", "cherry"])
+    strictEqual(list.length, 2)
+  })
 })


### PR DESCRIPTION
## Summary

Fix `MutableList.filter` and `MutableList.remove` so `length` reflects the retained elements.

## What changed

- Added regression tests for `filter` and `remove` length updates.
- Updated `MutableList.filter` to refresh `self.length` after rebuilding the retained elements.

## Why

`filter` rebuilds the list buckets but leaves `self.length` unchanged. Since `remove` delegates to `filter`, both APIs can report stale lengths after dropping values.

## Testing

- `pnpm test packages/effect/test/MutableList.test.ts --run`
- `pnpm check:tsgo`
- `pnpm lint`
- `git diff --check`

Closes #2193
