### PR TITLE
EFF-807 Add Stream.broadcastN

### DIFF
--- a/.changeset/add-stream-broadcastn.md
+++ b/.changeset/add-stream-broadcastn.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add Stream.broadcastN for fixed-size stream broadcasts.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -8513,7 +8513,7 @@ const makePubSub = <A>(
  * the same elements as the source stream.
  *
  * The source stream starts after all downstream streams have been subscribed.
- * With the default suspend strategy, the source can only advance `maximumLag`
+ * With the default suspend strategy, the source can only advance `capacity`
  * chunks ahead of the slowest downstream stream. If a downstream stream is
  * interrupted, it unsubscribes from the broadcast so it no longer contributes
  * backpressure.
@@ -8526,7 +8526,7 @@ const makePubSub = <A>(
  * const program = Effect.scoped(
  *   Effect.gen(function*() {
  *     const [left, right] = yield* Stream.make(1, 2, 3).pipe(
- *       Stream.broadcastN(2, 8)
+ *       Stream.broadcastN({ n: 2, capacity: 8 })
  *     )
  *
  *     const values = yield* Effect.all([
@@ -8547,48 +8547,55 @@ const makePubSub = <A>(
  */
 export const broadcastN: {
   <N extends number>(
-    n: N,
-    maximumLag: number | {
-      readonly capacity: "unbounded"
-      readonly replay?: number | undefined
-    } | {
-      readonly capacity: number
-      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-      readonly replay?: number | undefined
-    }
+    options:
+      & {
+        readonly n: N
+      }
+      & ({
+        readonly capacity: "unbounded"
+        readonly replay?: number | undefined
+      } | {
+        readonly capacity: number
+        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+        readonly replay?: number | undefined
+      })
   ): <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
   <A, E, R, N extends number>(
     self: Stream<A, E, R>,
-    n: N,
-    maximumLag: number | {
-      readonly capacity: "unbounded"
-      readonly replay?: number | undefined
-    } | {
-      readonly capacity: number
-      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-      readonly replay?: number | undefined
-    }
+    options:
+      & {
+        readonly n: N
+      }
+      & ({
+        readonly capacity: "unbounded"
+        readonly replay?: number | undefined
+      } | {
+        readonly capacity: number
+        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+        readonly replay?: number | undefined
+      })
   ): Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
 } = dual(
-  3,
+  2,
   Effect.fnUntraced(function*<A, E, R, N extends number>(
     self: Stream<A, E, R>,
-    n: N,
-    maximumLag: number | {
-      readonly capacity: "unbounded"
-      readonly replay?: number | undefined
-    } | {
-      readonly capacity: number
-      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-      readonly replay?: number | undefined
-    }
+    options:
+      & {
+        readonly n: N
+      }
+      & ({
+        readonly capacity: "unbounded"
+        readonly replay?: number | undefined
+      } | {
+        readonly capacity: number
+        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+        readonly replay?: number | undefined
+      })
   ) {
-    const pubsub = yield* makePubSub<Take.Take<A, E>>(
-      typeof maximumLag === "number" ? { capacity: maximumLag } : maximumLag
-    )
+    const pubsub = yield* makePubSub<Take.Take<A, E>>(options)
     const parentScope = yield* Scope.Scope
     const streams = yield* Effect.all(
-      Array.from({ length: n }, () => {
+      Array.from({ length: options.n }, () => {
         const scope = Scope.forkUnsafe(parentScope)
         return PubSub.subscribe(pubsub).pipe(
           Effect.provideService(Scope.Scope, scope),

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -67,7 +67,7 @@ import * as Option from "./Option.ts"
 import type { Pipeable } from "./Pipeable.ts"
 import type { Predicate, Refinement } from "./Predicate.ts"
 import { hasProperty, isNotUndefined, isTagged } from "./Predicate.ts"
-import type * as PubSub from "./PubSub.ts"
+import * as PubSub from "./PubSub.ts"
 import * as Pull from "./Pull.ts"
 import * as Queue from "./Queue.ts"
 import * as RcMap from "./RcMap.ts"
@@ -90,6 +90,7 @@ import type {
   OmitReason,
   ReasonTags,
   Tags,
+  TupleOf,
   unassigned
 } from "./Types.ts"
 import type * as Unify from "./Unify.ts"
@@ -8485,6 +8486,111 @@ export const aggregateWithin: {
       Effect.flatMap((pull) => Effect.raceFirst(catchSinkHalt(pull), stepToBuffer))
     )
   }))))
+
+type BroadcastNOptions = {
+  readonly capacity: "unbounded"
+  readonly replay?: number | undefined
+} | {
+  readonly capacity: number
+  readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+  readonly replay?: number | undefined
+}
+
+const makeBroadcastNPubSub = <A, E>(
+  options: number | BroadcastNOptions
+): Effect.Effect<PubSub.PubSub<Take.Take<A, E>>, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    typeof options === "number"
+      ? PubSub.bounded<Take.Take<A, E>>(options)
+      : options.capacity === "unbounded"
+      ? PubSub.unbounded<Take.Take<A, E>>(options)
+      : options.strategy === "dropping"
+      ? PubSub.dropping<Take.Take<A, E>>(options)
+      : options.strategy === "sliding"
+      ? PubSub.sliding<Take.Take<A, E>>(options)
+      : PubSub.bounded<Take.Take<A, E>>(options),
+    PubSub.shutdown
+  )
+
+/**
+ * Fan out the stream, producing a fixed-size tuple of streams that each emit
+ * the same elements as the source stream.
+ *
+ * The source stream starts after all downstream streams have been subscribed.
+ * With the default suspend strategy, the source can only advance `maximumLag`
+ * chunks ahead of the slowest downstream stream. If a downstream stream is
+ * interrupted, it unsubscribes from the broadcast so it no longer contributes
+ * backpressure.
+ *
+ * **Example** (Broadcasting to two consumers)
+ *
+ * ```ts
+ * import { Console, Effect, Stream } from "effect"
+ *
+ * const program = Effect.scoped(
+ *   Effect.gen(function*() {
+ *     const [left, right] = yield* Stream.make(1, 2, 3).pipe(
+ *       Stream.broadcastN(2, 8)
+ *     )
+ *
+ *     const values = yield* Effect.all([
+ *       Stream.runCollect(left),
+ *       Stream.runCollect(right)
+ *     ], { concurrency: "unbounded" })
+ *
+ *     yield* Console.log(values)
+ *   })
+ * )
+ *
+ * Effect.runPromise(program)
+ * // Output: [[1, 2, 3], [1, 2, 3]]
+ * ```
+ *
+ * @category Broadcast
+ * @since 4.0.0
+ */
+export const broadcastN: {
+  <N extends number>(
+    n: N,
+    maximumLag: number | BroadcastNOptions
+  ): <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
+  <A, E, R, N extends number>(
+    self: Stream<A, E, R>,
+    n: N,
+    maximumLag: number | BroadcastNOptions
+  ): Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
+} = dual(
+  3,
+  Effect.fnUntraced(function*<A, E, R, N extends number>(
+    self: Stream<A, E, R>,
+    n: N,
+    maximumLag: number | BroadcastNOptions
+  ) {
+    const pubsub = yield* makeBroadcastNPubSub<A, E>(maximumLag)
+    const parentScope = yield* Scope.Scope
+    const streams = yield* Effect.all(
+      Array.from({ length: n }, () => {
+        const scope = Scope.forkUnsafe(parentScope)
+        return PubSub.subscribe(pubsub).pipe(
+          Effect.provideService(Scope.Scope, scope),
+          Effect.map((subscription) =>
+            fromChannel(
+              Channel.onExit(
+                Channel.fromEffectTake(PubSub.take(subscription)),
+                (exit) => Scope.close(scope, exit)
+              )
+            )
+          )
+        )
+      })
+    )
+    yield* Channel.runForEach(self.channel, (value) => PubSub.publish(pubsub, value)).pipe(
+      Effect.onExit((exit) => PubSub.publish(pubsub, exit)),
+      Effect.forkScoped
+    )
+    return streams as TupleOf<N, Stream<A, E>>
+  })
+)
 
 /**
  * Creates a PubSub-backed stream that multicasts the source to all subscribers.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -8487,27 +8487,6 @@ export const aggregateWithin: {
     )
   }))))
 
-const makePubSub = <A>(
-  options: {
-    readonly capacity: "unbounded"
-    readonly replay?: number | undefined
-  } | {
-    readonly capacity: number
-    readonly strategy?: "dropping" | "sliding" | "suspend" | undefined
-    readonly replay?: number | undefined
-  }
-) =>
-  Effect.acquireRelease(
-    options.capacity === "unbounded"
-      ? PubSub.unbounded<A>(options)
-      : options.strategy === "dropping"
-      ? PubSub.dropping<A>(options)
-      : options.strategy === "sliding"
-      ? PubSub.sliding<A>(options)
-      : PubSub.bounded<A>(options),
-    PubSub.shutdown
-  )
-
 /**
  * Fan out the stream, producing a fixed-size tuple of streams that each emit
  * the same elements as the source stream.
@@ -8546,70 +8525,59 @@ const makePubSub = <A>(
  * @since 4.0.0
  */
 export const broadcastN: {
-  <N extends number>(
-    options:
-      & {
-        readonly n: N
-      }
-      & ({
-        readonly capacity: "unbounded"
-        readonly replay?: number | undefined
-      } | {
-        readonly capacity: number
-        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-        readonly replay?: number | undefined
-      })
+  <const N extends number>(
+    options: {
+      readonly n: N
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly n: N
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ): <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
-  <A, E, R, N extends number>(
+  <A, E, R, const N extends number>(
     self: Stream<A, E, R>,
-    options:
-      & {
-        readonly n: N
-      }
-      & ({
-        readonly capacity: "unbounded"
-        readonly replay?: number | undefined
-      } | {
-        readonly capacity: number
-        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-        readonly replay?: number | undefined
-      })
+    options: {
+      readonly n: N
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly capacity: number
+      readonly n: N
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ): Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
 } = dual(
   2,
-  Effect.fnUntraced(function*<A, E, R, N extends number>(
+  Effect.fnUntraced(function*<A, E, R, const N extends number>(
     self: Stream<A, E, R>,
-    options:
-      & {
-        readonly n: N
-      }
-      & ({
-        readonly capacity: "unbounded"
-        readonly replay?: number | undefined
-      } | {
-        readonly capacity: number
-        readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-        readonly replay?: number | undefined
-      })
+    options: {
+      readonly n: N
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly n: N
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ) {
     const pubsub = yield* makePubSub<Take.Take<A, E>>(options)
+    const streams = new Array(options.n)
     const parentScope = yield* Scope.Scope
-    const streams = yield* Effect.all(
-      Array.from({ length: options.n }, () => {
-        const scope = Scope.forkUnsafe(parentScope)
-        return PubSub.subscribe(pubsub).pipe(
-          Effect.provideService(Scope.Scope, scope),
-          Effect.map((subscription) =>
-            fromChannel(
-              Channel.onExit(
-                Channel.fromEffectTake(PubSub.take(subscription)),
-                (exit) => Scope.close(scope, exit)
-              )
-            )
-          )
-        )
-      })
-    )
+    for (let i = 0; i < options.n; i++) {
+      const scope = Scope.forkUnsafe(parentScope)
+      const subscription = yield* PubSub.subscribe(pubsub).pipe(
+        Effect.provideService(Scope.Scope, scope)
+      )
+      streams[i] = Channel.fromEffectTake(PubSub.take(subscription)).pipe(
+        Channel.onExit((exit) => Scope.close(scope, exit)),
+        fromChannel
+      )
+    }
     yield* Channel.runForEach(self.channel, (value) => PubSub.publish(pubsub, value)).pipe(
       Effect.onExit((exit) => PubSub.publish(pubsub, exit)),
       Effect.forkScoped
@@ -8617,6 +8585,27 @@ export const broadcastN: {
     return streams as TupleOf<N, Stream<A, E>>
   })
 )
+
+const makePubSub = <A>(
+  options: {
+    readonly capacity: "unbounded"
+    readonly replay?: number | undefined
+  } | {
+    readonly capacity: number
+    readonly strategy?: "dropping" | "sliding" | "suspend" | undefined
+    readonly replay?: number | undefined
+  }
+) =>
+  Effect.acquireRelease(
+    options.capacity === "unbounded"
+      ? PubSub.unbounded<A>(options)
+      : options.strategy === "dropping"
+      ? PubSub.dropping<A>(options)
+      : options.strategy === "sliding"
+      ? PubSub.sliding<A>(options)
+      : PubSub.bounded<A>(options),
+    PubSub.shutdown
+  )
 
 /**
  * Creates a PubSub-backed stream that multicasts the source to all subscribers.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -8487,28 +8487,24 @@ export const aggregateWithin: {
     )
   }))))
 
-type BroadcastNOptions = {
-  readonly capacity: "unbounded"
-  readonly replay?: number | undefined
-} | {
-  readonly capacity: number
-  readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
-  readonly replay?: number | undefined
-}
-
-const makeBroadcastNPubSub = <A, E>(
-  options: number | BroadcastNOptions
-): Effect.Effect<PubSub.PubSub<Take.Take<A, E>>, never, Scope.Scope> =>
+const makePubSub = <A>(
+  options: {
+    readonly capacity: "unbounded"
+    readonly replay?: number | undefined
+  } | {
+    readonly capacity: number
+    readonly strategy?: "dropping" | "sliding" | "suspend" | undefined
+    readonly replay?: number | undefined
+  }
+) =>
   Effect.acquireRelease(
-    typeof options === "number"
-      ? PubSub.bounded<Take.Take<A, E>>(options)
-      : options.capacity === "unbounded"
-      ? PubSub.unbounded<Take.Take<A, E>>(options)
+    options.capacity === "unbounded"
+      ? PubSub.unbounded<A>(options)
       : options.strategy === "dropping"
-      ? PubSub.dropping<Take.Take<A, E>>(options)
+      ? PubSub.dropping<A>(options)
       : options.strategy === "sliding"
-      ? PubSub.sliding<Take.Take<A, E>>(options)
-      : PubSub.bounded<Take.Take<A, E>>(options),
+      ? PubSub.sliding<A>(options)
+      : PubSub.bounded<A>(options),
     PubSub.shutdown
   )
 
@@ -8552,21 +8548,44 @@ const makeBroadcastNPubSub = <A, E>(
 export const broadcastN: {
   <N extends number>(
     n: N,
-    maximumLag: number | BroadcastNOptions
+    maximumLag: number | {
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ): <A, E, R>(self: Stream<A, E, R>) => Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
   <A, E, R, N extends number>(
     self: Stream<A, E, R>,
     n: N,
-    maximumLag: number | BroadcastNOptions
+    maximumLag: number | {
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ): Effect.Effect<TupleOf<N, Stream<A, E>>, never, Scope.Scope | R>
 } = dual(
   3,
   Effect.fnUntraced(function*<A, E, R, N extends number>(
     self: Stream<A, E, R>,
     n: N,
-    maximumLag: number | BroadcastNOptions
+    maximumLag: number | {
+      readonly capacity: "unbounded"
+      readonly replay?: number | undefined
+    } | {
+      readonly capacity: number
+      readonly strategy?: "sliding" | "dropping" | "suspend" | undefined
+      readonly replay?: number | undefined
+    }
   ) {
-    const pubsub = yield* makeBroadcastNPubSub<A, E>(maximumLag)
+    const pubsub = yield* makePubSub<Take.Take<A, E>>(
+      typeof maximumLag === "number" ? { capacity: maximumLag } : maximumLag
+    )
     const parentScope = yield* Scope.Scope
     const streams = yield* Effect.all(
       Array.from({ length: n }, () => {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -4587,6 +4587,36 @@ describe("Stream", () => {
         deepStrictEqual(result1, result2)
       })))
   })
+
+  describe("broadcastN", () => {
+    it.effect("fans out to a fixed number of streams", () =>
+      Effect.scoped(Effect.gen(function*() {
+        const [left, right] = yield* Stream.make(1, 2, 3).pipe(
+          Stream.broadcastN(2, 4)
+        )
+
+        const result = yield* Effect.all([
+          Stream.runCollect(left),
+          Stream.runCollect(right)
+        ], { concurrency: "unbounded" })
+
+        assert.deepStrictEqual(result, [[1, 2, 3], [1, 2, 3]])
+      })))
+
+    it.effect("propagates failures to all downstream streams", () =>
+      Effect.scoped(Effect.gen(function*() {
+        const [left, right] = yield* Stream.fail("boom").pipe(
+          Stream.broadcastN(2, 4)
+        )
+
+        const result = yield* Effect.all([
+          Stream.runCollect(left).pipe(Effect.exit),
+          Stream.runCollect(right).pipe(Effect.exit)
+        ], { concurrency: "unbounded" })
+
+        assert.deepStrictEqual(result, [Exit.fail("boom"), Exit.fail("boom")])
+      })))
+  })
 })
 
 const grouped = <A>(arr: Array<A>, size: number): Array<NonEmptyArray<A>> => {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -4592,7 +4592,7 @@ describe("Stream", () => {
     it.effect("fans out to a fixed number of streams", () =>
       Effect.scoped(Effect.gen(function*() {
         const [left, right] = yield* Stream.make(1, 2, 3).pipe(
-          Stream.broadcastN(2, 4)
+          Stream.broadcastN({ n: 2, capacity: 4 })
         )
 
         const result = yield* Effect.all([
@@ -4606,7 +4606,7 @@ describe("Stream", () => {
     it.effect("propagates failures to all downstream streams", () =>
       Effect.scoped(Effect.gen(function*() {
         const [left, right] = yield* Stream.fail("boom").pipe(
-          Stream.broadcastN(2, 4)
+          Stream.broadcastN({ n: 2, capacity: 4 })
         )
 
         const result = yield* Effect.all([


### PR DESCRIPTION
## Summary
- Add `Stream.broadcastN`, a fixed-size broadcast API ported from Effect v3 `Stream.broadcast`
- Pre-subscribe downstream streams before starting upstream and unsubscribe individual streams on exit
- Publish `Take` values, including final exits, so downstream streams observe completion and failure
- Address review feedback by exposing `broadcastN` with a single options object (for example `{ n: 2, capacity: 8 }`) and by using a `makePubSub` helper copied from `Channel.ts`
- Add Stream tests for fan-out and failure propagation plus a changeset

## Validation
- `pnpm lint-fix`
- `pnpm test Stream.test.ts`
- `pnpm check:tsgo`
- `cd packages/effect && pnpm docgen`