### PR TITLE
feat: add support for merging external events into `Prompt.custom`

### DIFF
--- a/.changeset/bold-planets-shout.md
+++ b/.changeset/bold-planets-shout.md
@@ -1,0 +1,22 @@
+---
+"effect": minor
+---
+
+add support for merging external events into `Prompt.custom` render loops via an optional `events` dequeue and `receive` handler.
+
+The prompt races user input against events from the dequeue, allowing background events to trigger re-renders without waiting for a keypress:
+
+```ts
+const eventQueue = yield * Queue.make<number>()
+
+const prompt = Prompt.custom(
+  { count: 0 },
+  {
+    render: (state) => Effect.succeed(`Count: ${state.count}`),
+    process: (_input, state) => Effect.succeed(Action.Submit({ value: state.count })),
+    clear: () => Effect.succeed(""),
+    receive: (value, state) => Effect.succeed(Action.NextFrame({ state: { count: state.count + value } })) // <-- handle events from the dequeue
+  },
+  Queue.asDequeue(eventQueue) // <-- provide the event queue as a dequeue to the prompt
+)
+```

--- a/.changeset/bold-planets-shout.md
+++ b/.changeset/bold-planets-shout.md
@@ -11,12 +11,20 @@ const eventQueue = yield * Queue.make<number>()
 
 const prompt = Prompt.custom(
   { count: 0 },
+  Queue.asDequeue(eventQueue), // <-- provide the event queue as a dequeue to the prompt
   {
     render: (state) => Effect.succeed(`Count: ${state.count}`),
-    process: (_input, state) => Effect.succeed(Action.Submit({ value: state.count })),
-    clear: () => Effect.succeed(""),
-    receive: (value, state) => Effect.succeed(Action.NextFrame({ state: { count: state.count + value } })) // <-- handle events from the dequeue
-  },
-  Queue.asDequeue(eventQueue) // <-- provide the event queue as a dequeue to the prompt
+    process: (input, state) =>
+      Effect.succeed(
+        Match.value(input).pipe(
+          // handle user input
+          Match.tag("Input", () => Action.Submit({ value: state.count })),
+          // handle external events from the queue
+          Match.tag("Event", (input) => Action.NextFrame({ state: { count: state.count + input.value } })),
+          Match.exhaustive
+        )
+      ),
+    clear: () => Effect.succeed("")
+  }
 )
 ```

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -94,6 +94,18 @@ export interface ActionDefinition extends Data.TaggedEnum.WithGenerics<2> {
 }
 
 /**
+ * Represents the input that should be processed by a `Prompt` based upon user
+ * input or an external event received during the current frame.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ProcessInput<A> = Data.TaggedEnum<{
+  readonly Input: { readonly input: Terminal.UserInput }
+  readonly Event: { readonly value: A }
+}>
+
+/**
  * Represents the set of handlers used by a `Prompt`.
  *
  * **Details**
@@ -104,7 +116,7 @@ export interface ActionDefinition extends Data.TaggedEnum.WithGenerics<2> {
  * @category models
  * @since 4.0.0
  */
-export interface Handlers<State, Output> {
+export interface Handlers<State, Output, Input = Terminal.UserInput> {
   /**
    * A function that is called to render the current frame of the `Prompt`.
    */
@@ -117,7 +129,7 @@ export interface Handlers<State, Output> {
    * `Prompt.Action` that should be taken.
    */
   readonly process: (
-    input: Terminal.UserInput,
+    input: Input,
     state: State
   ) => Effect.Effect<Action<State, Output>, never, Environment>
   /**
@@ -767,25 +779,24 @@ export const custom: {
   ): Prompt<Output>
   <State, Output, A>(
     initialState: State | Effect.Effect<State, never, Environment>,
-    handlers: Handlers<State, Output> & {
-      readonly receive: (value: A, state: State) => Effect.Effect<Action<State, Output>, never, Environment>
-    },
-    events: Queue.Dequeue<A, never>
+    events: Queue.Dequeue<A, never>,
+    handlers: Handlers<State, Output, ProcessInput<A>>
   ): Prompt<Output>
 } = <State, Output, A>(
   initialState: State | Effect.Effect<State, never, Environment>,
-  handlers: Handlers<State, Output> & {
-    readonly receive?: (value: A, state: State) => Effect.Effect<Action<State, Output>, never, Environment>
-  },
-  events?: Queue.Dequeue<A, never>
+  ...args:
+    | [handlers: Handlers<State, Output, Terminal.UserInput>]
+    | [events: Queue.Dequeue<A, never>, handlers: Handlers<State, Output, ProcessInput<A>>]
 ): Prompt<Output> => {
+  const [events, handlers] = args.length === 1
+    ? [undefined, args[0]] as const
+    : [args[0], args[1]] as const
   const op = Object.create(proto)
   op._tag = "Loop"
   op.initialState = initialState
   op.render = handlers.render
   op.process = handlers.process
   op.clear = handlers.clear
-  op.receive = handlers.receive
   op.events = events
   return op
 }
@@ -1275,11 +1286,11 @@ interface Loop extends
   Op<"Loop", {
     readonly initialState: unknown | Effect.Effect<unknown, never, Environment>
     readonly render: Handlers<unknown, unknown>["render"]
-    readonly process: Handlers<unknown, unknown>["process"]
+    readonly process: (
+      input: unknown,
+      state: unknown
+    ) => Effect.Effect<Action<unknown, unknown>, never, Environment>
     readonly clear: Handlers<unknown, unknown>["clear"]
-    readonly receive:
-      | ((value: unknown, state: unknown) => Effect.Effect<Action<unknown, unknown>, never, Environment>)
-      | undefined
     readonly events: Queue.Dequeue<unknown, never> | undefined
   }>
 {}
@@ -1351,16 +1362,19 @@ const runLoop = Effect.fnUntraced(
     while (true) {
       const msg = yield* loop.render(state, action)
       yield* Effect.orDie(terminal.display(msg))
-      const takeInput = Queue.take(input).pipe(Effect.map((event) => ({ _tag: "Input" as const, event })))
-      const result = loop.events
-        ? yield* Effect.raceFirst(
+      if (loop.events) {
+        const takeInput = Queue.take(input).pipe(
+          Effect.map((event) => ({ _tag: "Input" as const, event }))
+        )
+        const result = yield* Effect.raceFirst(
           takeInput,
           Queue.take(loop.events).pipe(Effect.map((value) => ({ _tag: "Event" as const, value })))
         )
-        : yield* takeInput
-      action = result._tag === "Input"
-        ? yield* loop.process(result.event, state)
-        : yield* loop.receive!(result.value, state)
+        action = yield* loop.process(result, state)
+      } else {
+        const result = yield* Queue.take(input)
+        action = yield* loop.process(result, state)
+      }
       switch (action._tag) {
         case "Beep":
           continue

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -66,8 +66,8 @@ export const isPrompt = (u: unknown): u is Prompt<unknown> => Predicate.hasPrope
 export type Environment = FileSystem.FileSystem | Path.Path | Terminal.Terminal
 
 /**
- * Represents the action that should be taken by a `Prompt` based upon the
- * user input received during the current frame.
+ * Represents the action that should be taken by a `Prompt` based upon user
+ * input or an external event received during the current frame.
  *
  * @category models
  * @since 4.0.0
@@ -751,12 +751,33 @@ export const confirm = (options: ConfirmOptions): Prompt<boolean> => {
  * next prompt action, and `clear` returns ANSI output used to clear the previous
  * frame.
  *
+ * Optionally, an external `events` dequeue can be provided as the third
+ * argument. When present, the render loop will race user input against events
+ * from the dequeue, allowing background events to trigger re-renders without
+ * waiting for a keypress. When an event is received from the dequeue, the
+ * `receive` handler is called instead of `process`.
+ *
  * @category constructors
  * @since 4.0.0
  */
-export const custom = <State, Output>(
+export const custom: {
+  <State, Output>(
+    initialState: State | Effect.Effect<State, never, Environment>,
+    handlers: Handlers<State, Output>
+  ): Prompt<Output>
+  <State, Output, A>(
+    initialState: State | Effect.Effect<State, never, Environment>,
+    handlers: Handlers<State, Output> & {
+      readonly receive: (value: A, state: State) => Effect.Effect<Action<State, Output>, never, Environment>
+    },
+    events: Queue.Dequeue<A, never>
+  ): Prompt<Output>
+} = <State, Output, A>(
   initialState: State | Effect.Effect<State, never, Environment>,
-  handlers: Handlers<State, Output>
+  handlers: Handlers<State, Output> & {
+    readonly receive?: (value: A, state: State) => Effect.Effect<Action<State, Output>, never, Environment>
+  },
+  events?: Queue.Dequeue<A, never>
 ): Prompt<Output> => {
   const op = Object.create(proto)
   op._tag = "Loop"
@@ -764,6 +785,8 @@ export const custom = <State, Output>(
   op.render = handlers.render
   op.process = handlers.process
   op.clear = handlers.clear
+  op.receive = handlers.receive
+  op.events = events
   return op
 }
 
@@ -1254,6 +1277,10 @@ interface Loop extends
     readonly render: Handlers<unknown, unknown>["render"]
     readonly process: Handlers<unknown, unknown>["process"]
     readonly clear: Handlers<unknown, unknown>["clear"]
+    readonly receive:
+      | ((value: unknown, state: unknown) => Effect.Effect<Action<unknown, unknown>, never, Environment>)
+      | undefined
+    readonly events: Queue.Dequeue<unknown, never> | undefined
   }>
 {}
 
@@ -1324,8 +1351,16 @@ const runLoop = Effect.fnUntraced(
     while (true) {
       const msg = yield* loop.render(state, action)
       yield* Effect.orDie(terminal.display(msg))
-      const event = yield* Queue.take(input)
-      action = yield* loop.process(event, state)
+      const takeInput = Queue.take(input).pipe(Effect.map((event) => ({ _tag: "Input" as const, event })))
+      const result = loop.events
+        ? yield* Effect.raceFirst(
+          takeInput,
+          Queue.take(loop.events).pipe(Effect.map((value) => ({ _tag: "Event" as const, value })))
+        )
+        : yield* takeInput
+      action = result._tag === "Input"
+        ? yield* loop.process(result.event, state)
+        : yield* loop.receive!(result.value, state)
       switch (action._tag) {
         case "Beep":
           continue

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Data, Effect, Fiber, FileSystem, Layer, Path, Queue, Redacted } from "effect"
+import { Data, Effect, Fiber, FileSystem, Layer, Match, Path, Queue, Redacted } from "effect"
 import { TestConsole } from "effect/testing"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
@@ -527,14 +527,20 @@ describe("Prompt.custom", () => {
 
       const prompt = Prompt.custom(
         { count: 0 },
+        Queue.asDequeue(eventQueue),
         {
           render: (state) => Effect.succeed(`Count: ${state.count}`),
-          process: (_input, state) => Effect.succeed(Action.Submit({ value: state.count })),
-          clear: () => Effect.succeed(""),
-          receive: (value, state) =>
-            Effect.succeed(Action.NextFrame({ state: { count: state.count + (value === "tick" ? 1 : 0) } }))
-        },
-        Queue.asDequeue(eventQueue)
+          process: (input, state) =>
+            Match.value(input).pipe(
+              Match.tag("Input", () => Effect.succeed(Action.Submit({ value: state.count }))),
+              Match.tag("Event", ({ value }) =>
+                Effect.succeed(
+                  Action.NextFrame({ state: { count: state.count + (value === "tick" ? 1 : 0) } })
+                )),
+              Match.exhaustive
+            ),
+          clear: () => Effect.succeed("")
+        }
       )
 
       const fiber = yield* Prompt.run(prompt).pipe(Effect.forkChild)
@@ -563,18 +569,22 @@ describe("Prompt.custom", () => {
 
       const prompt = Prompt.custom(
         { keys: 0 },
+        Queue.asDequeue(eventQueue),
         {
           render: (state) => Effect.succeed(`Keys: ${state.keys}`),
-          process: (_input, state) => {
-            const next = state.keys + 1
-            return next >= 3
-              ? Effect.succeed(Action.Submit({ value: next }))
-              : Effect.succeed(Action.NextFrame({ state: { keys: next } }))
-          },
-          clear: () => Effect.succeed(""),
-          receive: (_value, state) => Effect.succeed(Action.NextFrame({ state }))
-        },
-        Queue.asDequeue(eventQueue)
+          process: (input, state) =>
+            Match.value(input).pipe(
+              Match.tag("Input", () => {
+                const next = state.keys + 1
+                return next >= 3
+                  ? Effect.succeed(Action.Submit({ value: next }))
+                  : Effect.succeed(Action.NextFrame({ state: { keys: next } }))
+              }),
+              Match.tag("Event", () => Effect.succeed(Action.NextFrame({ state }))),
+              Match.exhaustive
+            ),
+          clear: () => Effect.succeed("")
+        }
       )
 
       yield* MockTerminal.inputKey("a")

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, FileSystem, Layer, Path, Redacted } from "effect"
+import { Data, Effect, Fiber, FileSystem, Layer, Path, Queue, Redacted } from "effect"
 import { TestConsole } from "effect/testing"
 import { Prompt } from "effect/unstable/cli"
 import * as MockTerminal from "./services/MockTerminal.ts"
@@ -15,6 +15,7 @@ const TestLayer = Layer.mergeAll(
   PathLayer,
   TerminalLayer
 )
+const Action = Data.taggedEnum<Prompt.ActionDefinition>()
 
 const escape = String.fromCharCode(27)
 const bell = String.fromCharCode(7)
@@ -516,5 +517,71 @@ describe("Prompt.multiSelect", () => {
 
       const result = yield* Fiber.join(fiber)
       assert.deepStrictEqual(result, [])
+    }).pipe(Effect.provide(TestLayer)))
+})
+
+describe("Prompt.custom", () => {
+  it.effect("receive handles events from external dequeue", () =>
+    Effect.gen(function*() {
+      const eventQueue = yield* Queue.make<string>()
+
+      const prompt = Prompt.custom(
+        { count: 0 },
+        {
+          render: (state) => Effect.succeed(`Count: ${state.count}`),
+          process: (_input, state) => Effect.succeed(Action.Submit({ value: state.count })),
+          clear: () => Effect.succeed(""),
+          receive: (value, state) =>
+            Effect.succeed(Action.NextFrame({ state: { count: state.count + (value === "tick" ? 1 : 0) } }))
+        },
+        Queue.asDequeue(eventQueue)
+      )
+
+      const fiber = yield* Prompt.run(prompt).pipe(Effect.forkChild)
+
+      // Give the prompt loop time to start and block on the race
+      yield* Effect.yieldNow
+
+      // Push two events
+      yield* Queue.offer(eventQueue, "tick")
+      yield* Effect.yieldNow
+      yield* Queue.offer(eventQueue, "tock")
+      yield* Effect.yieldNow
+      yield* Queue.offer(eventQueue, "tick")
+      yield* Effect.yieldNow
+
+      // Submit via keypress
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Fiber.join(fiber)
+      assert.strictEqual(result, 2)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("falls back to process when no events are pending", () =>
+    Effect.gen(function*() {
+      const eventQueue = yield* Queue.make<string>()
+
+      const prompt = Prompt.custom(
+        { keys: 0 },
+        {
+          render: (state) => Effect.succeed(`Keys: ${state.keys}`),
+          process: (_input, state) => {
+            const next = state.keys + 1
+            return next >= 3
+              ? Effect.succeed(Action.Submit({ value: next }))
+              : Effect.succeed(Action.NextFrame({ state: { keys: next } }))
+          },
+          clear: () => Effect.succeed(""),
+          receive: (_value, state) => Effect.succeed(Action.NextFrame({ state }))
+        },
+        Queue.asDequeue(eventQueue)
+      )
+
+      yield* MockTerminal.inputKey("a")
+      yield* MockTerminal.inputKey("b")
+      yield* MockTerminal.inputKey("c")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, 3)
     }).pipe(Effect.provide(TestLayer)))
 })

--- a/packages/effect/typetest/unstable/cli/Prompt.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Prompt.tst.ts
@@ -1,0 +1,97 @@
+import { Effect, Match, type Queue, type Terminal } from "effect"
+import { Prompt } from "effect/unstable/cli"
+import { describe, expect, it } from "tstyche"
+
+declare const stringEvents: Queue.Dequeue<string, never>
+declare const objectEvents: Queue.Dequeue<{ readonly tick: number }, never>
+
+describe("Prompt", () => {
+  describe("custom", () => {
+    it("without events, process receives Terminal.UserInput", () => {
+      Prompt.custom(
+        { count: 0 },
+        {
+          render: () => Effect.succeed(""),
+          process: (input, _state) => {
+            expect(input).type.toBe<Terminal.UserInput>()
+            return Effect.succeed({ _tag: "Submit" as const, value: 42 })
+          },
+          clear: () => Effect.succeed("")
+        }
+      )
+    })
+
+    it("with events, process receives ProcessInput<A>", () => {
+      Prompt.custom(
+        { count: 0 },
+        stringEvents,
+        {
+          render: () => Effect.succeed(""),
+          process: (input, _state) => {
+            expect(input).type.toBe<Prompt.ProcessInput<string>>()
+            return Effect.succeed({ _tag: "Submit" as const, value: 42 })
+          },
+          clear: () => Effect.succeed("")
+        }
+      )
+    })
+
+    it("ProcessInput is a discriminated union narrowed by _tag", () => {
+      Prompt.custom(
+        { count: 0 },
+        objectEvents,
+        {
+          render: () => Effect.succeed(""),
+          process: (input, _state) => {
+            if (input._tag === "Input") {
+              expect(input.input).type.toBe<Terminal.UserInput>()
+            } else {
+              expect(input.value).type.toBe<{ readonly tick: number }>()
+            }
+            return Effect.succeed({ _tag: "Submit" as const, value: 0 })
+          },
+          clear: () => Effect.succeed("")
+        }
+      )
+    })
+
+    it("returns Prompt<Output>", () => {
+      const prompt = Prompt.custom(
+        0,
+        {
+          render: () => Effect.succeed(""),
+          process: ({ key }, state) =>
+            Effect.succeed(
+              key.name === "enter" ? { _tag: "Submit" as const, value: state } : { _tag: "Beep" as const }
+            ),
+          clear: () => Effect.succeed("")
+        }
+      )
+
+      expect(prompt).type.toBe<Prompt.Prompt<number>>()
+    })
+
+    it("returns Prompt<Output> with events", () => {
+      const prompt = Prompt.custom(
+        0,
+        stringEvents,
+        {
+          render: () => Effect.succeed(""),
+          process: (input, state) =>
+            Effect.succeed(
+              Match.value(input).pipe(
+                Match.tag("Input", ({ input }) =>
+                  input.key.name === "enter" ? { _tag: "Submit" as const, value: state } : { _tag: "Beep" as const }),
+                Match.tag("Event", ({ value }) =>
+                  value === "tick" ? { _tag: "NextFrame" as const, state: state + 1 } : { _tag: "Beep" as const }),
+                Match.exhaustive
+              )
+            ),
+          clear: () => Effect.succeed("")
+        }
+      )
+
+      expect(prompt).type.toBe<Prompt.Prompt<number>>()
+    })
+  })
+})


### PR DESCRIPTION
## Type

- [x] Feature

## Description

I've been wanting a way to link in external data into the `Prompt.custom` in a way that triggers a re-render without needing to press a key stroke. In the current implementation I need to fake a key stroke using `process.stdin` as a hack-y work around or build me own render loop from scratch.  Ideally what I wanted was an API where I could just pass in a stream of events and be able to trigger the action with the next state:

```ts
const eventQueue = yield * Queue.make<number>()

