### PR TITLE
Fix sqlite-do Durable Object transactions

### DIFF
--- a/.changeset/sqlite-do-durable-object-transactions.md
+++ b/.changeset/sqlite-do-durable-object-transactions.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-do": patch
+---
+
+Support Cloudflare Durable Object SQLite transactions by allowing `SqliteClient` to be configured with `DurableObjectStorage` and routing `withTransaction` through `storage.transaction`.

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -85,6 +85,10 @@ export interface SqliteClient extends Client.SqlClient {
  */
 export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-do/SqliteClient")
 
+const SqliteTransaction = Context.Service<Client.TransactionConnection, Client.TransactionConnection.Service>(
+  "@effect/sql-sqlite-do/SqliteClient/SqliteTransaction"
+)
+
 /**
  * Configuration for a Cloudflare Durable Object SQLite client, including either a `SqlStorage` handle or the full `DurableObjectStorage` for transaction support, span attributes, and query/result name transforms.
  *
@@ -115,14 +119,13 @@ const makeUnsupportedWithTransaction = (message: string): Client.SqlClient["with
 
 const makeStorageBackedWithTransaction = (
   storage: DurableObjectStorage,
-  transactionService: Client.SqlClient["transactionService"],
   connection: Connection,
   semaphore: Semaphore.Semaphore
 ): Client.SqlClient["withTransaction"] =>
 <R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
   Effect.withFiber((fiber) => {
     const services = fiber.context
-    const connOption = Context.getOption(services, transactionService)
+    const connOption = Context.getOption(services, SqliteTransaction)
     if (connOption._tag === "Some") {
       return Effect.fail(
         unsupportedTransaction(
@@ -139,7 +142,7 @@ const makeStorageBackedWithTransaction = (
             Effect.runPromiseExit(
               Effect.provideContext(
                 effect,
-                Context.add(services, transactionService, [connection, 0] as const)
+                Context.add(services, SqliteTransaction, [connection, 0] as const)
               )
             ).then((exit) => {
               if (Exit.isFailure(exit)) {
@@ -270,6 +273,7 @@ export const make = (
       acquirer,
       compiler,
       transactionAcquirer,
+      transactionService: SqliteTransaction,
       spanAttributes: [
         ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
         [ATTR_DB_SYSTEM_NAME, "sqlite"]
@@ -281,7 +285,7 @@ export const make = (
       [TypeId]: TypeId as TypeId,
       config: options,
       withTransaction: options.storage
-        ? makeStorageBackedWithTransaction(options.storage, client.transactionService, connection, semaphore)
+        ? makeStorageBackedWithTransaction(options.storage, connection, semaphore)
         : makeUnsupportedWithTransaction(
           "Transactions require Durable Object storage; pass ctx.storage as the storage option"
         )

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -136,24 +136,34 @@ const makeStorageBackedWithTransaction = (
       )
     }
 
+    const effectWithTxn = Effect.provideContext(
+      effect,
+      Context.add(services, SqliteTransaction, [connection, 0] as const)
+    )
+
     return semaphore.withPermits(1)(
-      Effect.tryPromise({
-        try: () =>
-          storage.transaction((txn) =>
-            Effect.runPromiseExit(
-              Effect.provideContext(
-                effect,
-                Context.add(services, SqliteTransaction, [connection, 0] as const)
-              ) as Effect.Effect<A, E>
-            ).then((exit) => {
+      Effect.callback((resume) => {
+        let interrupted = false
+        const promise = storage.transaction((txn) =>
+          new Promise<void>((resolve) => {
+            if (interrupted) return resolve()
+            resume(Effect.onExit(effectWithTxn, (exit) => {
               if (Exit.isFailure(exit)) {
                 txn.rollback()
               }
-              return exit
-            })
-          ),
-        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed transaction", "transaction") })
-      }).pipe(Effect.flatten)
+              resolve()
+              // wait for the transaction to complete
+              return Effect.promise(() => promise)
+            }))
+          })
+        ).catch((cause) =>
+          resume(Effect.fail(new SqlError({ reason: classifyError(cause, "Failed transaction", "transaction") })))
+        )
+        return Effect.suspend(() => {
+          interrupted = true
+          return Effect.promise(() => promise)
+        })
+      })
     )
   })
 

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -1,18 +1,30 @@
 /**
  * Connects Effect SQL to SQLite storage inside Cloudflare Durable Objects.
  *
- * This module wraps a Durable Object `SqlStorage` handle and exposes it as both
- * `SqliteClient` and the generic Effect SQL client. It serializes access,
- * supports normal and streaming queries, converts returned `ArrayBuffer` values
- * to `Uint8Array`, and provides layers for wiring the client into an Effect
- * application. `updateValues` is not supported by this driver.
+ * This module adapts a Durable Object `SqlStorage` handle into both the
+ * Durable Object-specific `SqliteClient` service and the generic Effect
+ * `SqlClient` service. Use it from inside a Durable Object to run local
+ * per-object queries, repositories, migrations, transactional read/write
+ * workflows, and tests that exercise Cloudflare's SQLite-backed storage API.
+ *
+ * Durable Object SQLite storage is scoped to one object id, so each object
+ * instance has its own database. Callers can pass the `SqlStorage` handle for
+ * normal queries, or the full `DurableObjectStorage` when `withTransaction` or
+ * migrations need Cloudflare-managed transactions. This adapter serializes
+ * Effect SQL access through one connection; a transaction holds that permit for
+ * the lifetime of its scope, so keep transactions short, avoid suspending them
+ * across unrelated work, and use them when multi-statement writes must commit
+ * atomically. `SqlStorage.exec` returns `ArrayBuffer` values
+ * for SQLite blobs, which this client normalizes to `Uint8Array`, and SQLite
+ * does not support `updateValues`.
  *
  * @since 4.0.0
  */
-import type { SqlStorage } from "@cloudflare/workers-types"
+import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types"
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
 import { identity } from "effect/Function"
 import * as Layer from "effect/Layer"
@@ -22,7 +34,7 @@ import * as Stream from "effect/Stream"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
-import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
+import { classifySqliteError, SqlError, UnknownError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
@@ -74,21 +86,89 @@ export interface SqliteClient extends Client.SqlClient {
 export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-do/SqliteClient")
 
 /**
- * Configuration for a Cloudflare Durable Object SQLite client, including the `SqlStorage` handle, span attributes, and query/result name transforms.
+ * Configuration for a Cloudflare Durable Object SQLite client, including either a `SqlStorage` handle or the full `DurableObjectStorage` for transaction support, span attributes, and query/result name transforms.
  *
  * @category models
  * @since 4.0.0
  */
 export interface SqliteClientConfig {
-  readonly db: SqlStorage
+  readonly db?: SqlStorage | undefined
+  readonly storage?: DurableObjectStorage | undefined
   readonly spanAttributes?: Record<string, unknown> | undefined
 
   readonly transformResultNames?: ((str: string) => string) | undefined
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
 
+const Rollback = Symbol("@effect/sql-sqlite-do/Rollback")
+
+const unsupportedTransaction = (message: string, operation: string) =>
+  new SqlError({
+    reason: new UnknownError({
+      cause: new Error(message),
+      message,
+      operation
+    })
+  })
+
+const makeUnsupportedWithTransaction = (message: string): Client.SqlClient["withTransaction"] =>
+<R, E, A>(_effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+  Effect.fail(unsupportedTransaction(message, "transaction"))
+
+const makeStorageBackedWithTransaction = (
+  storage: DurableObjectStorage,
+  transactionService: Client.SqlClient["transactionService"],
+  connection: Connection,
+  semaphore: Semaphore.Semaphore
+): Client.SqlClient["withTransaction"] =>
+<R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+  Effect.withFiber((fiber) => {
+    const services = fiber.context
+    const connOption = Context.getOption(services, transactionService)
+    if (connOption._tag === "Some") {
+      return Effect.fail(
+        unsupportedTransaction(
+          "Nested transactions are not supported by Cloudflare Durable Object SQLite storage",
+          "transaction"
+        )
+      )
+    }
+
+    let exit: Exit.Exit<A, E> | undefined = undefined
+    const transaction = Effect.tryPromise<A, SqlError | typeof Rollback>({
+      try: () =>
+        storage.transaction(() =>
+          Effect.runPromiseExit(
+            Effect.provideContext(
+              effect,
+              Context.add(services, transactionService, [connection, 0] as const)
+            )
+          ).then((result) => {
+            exit = result
+            if (Exit.isFailure(result)) {
+              throw Rollback
+            }
+            return result.value
+          })
+        ),
+      catch: (cause) =>
+        cause === Rollback
+          ? Rollback
+          : new SqlError({ reason: classifyError(cause, "Failed transaction", "transaction") })
+    })
+
+    return semaphore.withPermits(1)(transaction).pipe(
+      Effect.catchAll((error) => {
+        if (error === Rollback) {
+          return exit ?? Exit.die("sqlite-do transaction exited without result")
+        }
+        return Effect.fail(error)
+      })
+    )
+  })
+
 /**
- * Creates a scoped Cloudflare Durable Object SQLite client around `SqlStorage`, serializing access and converting returned `ArrayBuffer` values to `Uint8Array`.
+ * Creates a scoped Cloudflare Durable Object SQLite client around Durable Object SQLite storage, serializing access and converting returned `ArrayBuffer` values to `Uint8Array`.
  *
  * @category constructors
  * @since 4.0.0
@@ -101,10 +181,13 @@ export const make = (
     const transformRows = options.transformResultNames
       ? Statement.defaultTransforms(options.transformResultNames).array
       : undefined
+    const db = options.storage?.sql ?? options.db
+
+    if (db === undefined) {
+      return yield* Effect.die("SqliteClient.make requires either a Durable Object storage or sql storage")
+    }
 
     const makeConnection = Effect.gen(function*() {
-      const db = options.db
-
       function* runIterator(
         sql: string,
         params: ReadonlyArray<unknown> = []
@@ -197,22 +280,26 @@ export const make = (
       )
     })
 
-    return Object.assign(
-      (yield* Client.make({
-        acquirer,
-        compiler,
-        transactionAcquirer,
-        spanAttributes: [
-          ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
-          [ATTR_DB_SYSTEM_NAME, "sqlite"]
-        ],
-        transformRows
-      })) as SqliteClient,
-      {
-        [TypeId]: TypeId as TypeId,
-        config: options
-      }
-    )
+    const client = (yield* Client.make({
+      acquirer,
+      compiler,
+      transactionAcquirer,
+      spanAttributes: [
+        ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+        [ATTR_DB_SYSTEM_NAME, "sqlite"]
+      ],
+      transformRows
+    })) as SqliteClient
+
+    return Object.assign(client, {
+      [TypeId]: TypeId as TypeId,
+      config: options,
+      withTransaction: options.storage
+        ? makeStorageBackedWithTransaction(options.storage, client.transactionService, connection, semaphore)
+        : makeUnsupportedWithTransaction(
+          "Transactions require Durable Object storage; pass ctx.storage as the storage option"
+        )
+    })
   })
 
 /**

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -113,9 +113,10 @@ const unsupportedTransaction = (message: string, operation: string) =>
     })
   })
 
-const makeUnsupportedWithTransaction = (message: string): Client.SqlClient["withTransaction"] =>
-<R, E, A>(_effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
-  Effect.fail(unsupportedTransaction(message, "transaction"))
+const makeUnsupportedWithTransaction =
+  (message: string): Client.SqlClient["withTransaction"] =>
+  <R, E, A>(_effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+    Effect.fail(unsupportedTransaction(message, "transaction"))
 
 const makeStorageBackedWithTransaction = (
   storage: DurableObjectStorage,
@@ -143,7 +144,7 @@ const makeStorageBackedWithTransaction = (
               Effect.provideContext(
                 effect,
                 Context.add(services, SqliteTransaction, [connection, 0] as const)
-              )
+              ) as Effect.Effect<A, E>
             ).then((exit) => {
               if (Exit.isFailure(exit)) {
                 txn.rollback()
@@ -175,13 +176,14 @@ export const make = (
     if (db === undefined) {
       return yield* Effect.die("SqliteClient.make requires either a Durable Object storage or sql storage")
     }
+    const sqlStorage = db
 
     const makeConnection = Effect.gen(function*() {
       function* runIterator(
         sql: string,
         params: ReadonlyArray<unknown> = []
       ) {
-        const cursor = db.exec(sql, ...params)
+        const cursor = sqlStorage.exec(sql, ...params)
         const columns = cursor.columnNames
         for (const result of cursor.raw()) {
           const obj: any = {}
@@ -208,7 +210,7 @@ export const make = (
       ): Effect.Effect<ReadonlyArray<any>, SqlError, never> =>
         Effect.try({
           try: () =>
-            Array.from(db.exec(sql, ...params).raw(), (row) => {
+            Array.from(sqlStorage.exec(sql, ...params).raw(), (row) => {
               for (let i = 0; i < row.length; i++) {
                 const value = row[i]
                 if (value instanceof ArrayBuffer) {

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -100,8 +100,6 @@ export interface SqliteClientConfig {
   readonly transformQueryNames?: ((str: string) => string) | undefined
 }
 
-const Rollback = Symbol("@effect/sql-sqlite-do/Rollback")
-
 const unsupportedTransaction = (message: string, operation: string) =>
   new SqlError({
     reason: new UnknownError({
@@ -134,36 +132,24 @@ const makeStorageBackedWithTransaction = (
       )
     }
 
-    let exit: Exit.Exit<A, E> | undefined = undefined
-    const transaction = Effect.tryPromise<A, SqlError | typeof Rollback>({
-      try: () =>
-        storage.transaction(() =>
-          Effect.runPromiseExit(
-            Effect.provideContext(
-              effect,
-              Context.add(services, transactionService, [connection, 0] as const)
-            )
-          ).then((result) => {
-            exit = result
-            if (Exit.isFailure(result)) {
-              throw Rollback
-            }
-            return result.value
-          })
-        ),
-      catch: (cause) =>
-        cause === Rollback
-          ? Rollback
-          : new SqlError({ reason: classifyError(cause, "Failed transaction", "transaction") })
-    })
-
-    return semaphore.withPermits(1)(transaction).pipe(
-      Effect.catchAll((error) => {
-        if (error === Rollback) {
-          return exit ?? Exit.die("sqlite-do transaction exited without result")
-        }
-        return Effect.fail(error)
-      })
+    return semaphore.withPermits(1)(
+      Effect.tryPromise({
+        try: () =>
+          storage.transaction((txn) =>
+            Effect.runPromiseExit(
+              Effect.provideContext(
+                effect,
+                Context.add(services, transactionService, [connection, 0] as const)
+              )
+            ).then((exit) => {
+              if (Exit.isFailure(exit)) {
+                txn.rollback()
+              }
+              return exit
+            })
+          ),
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed transaction", "transaction") })
+      }).pipe(Effect.flatten)
     )
   })
 

--- a/packages/sql/sqlite-do/src/SqliteMigrator.ts
+++ b/packages/sql/sqlite-do/src/SqliteMigrator.ts
@@ -2,10 +2,25 @@
  * Runs database migrations for Durable Object SQLite storage that uses Effect
  * SQL.
  *
- * This module re-exports the shared migration loaders and errors, then provides
- * `run` and `layer` helpers that apply pending migration files with the current
- * `SqlClient`. The SQL client supplies the Durable Object storage connection;
- * this module only handles migration execution.
+ * This module re-exports the shared `Migrator` loaders and error types, then
+ * provides `run` and `layer` helpers that execute ordered migrations through the
+ * current Durable Object SQLite `SqlClient`. Use it when a Durable
+ * Object needs to create or upgrade its local schema during construction, before
+ * repositories or request handlers use the object storage, or in tests that
+ * exercise Durable Object persistence.
+ *
+ * Migrations are recorded in `effect_sql_migrations` by default and are loaded
+ * using the shared `<id>_<name>` file or record-key convention. The underlying
+ * storage is scoped to a Durable Object id, so running migrations for one object
+ * does not update any other object instance; run the migrator against the same
+ * `DurableObjectStorage`-backed client that the object uses for normal queries
+ * so migrations can run in Cloudflare-managed transactions. These SQL
+ * migrations are separate from Cloudflare's Durable Object class migrations, and
+ * the Durable Object must already be configured with SQLite storage before this
+ * module can apply schema changes. Repeated startup runs are expected and are
+ * guarded by the migrations table, but request handling should wait until the
+ * migration layer has finished. This adapter does not currently write SQLite
+ * schema dumps for `schemaDirectory`.
  *
  * @since 4.0.0
  */

--- a/packages/sql/sqlite-do/test/Client.test.ts
+++ b/packages/sql/sqlite-do/test/Client.test.ts
@@ -1,7 +1,7 @@
 import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types"
 import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-do"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Deferred, Effect, Fiber } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as SqlClient from "effect/unstable/sql/SqlClient"
 
@@ -247,6 +247,27 @@ describe("Client", () => {
       const rows = yield* sql`SELECT * FROM test`
 
       assert.strictEqual(error, "boom")
+      assert.deepStrictEqual(rows, [])
+      assert.strictEqual(storage.rollbackCalls, 1)
+    }))
+
+  it.effect("storage-backed interrupted transactions roll back before release", () =>
+    Effect.gen(function*() {
+      const storage = new FakeDurableObjectStorage()
+      const sql = yield* makeClient({ storage: storage as unknown as DurableObjectStorage })
+      const inserted = yield* Deferred.make<void>()
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const fiber = yield* sql`INSERT INTO test (name) VALUES ('hello')`.pipe(
+        Effect.tap(() => Deferred.succeed(inserted, void 0)),
+        Effect.andThen(Effect.never),
+        sql.withTransaction,
+        Effect.forkChild
+      )
+      yield* Deferred.await(inserted)
+      yield* Fiber.interrupt(fiber)
+      const rows = yield* sql`SELECT * FROM test`
+
       assert.deepStrictEqual(rows, [])
       assert.strictEqual(storage.rollbackCalls, 1)
     }))

--- a/packages/sql/sqlite-do/test/Client.test.ts
+++ b/packages/sql/sqlite-do/test/Client.test.ts
@@ -1,7 +1,164 @@
-import { SqliteClient } from "@effect/sql-sqlite-do"
+import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types"
+import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-do"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+
+class FakeCursor {
+  readonly columnNames: ReadonlyArray<string>
+  readonly rows: ReadonlyArray<ReadonlyArray<unknown>>
+
+  constructor(rows: ReadonlyArray<Record<string, unknown>>, columns?: ReadonlyArray<string>) {
+    this.columnNames = columns ?? Object.keys(rows[0] ?? {})
+    this.rows = rows.map((row) => this.columnNames.map((column) => row[column]))
+  }
+
+  *raw() {
+    yield* this.rows.map((row) => [...row])
+  }
+}
+
+class FakeSqlStorage {
+  readonly statements: Array<string> = []
+  tables = new Map<string, Array<Record<string, unknown>>>()
+  columns = new Map<string, Array<string>>()
+
+  snapshot() {
+    return {
+      tables: new Map(Array.from(this.tables, ([table, rows]) => [table, rows.map((row) => ({ ...row }))])),
+      columns: new Map(Array.from(this.columns, ([table, columns]) => [table, [...columns]]))
+    }
+  }
+
+  restore(snapshot: ReturnType<FakeSqlStorage["snapshot"]>) {
+    this.tables = snapshot.tables
+    this.columns = snapshot.columns
+  }
+
+  exec(sql: string, ...params: ReadonlyArray<unknown>) {
+    this.statements.push(sql)
+    const statement = normalizeSql(sql)
+    if (/^(BEGIN|COMMIT|ROLLBACK|SAVEPOINT)\b/i.test(statement)) {
+      throw new Error(`Unsupported transaction SQL: ${statement}`)
+    }
+
+    if (/^CREATE TABLE\b/i.test(statement)) {
+      const match = /^CREATE TABLE(?: IF NOT EXISTS)?\s+("[^"]+"|\w+)\s*\((.*)\)$/i.exec(statement)
+      if (match !== null) {
+        const table = unquote(match[1])
+        if (!this.tables.has(table)) {
+          this.tables.set(table, [])
+          this.columns.set(
+            table,
+            match[2].split(",").map((part) => unquote(part.trim().split(/\s+/)[0])).filter((column) =>
+              column.length > 0 && column.toUpperCase() !== "PRIMARY"
+            )
+          )
+        }
+      }
+      return new FakeCursor([])
+    }
+
+    if (/^INSERT INTO\b/i.test(statement)) {
+      const match = /^INSERT INTO\s+("[^"]+"|\w+)\s*\(([^)]+)\)\s+VALUES\s+(.+)$/i.exec(statement)
+      if (match !== null) {
+        const table = unquote(match[1])
+        const columns = match[2].split(",").map((column) => unquote(column.trim()))
+        const rows = this.tables.get(table) ?? []
+        const tableColumns = this.columns.get(table) ?? [...columns]
+        if (!this.tables.has(table)) {
+          this.tables.set(table, rows)
+          this.columns.set(table, tableColumns)
+        }
+        let paramIndex = 0
+        for (const group of valueGroups(match[3])) {
+          const values = group.split(",").map((value) => parseValue(value.trim(), params, () => paramIndex++))
+          const row: Record<string, unknown> = {}
+          if (tableColumns.includes("id") && !columns.includes("id")) {
+            row.id = rows.length + 1
+          }
+          for (let i = 0; i < columns.length; i++) {
+            row[columns[i]] = values[i]
+          }
+          if (tableColumns.includes("created_at") && row.created_at === undefined) {
+            row.created_at = "current_timestamp"
+          }
+          rows.push(row)
+        }
+      }
+      return new FakeCursor([])
+    }
+
+    if (/^SELECT\b/i.test(statement)) {
+      const match = /^SELECT\s+(.+)\s+FROM\s+("[^"]+"|\w+)(?:\s+WHERE\s+("[^"]+"|\w+)\s*=\s*(\?|('[^']*')|\d+))?(?:\s+ORDER BY\s+("[^"]+"|\w+)\s+DESC)?$/i.exec(statement)
+      if (match !== null) {
+        const table = unquote(match[2])
+        const selectedColumns = match[1].trim() === "*"
+          ? this.columns.get(table) ?? []
+          : match[1].split(",").map((column) => unquote(column.trim()))
+        let rows = [...(this.tables.get(table) ?? [])]
+        if (match[3] !== undefined) {
+          const column = unquote(match[3])
+          const value = match[4] === "?" ? params[0] : parseValue(match[4], [], () => 0)
+          rows = rows.filter((row) => row[column] === value)
+        }
+        if (match[6] !== undefined) {
+          const column = unquote(match[6])
+          rows.sort((a, b) => Number(b[column]) - Number(a[column]))
+        }
+        return new FakeCursor(rows, selectedColumns)
+      }
+    }
+
+    return new FakeCursor([])
+  }
+}
+
+class FakeDurableObjectStorage {
+  readonly sql = new FakeSqlStorage()
+  transactionCalls = 0
+
+  transaction<T>(body: () => T | Promise<T>): Promise<T> {
+    this.transactionCalls++
+    const snapshot = this.sql.snapshot()
+    return Promise.resolve().then(body).catch((error) => {
+      this.sql.restore(snapshot)
+      throw error
+    })
+  }
+}
+
+const normalizeSql = (sql: string) => sql.replace(/;$/, "").replace(/\s+/g, " ").trim()
+
+const unquote = (value: string) => value.replace(/^"|"$/g, "")
+
+const valueGroups = (values: string): Array<string> =>
+  values.match(/\(([^)]*)\)/g)?.map((group) => group.slice(1, -1)) ?? []
+
+const parseValue = (
+  value: string,
+  params: ReadonlyArray<unknown>,
+  nextParamIndex: () => number
+): unknown => {
+  if (value === "?") {
+    return params[nextParamIndex()]
+  }
+  if (/^'.*'$/.test(value)) {
+    return value.slice(1, -1)
+  }
+  const number = Number(value)
+  return Number.isNaN(number) ? value : number
+}
+
+const makeClient = (config: SqliteClient.SqliteClientConfig) =>
+  SqliteClient.make(config).pipe(
+    Effect.scoped,
+    Effect.provide(Reactivity.layer)
+  )
+
+const hasForbiddenTransactionSql = (db: FakeSqlStorage) =>
+  db.statements.some((statement) => /^(BEGIN|COMMIT|ROLLBACK|SAVEPOINT)\b/i.test(normalizeSql(statement)))
 
 describe("Client", () => {
   it.effect("classifies native errors without stable sqlite codes as UnknownError", () =>
@@ -10,15 +167,112 @@ describe("Client", () => {
         exec: () => {
           throw new Error("boom")
         }
-      } as any
+      } as unknown as SqlStorage
 
-      const client = yield* SqliteClient.make({ db: failingDb })
+      const client = yield* makeClient({ db: failingDb })
       const error = yield* Effect.flip(client`SELECT 1`)
       assert.strictEqual(error.reason._tag, "UnknownError")
-    }).pipe(
-      Effect.scoped,
-      Effect.provide(Reactivity.layer)
-    ))
+    }))
 
-  it.effect("should work", () => Effect.void)
+  it.effect("db-only clients support normal queries", () =>
+    Effect.gen(function*() {
+      const db = new FakeSqlStorage()
+      const sql = yield* makeClient({ db: db as unknown as SqlStorage })
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql`INSERT INTO test (name) VALUES (${"hello"})`
+      const rows = yield* sql`SELECT * FROM test`
+
+      assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+    }))
+
+  it.effect("db-only transactions fail clearly without transaction SQL", () =>
+    Effect.gen(function*() {
+      const db = new FakeSqlStorage()
+      const sql = yield* makeClient({ db: db as unknown as SqlStorage })
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const error = yield* Effect.flip(sql.withTransaction(sql`INSERT INTO test (name) VALUES ('hello')`))
+      const rows = yield* sql`SELECT * FROM test`
+
+      assert.strictEqual(error.reason._tag, "UnknownError")
+      assert.match(error.message, /Transactions require Durable Object storage/)
+      assert.deepStrictEqual(rows, [])
+      assert.strictEqual(hasForbiddenTransactionSql(db), false)
+    }))
+
+  it.effect("storage-backed transactions use DurableObjectStorage.transaction", () =>
+    Effect.gen(function*() {
+      const storage = new FakeDurableObjectStorage()
+      const sql = yield* makeClient({ storage: storage as unknown as DurableObjectStorage })
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql.withTransaction(sql`INSERT INTO test (name) VALUES ('hello')`)
+      const rows = yield* sql`SELECT * FROM test`
+
+      assert.strictEqual(storage.transactionCalls, 1)
+      assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+      assert.strictEqual(hasForbiddenTransactionSql(storage.sql), false)
+    }))
+
+  it.effect("storage-backed failed transactions roll back and re-emit the original failure", () =>
+    Effect.gen(function*() {
+      const storage = new FakeDurableObjectStorage()
+      const sql = yield* makeClient({ storage: storage as unknown as DurableObjectStorage })
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const error = yield* sql`INSERT INTO test (name) VALUES ('hello')`.pipe(
+        Effect.andThen(Effect.fail("boom")),
+        sql.withTransaction,
+        Effect.flip
+      )
+      const rows = yield* sql`SELECT * FROM test`
+
+      assert.strictEqual(error, "boom")
+      assert.deepStrictEqual(rows, [])
+    }))
+
+  it.effect("nested transactions fail clearly without savepoint SQL", () =>
+    Effect.gen(function*() {
+      const storage = new FakeDurableObjectStorage()
+      const sql = yield* makeClient({ storage: storage as unknown as DurableObjectStorage })
+
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const error = yield* sql.withTransaction(
+        Effect.gen(function*() {
+          yield* sql`INSERT INTO test (name) VALUES ('outer')`
+          yield* sql.withTransaction(sql`INSERT INTO test (name) VALUES ('inner')`)
+        })
+      ).pipe(Effect.flip)
+      const rows = yield* sql`SELECT * FROM test`
+
+      assert.strictEqual(error.reason._tag, "UnknownError")
+      assert.match(error.message, /Nested transactions are not supported/)
+      assert.deepStrictEqual(rows, [])
+      assert.strictEqual(hasForbiddenTransactionSql(storage.sql), false)
+    }))
+
+  it.effect("SqliteMigrator.run works with storage-backed transactions", () =>
+    Effect.gen(function*() {
+      const storage = new FakeDurableObjectStorage()
+      const sql = yield* makeClient({ storage: storage as unknown as DurableObjectStorage })
+
+      const completed = yield* SqliteMigrator.run({
+        loader: SqliteMigrator.fromRecord({
+          "1_create": Effect.gen(function*() {
+            const sql = yield* SqlClient.SqlClient
+            yield* sql`CREATE TABLE migrated (id INTEGER PRIMARY KEY, name TEXT)`
+            yield* sql`INSERT INTO migrated (name) VALUES ('ok')`
+          })
+        })
+      }).pipe(Effect.provideService(SqlClient.SqlClient, sql))
+      const rows = yield* sql`SELECT * FROM migrated`
+      const migrations = yield* sql`SELECT * FROM effect_sql_migrations`
+
+      assert.deepStrictEqual(completed, [[1, "create"]])
+      assert.deepStrictEqual(rows, [{ id: 1, name: "ok" }])
+      assert.deepStrictEqual(migrations, [{ migration_id: 1, name: "create", created_at: "current_timestamp" }])
+      assert.strictEqual(storage.transactionCalls, 1)
+      assert.strictEqual(hasForbiddenTransactionSql(storage.sql), false)
+    }))
 })