const prompt = Prompt.custom(
  { count: 0 },
  Queue.asDequeue(eventQueue), // <-- provide the event queue as a dequeue to the prompt
  {
    render: (state) => Effect.succeed(`Count: ${state.count}`),
    process: (input, state) =>
      Effect.succeed(
        Match.value(input).pipe(
          // handle user input
          Match.tag("Input", () => Action.Submit({ value: state.count })),
          // handle external events from the queue
          Match.tag("Event", (input) => Action.NextFrame({ state: { count: state.count + input.value } })),
          Match.exhaustive
        )
      ),
    clear: () => Effect.succeed("")
  }
)
```

I've been digging around in the Prompt.ts for a while now so I already knew the `Terminal.readInput` was a Queue and that it shouldn't be too hard to just merge two Queues together.

What I settled on was a type overload where there is the current implementation without the event doing the same thing (non-breaking) and the new type that adds the new `events` Queue.Dequeued argument ~and extends the handlers with the `received` callback~.  This way adding the queue can be a progressive enhancement on an already functioning user input only prompt.

Some things I needed to mull over:
- The `Prompt` isn't responsible for cleaning up the `Queue`, this needs to be handled by the user
- There is a very small possibility of an event and a user input happening simultaneously and which one is picked first is indeterministic (I think)
- Queue needs to not fail (`Queue.Dequeue<A, never>` so the user is responsible outside of the Prompt to handle these causes.

## Related

I wanted to make an issue first but needed to open the repo to poke around in the types and next thing I know I was already halfway through implementing it 🤦‍♂️

Open to other suggestions or requests to change the approach.

---

Edit: Have changed the api a bit to put the event before the handler as well as removed the new received callback in favour of overloading the process with a taggedEnum when event us present.