--- a/packages/sql/sqlite-do/test/Client.test.ts
+++ b/packages/sql/sqlite-do/test/Client.test.ts
@@ -118,14 +118,30 @@ class FakeSqlStorage {
 class FakeDurableObjectStorage {
   readonly sql = new FakeSqlStorage()
   transactionCalls = 0
+  rollbackCalls = 0
 
-  transaction<T>(body: () => T | Promise<T>): Promise<T> {
+  transaction<T>(body: (txn: { rollback: () => void }) => Promise<T>): Promise<T> {
     this.transactionCalls++
     const snapshot = this.sql.snapshot()
-    return Promise.resolve().then(body).catch((error) => {
-      this.sql.restore(snapshot)
-      throw error
-    })
+    let rolledBack = false
+    const txn = {
+      rollback: () => {
+        this.rollbackCalls++
+        rolledBack = true
+      }
+    }
+    return Promise.resolve().then(() => body(txn)).then(
+      (value) => {
+        if (rolledBack) {
+          this.sql.restore(snapshot)
+        }
+        return value
+      },
+      (error) => {
+        this.sql.restore(snapshot)
+        throw error
+      }
+    )
   }
 }
 
@@ -230,6 +246,7 @@ describe("Client", () => {
 
       assert.strictEqual(error, "boom")
       assert.deepStrictEqual(rows, [])
+      assert.strictEqual(storage.rollbackCalls, 1)
     }))
 
   it.effect("nested transactions fail clearly without savepoint SQL", () =>
@@ -249,6 +266,7 @@ describe("Client", () => {
       assert.strictEqual(error.reason._tag, "UnknownError")
       assert.match(error.message, /Nested transactions are not supported/)
       assert.deepStrictEqual(rows, [])
+      assert.strictEqual(storage.rollbackCalls, 1)
       assert.strictEqual(hasForbiddenTransactionSql(storage.sql), false)
     }))
 

--- a/packages/sql/sqlite-do/test/Client.test.ts
+++ b/packages/sql/sqlite-do/test/Client.test.ts
@@ -2,8 +2,8 @@ import type { DurableObjectStorage, SqlStorage } from "@cloudflare/workers-types
 import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-do"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
-import * as SqlClient from "effect/unstable/sql/SqlClient"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as SqlClient from "effect/unstable/sql/SqlClient"
 
 class FakeCursor {
   readonly columnNames: ReadonlyArray<string>
@@ -91,7 +91,9 @@ class FakeSqlStorage {
     }
 
     if (/^SELECT\b/i.test(statement)) {
-      const match = /^SELECT\s+(.+)\s+FROM\s+("[^"]+"|\w+)(?:\s+WHERE\s+("[^"]+"|\w+)\s*=\s*(\?|('[^']*')|\d+))?(?:\s+ORDER BY\s+("[^"]+"|\w+)\s+DESC)?$/i.exec(statement)
+      const match =
+        /^SELECT\s+(.+)\s+FROM\s+("[^"]+"|\w+)(?:\s+WHERE\s+("[^"]+"|\w+)\s*=\s*(\?|('[^']*')|\d+))?(?:\s+ORDER BY\s+("[^"]+"|\w+)\s+DESC)?$/i
+          .exec(statement)
       if (match !== null) {
         const table = unquote(match[2])
         const selectedColumns = match[1].trim() === "*"


### PR DESCRIPTION
Closes #2216

Author: Pi (GPT 5.5 on high)
Guided by: Dillon Mulroy <dillon@cloudflare.com>

## Changes
- accept `storage?: DurableObjectStorage` in `SqliteClientConfig`
- route `withTransaction` through `storage.transaction(...)`
- fail db-only / nested transactions without emitting `BEGIN` / `SAVEPOINT`
- add sqlite-do transaction + migrator regression tests

## Validation
- `pnpm test packages/sql/sqlite-do/test/Client.test.ts` — blocked: `vitest` not installed
- `pnpm lint-fix` — blocked: `oxlint` not installed
- `pnpm check:tsgo` — blocked: local tool/build-mode issue