### PR TITLE
fix(rpc): correct Protocol tag in RpcWorker + add lint rule preventing class

### DIFF
--- a/.changeset/fix-rpc-worker-protocol-tag.md
+++ b/.changeset/fix-rpc-worker-protocol-tag.md
@@ -1,0 +1,9 @@
+---
+"effect": patch
+---
+
+Fix `RpcWorker.initialMessage` looking up the wrong service identity.
+
+The internal `ProtocolTag` in `RpcWorker` was created with the v3 package-name string `"@effect/rpc/RpcServer/Protocol"`, while `RpcServer.Protocol` is keyed by the v4 canonical `"effect/rpc/RpcServer/Protocol"`. At runtime Effect's `ServiceMap` keys by tag string, so the two tags resolved to distinct service identities and any call to `RpcWorker.initialMessage(schema)` failed with `Service not found: @effect/rpc/RpcServer/Protocol` even when a properly-provided `RpcServer.Protocol` was in context.
+
+The `as any` cast on the same line erased the string-literal type, hiding the mismatch from the type-checker. The cast has been removed in favour of the canonical typed `Context.Service<Self, Shape>(key)` form, restoring compile-time detection of this class of error.

--- a/.changeset/fix-rpc-worker-protocol-tag.md
+++ b/.changeset/fix-rpc-worker-protocol-tag.md
@@ -2,8 +2,16 @@
 "effect": patch
 ---
 
-Fix `RpcWorker.initialMessage` looking up the wrong service identity.
+Fix `RpcWorker.initialMessage` looking up the wrong service identity, and add a lint rule preventing reintroduction of the bug class.
 
 The internal `ProtocolTag` in `RpcWorker` was created with the v3 package-name string `"@effect/rpc/RpcServer/Protocol"`, while `RpcServer.Protocol` is keyed by the v4 canonical `"effect/rpc/RpcServer/Protocol"`. At runtime Effect's `ServiceMap` keys by tag string, so the two tags resolved to distinct service identities and any call to `RpcWorker.initialMessage(schema)` failed with `Service not found: @effect/rpc/RpcServer/Protocol` even when a properly-provided `RpcServer.Protocol` was in context.
 
 The `as any` cast on the same line erased the string-literal type, hiding the mismatch from the type-checker. The cast has been removed in favour of the canonical typed `Context.Service<Self, Shape>(key)` form, restoring compile-time detection of this class of error.
+
+A new oxlint rule, `effect/no-at-prefix-in-tag-string`, flags any `Context.{Service,Tag,Key,GenericTag}` or `ServiceMap.{Service,Tag,Key,GenericTag}` constructor (call form and class-extends form) whose tag string starts with `@effect/`, with an auto-fix that drops the leading `@`. The rule is scoped to `packages/effect/src/**` via `.oxlintrc.json` overrides (other packages in the monorepo still use the legacy `@<pkg>/...` convention and are out of scope for this fix). Applying the rule produced three additional auto-fixes in `packages/effect/src/`:
+
+- `unstable/socket/Socket.ts` (`WebSocketConstructor` tag)
+- `unstable/socket/SocketServer.ts` (`SocketServer` tag)
+- `unstable/ai/IdGenerator.ts` (`IdGenerator` tag)
+
+These were latent landmines: the tags are currently accessed by class identity rather than by string lookup, so no consumer was observing a service-identity mismatch yet. Aligning them with the canonical convention removes the hazard and matches the rest of `packages/effect/src/`, where the canonical `"effect/..."` prefix outnumbers the legacy form by ~40:1.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,5 +21,10 @@
       "eslint/no-console": "off",
       "effect/no-import-from-barrel-package": "off"
     }
+  }, {
+    "files": ["packages/effect/src/**"],
+    "rules": {
+      "effect/no-at-prefix-in-tag-string": "error"
+    }
   }]
 }

--- a/packages/effect/src/unstable/ai/IdGenerator.ts
+++ b/packages/effect/src/unstable/ai/IdGenerator.ts
@@ -78,7 +78,7 @@ import * as Random from "../../Random.ts"
  * @since 4.0.0
  */
 export class IdGenerator extends Context.Service<IdGenerator, Service>()(
-  "@effect/ai/IdGenerator"
+  "effect/ai/IdGenerator"
 ) {}
 
 /**

--- a/packages/effect/src/unstable/rpc/RpcWorker.ts
+++ b/packages/effect/src/unstable/rpc/RpcWorker.ts
@@ -62,7 +62,7 @@ export declare namespace InitialMessage {
   }
 }
 
-const ProtocolTag: typeof Protocol = Context.Service("@effect/rpc/RpcServer/Protocol") as any
+const ProtocolTag = Context.Service<Protocol, Protocol["Service"]>("effect/rpc/RpcServer/Protocol")
 
 /**
  * Runs an effect, encodes its result with the schema's JSON codec, and returns

--- a/packages/effect/src/unstable/socket/Socket.ts
+++ b/packages/effect/src/unstable/socket/Socket.ts
@@ -567,7 +567,7 @@ export class WebSocket extends Context.Service<WebSocket, globalThis.WebSocket>(
 export class WebSocketConstructor extends Context.Service<
   WebSocketConstructor,
   (url: string, protocols?: string | Array<string> | undefined) => globalThis.WebSocket
->()("@effect/platform/Socket/WebSocketConstructor") {}
+>()("effect/platform/Socket/WebSocketConstructor") {}
 
 /**
  * Layer that provides `WebSocketConstructor` using `globalThis.WebSocket`.

--- a/packages/effect/src/unstable/socket/SocketServer.ts
+++ b/packages/effect/src/unstable/socket/SocketServer.ts
@@ -40,7 +40,7 @@ export class SocketServer extends Context.Service<SocketServer, {
   readonly run: <R, E, _>(
     handler: (socket: Socket.Socket) => Effect.Effect<_, E, R>
   ) => Effect.Effect<never, SocketServerError, R>
-}>()("@effect/platform/SocketServer") {}
+}>()("effect/platform/SocketServer") {}
 
 /**
  * Runtime type identifier attached to `SocketServerError` values.

--- a/packages/effect/test/rpc/RpcWorker.test.ts
+++ b/packages/effect/test/rpc/RpcWorker.test.ts
@@ -1,0 +1,60 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as Cause from "effect/Cause"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Queue from "effect/Queue"
+import * as Schema from "effect/Schema"
+import { RpcServer, RpcWorker } from "effect/unstable/rpc"
+
+const InitialPayload = Schema.Struct({
+  workerId: Schema.String,
+  count: Schema.Number
+})
+
+const makeProtocolLayer = (
+  encodedInitialMessage: Option.Option<unknown>
+): Layer.Layer<RpcServer.Protocol> =>
+  Layer.effect(RpcServer.Protocol)(
+    Effect.gen(function*() {
+      const disconnects = yield* Queue.unbounded<number>()
+      return RpcServer.Protocol.of({
+        run: () => Effect.never,
+        disconnects,
+        send: () => Effect.void,
+        end: () => Effect.void,
+        clientIds: Effect.succeed(new Set<number>()),
+        initialMessage: Effect.succeed(encodedInitialMessage),
+        supportsAck: false,
+        supportsTransferables: false,
+        supportsSpanPropagation: false
+      })
+    })
+  )
+
+describe("RpcWorker", () => {
+  describe("initialMessage", () => {
+    it.effect("decodes the encoded initial message produced by the provided Protocol", () =>
+      Effect.gen(function*() {
+        const encoded = { workerId: "alpha", count: 7 }
+        const decoded = yield* RpcWorker.initialMessage(InitialPayload)
+        assert.deepStrictEqual(decoded, { workerId: "alpha", count: 7 })
+        return encoded
+      }).pipe(
+        Effect.provide(makeProtocolLayer(Option.some({ workerId: "alpha", count: 7 })))
+      ))
+
+    it.effect("fails with NoSuchElementError when the Protocol has no initial message", () =>
+      Effect.gen(function*() {
+        const exit = yield* Effect.exit(RpcWorker.initialMessage(InitialPayload))
+        assert.isTrue(Exit.isFailure(exit))
+        if (Exit.isFailure(exit)) {
+          const error = Cause.squash(exit.cause)
+          assert.isTrue(Cause.isNoSuchElementError(error))
+        }
+      }).pipe(
+        Effect.provide(makeProtocolLayer(Option.none()))
+      ))
+  })
+})

--- a/packages/tools/oxc/oxlintrc.json
+++ b/packages/tools/oxc/oxlintrc.json
@@ -8,6 +8,9 @@
   },
   "rules": {
     // Effect custom rules
+    // no-at-prefix-in-tag-string: enabled only for packages/effect/src via root overrides;
+    // other packages still use the legacy "@<pkg>/..." tag prefix convention.
+    "effect/no-at-prefix-in-tag-string": "off",
     "effect/no-bigint-literals": "error",
     "effect/no-import-from-barrel-package": ["error", {
       "checkPatterns": [

--- a/packages/tools/oxc/src/oxlint/index.ts
+++ b/packages/tools/oxc/src/oxlint/index.ts
@@ -1,3 +1,4 @@
+import noAtPrefixInTagString from "./rules/no-at-prefix-in-tag-string.ts"
 import noBigIntLiterals from "./rules/no-bigint-literals.ts"
 import noImportFromBarrelPackage from "./rules/no-import-from-barrel-package.ts"
 import noJsExtensionImports from "./rules/no-js-extension-imports.ts"
@@ -9,6 +10,7 @@ export default {
     name: "effect"
   },
   rules: {
+    "no-at-prefix-in-tag-string": noAtPrefixInTagString,
     "no-bigint-literals": noBigIntLiterals,
     "no-import-from-barrel-package": noImportFromBarrelPackage,
     "no-js-extension-imports": noJsExtensionImports,

--- a/packages/tools/oxc/src/oxlint/rules/no-at-prefix-in-tag-string.ts
+++ b/packages/tools/oxc/src/oxlint/rules/no-at-prefix-in-tag-string.ts
@@ -1,0 +1,89 @@
+import type { CreateRule, ESTree, Fixer, Visitor } from "oxlint"
+
+const TAG_OBJECTS = new Set(["Context", "ServiceMap"])
+const TAG_PROPERTIES = new Set(["Service", "Tag", "Key", "GenericTag"])
+const FORBIDDEN_PREFIX = "@effect/"
+
+// `Context.Service` / `Context.Tag` / `Context.Key` / `Context.GenericTag`
+// (and the same four on `ServiceMap`) — non-computed member access only.
+function isTagCallee(expr: ESTree.Expression): boolean {
+  if (expr.type !== "MemberExpression") return false
+  if (expr.computed) return false
+  if (expr.object.type !== "Identifier") return false
+  if (!TAG_OBJECTS.has(expr.object.name)) return false
+  if (expr.property.type !== "Identifier") return false
+  return TAG_PROPERTIES.has(expr.property.name)
+}
+
+// `StringLiteral.type === "Literal"` in oxlint's ESTree. The other "Literal"
+// variants (BooleanLiteral, NullLiteral, NumericLiteral, BigIntLiteral,
+// RegExpLiteral) have non-string `value`, so a type-of check narrows safely.
+function asStringLiteral(arg: ESTree.Argument): ESTree.StringLiteral | undefined {
+  if (arg.type !== "Literal") return undefined
+  if (typeof arg.value !== "string") return undefined
+  return arg
+}
+
+function reportLiteral(
+  context: Parameters<CreateRule["create"]>[0],
+  literal: ESTree.StringLiteral
+) {
+  if (!literal.value.startsWith(FORBIDDEN_PREFIX)) return
+
+  const fixedValue = literal.value.slice(1)
+  const raw = literal.raw ?? `"${literal.value}"`
+  const quote = raw.charAt(0) === "'" ? "'" : "\""
+  const replacement = `${quote}${fixedValue}${quote}`
+
+  context.report({
+    node: literal,
+    message:
+      `Tag string must not start with "@effect/" (use "${fixedValue}" instead). The "@<pkg>/" prefix is leftover from v3 package naming and breaks service identity when callers look up the tag by string.`,
+    fix: (fixer: Fixer) => fixer.replaceTextRange(literal.range, replacement)
+  })
+}
+
+function checkFirstArg(
+  context: Parameters<CreateRule["create"]>[0],
+  args: ReadonlyArray<ESTree.Argument>
+) {
+  const first = args[0]
+  if (!first) return
+  const literal = asStringLiteral(first)
+  if (literal) reportLiteral(context, literal)
+}
+
+const rule: CreateRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow \"@effect/\"-prefixed tag strings in Context.{Service,Tag,Key,GenericTag} and ServiceMap.{Service,Tag,Key,GenericTag} constructors"
+    },
+    fixable: "code"
+  },
+  create(context) {
+    function handleCall(node: ESTree.CallExpression) {
+      const callee = node.callee
+
+      // direct form: Context.Service("@effect/foo", ...)
+      if (isTagCallee(callee)) {
+        checkFirstArg(context, node.arguments)
+        return
+      }
+
+      // class-extends form: Context.Service<...>()("@effect/foo")
+      // AST: outer CallExpression whose callee is itself a CallExpression
+      // whose callee is the Member expression.
+      if (callee.type === "CallExpression" && isTagCallee(callee.callee)) {
+        checkFirstArg(context, node.arguments)
+      }
+    }
+
+    return {
+      CallExpression: handleCall
+    } as Visitor
+  }
+}
+
+export default rule

--- a/packages/tools/oxc/test/no-at-prefix-in-tag-string.test.ts
+++ b/packages/tools/oxc/test/no-at-prefix-in-tag-string.test.ts
@@ -1,0 +1,219 @@
+import rule from "@effect/oxc/oxlint/rules/no-at-prefix-in-tag-string"
+import { describe, expect, it } from "vitest"
+import { createTestContext } from "./utils.ts"
+
+interface FixDescriptor {
+  range: [number, number]
+  text: string
+}
+
+interface CapturedReport {
+  message: string
+  fix: FixDescriptor | undefined
+}
+
+function runRuleOnCall(node: unknown): Array<CapturedReport> {
+  const { context } = createTestContext()
+  const captured: Array<CapturedReport> = []
+
+  const reportingContext = {
+    ...context,
+    report(
+      opts: { node: unknown; message: string; fix?: ((fixer: unknown) => FixDescriptor) | undefined }
+    ) {
+      const fixer = {
+        replaceTextRange(range: [number, number], text: string): FixDescriptor {
+          return { range, text }
+        }
+      }
+      const fix = opts.fix ? opts.fix(fixer) : undefined
+      captured.push({ message: opts.message, fix })
+    }
+  }
+
+  const visitors = rule.create(reportingContext as never)
+  const handler = visitors.CallExpression
+  if (handler) {
+    ;(handler as (node: unknown) => void)(node)
+  }
+  return captured
+}
+
+// AST shape helpers
+const ident = (name: string) => ({ type: "Identifier", name })
+
+const memberCallee = (object: string, property: string) => ({
+  type: "MemberExpression",
+  object: ident(object),
+  property: ident(property),
+  computed: false
+})
+
+const stringLit = (value: string, range: [number, number] = [0, value.length + 2]) => ({
+  type: "Literal",
+  value,
+  raw: `"${value}"`,
+  range
+})
+
+const singleQuoteStringLit = (value: string, range: [number, number] = [0, value.length + 2]) => ({
+  type: "Literal",
+  value,
+  raw: `'${value}'`,
+  range
+})
+
+// Direct call form: Context.Service("@effect/foo")
+const directCall = (object: string, property: string, arg: unknown) => ({
+  type: "CallExpression",
+  callee: memberCallee(object, property),
+  arguments: [arg]
+})
+
+// Class-extends form outer call: Context.Service<...>()("@effect/foo")
+// Outer CallExpression's callee is the inner CallExpression
+const classExtendsCall = (object: string, property: string, arg: unknown) => ({
+  type: "CallExpression",
+  callee: {
+    type: "CallExpression",
+    callee: memberCallee(object, property),
+    arguments: []
+  },
+  arguments: [arg]
+})
+
+describe("no-at-prefix-in-tag-string", () => {
+  describe("direct call form", () => {
+    it("flags Context.Service(\"@effect/foo\")", () => {
+      const node = directCall("Context", "Service", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+      expect(reports[0].fix?.text).toBe("\"effect/foo\"")
+    })
+
+    it("flags Context.Tag(\"@effect/bar\")", () => {
+      const node = directCall("Context", "Tag", stringLit("@effect/bar"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+      expect(reports[0].fix?.text).toBe("\"effect/bar\"")
+    })
+
+    it("flags Context.Key(\"@effect/baz\")", () => {
+      const node = directCall("Context", "Key", stringLit("@effect/baz"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+    })
+
+    it("flags Context.GenericTag(\"@effect/qux\")", () => {
+      const node = directCall("Context", "GenericTag", stringLit("@effect/qux"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+    })
+
+    it("flags ServiceMap.Service(\"@effect/foo\")", () => {
+      const node = directCall("ServiceMap", "Service", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+      expect(reports[0].fix?.text).toBe("\"effect/foo\"")
+    })
+
+    it("flags ServiceMap.Key(\"@effect/foo\")", () => {
+      const node = directCall("ServiceMap", "Key", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+    })
+
+    it("preserves single-quote style in fix", () => {
+      const node = directCall("Context", "Service", singleQuoteStringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+      expect(reports[0].fix?.text).toBe("'effect/foo'")
+    })
+  })
+
+  describe("class-extends form", () => {
+    it("flags Context.Service<...>()(\"@effect/foo\")", () => {
+      const node = classExtendsCall("Context", "Service", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+      expect(reports[0].fix?.text).toBe("\"effect/foo\"")
+    })
+
+    it("flags Context.Tag<...>()(\"@effect/foo\")", () => {
+      const node = classExtendsCall("Context", "Tag", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+    })
+
+    it("flags ServiceMap.Service<...>()(\"@effect/foo\")", () => {
+      const node = classExtendsCall("ServiceMap", "Service", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(1)
+    })
+  })
+
+  describe("non-violations", () => {
+    it("does not flag canonical Context.Service(\"effect/foo\")", () => {
+      const node = directCall("Context", "Service", stringLit("effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag unrelated apis: someOtherApi(\"@effect/whatever\")", () => {
+      const node = {
+        type: "CallExpression",
+        callee: ident("someOtherApi"),
+        arguments: [stringLit("@effect/whatever")]
+      }
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag Schema.Class(\"@effect/foo\")", () => {
+      const node = directCall("Schema", "Class", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag Context.Service called with non-string first arg", () => {
+      const node = directCall("Context", "Service", { type: "Identifier", name: "name" })
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag empty Context.Service<...>()()", () => {
+      const node = {
+        type: "CallExpression",
+        callee: {
+          type: "CallExpression",
+          callee: memberCallee("Context", "Service"),
+          arguments: []
+        },
+        arguments: []
+      }
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag Context.Service called via computed property", () => {
+      const node = {
+        type: "CallExpression",
+        callee: {
+          type: "MemberExpression",
+          object: ident("Context"),
+          property: { type: "Literal", value: "Service", raw: "\"Service\"" },
+          computed: true
+        },
+        arguments: [stringLit("@effect/foo")]
+      }
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+
+    it("does not flag Context.SomethingElse(\"@effect/foo\")", () => {
+      const node = directCall("Context", "SomethingElse", stringLit("@effect/foo"))
+      const reports = runRuleOnCall(node)
+      expect(reports).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`RpcWorker.initialMessage(schema)` always fails at runtime with

```
Service not found: @effect/rpc/RpcServer/Protocol
```

because `RpcWorker.ts` reaches `RpcServer.Protocol` through a locally
re-declared `ProtocolTag` whose tag string carries a residual `@effect/`
prefix copied from the v3 package name. The string does not match the v4
canonical tag string produced by `RpcServer.Protocol`, so any layer
providing `RpcServer.Protocol` (e.g. `RpcServer.layerProtocolWorkerRunner`)
does **not** satisfy the requirement read by
`RpcWorker.initialMessage`.

The `as any` assertion on the same line erases the string-literal type
that `Context.Service<…>(…)` normally carries on its identifier, which
is why TypeScript does not catch the mismatch.

## Root cause

`RpcServer.Protocol`
([`RpcServer.ts:867`](https://github.com/Effect-TS/effect-smol/blob/8d71e5452cd040bd4c80df55bba2c95c8af79b54/packages/effect/src/unstable/rpc/RpcServer.ts#L867)):

```ts
class Protocol extends Context.Service<Protocol, { /* … */ }>()(
  "effect/rpc/RpcServer/Protocol",
) { /* … */ }
```

`RpcWorker.ProtocolTag`
([`RpcWorker.ts:65`](https://github.com/Effect-TS/effect-smol/blob/8d71e5452cd040bd4c80df55bba2c95c8af79b54/packages/effect/src/unstable/rpc/RpcWorker.ts#L65)):

```ts
const ProtocolTag: typeof Protocol =
  Context.Service("@effect/rpc/RpcServer/Protocol") as any
//                ^ residual v3 package prefix
```

Effect's `Context.Service` stores the supplied key verbatim on the
resulting Key instance ([`Context.ts:221`](https://github.com/Effect-TS/effect-smol/blob/8d71e5452cd040bd4c80df55bba2c95c8af79b54/packages/effect/src/Context.ts#L221) — `self.key = arguments[0]`), and
`Context` resolution is by `.key` equality, so two `Context.Service`
values with different `.key` strings are distinct services regardless of
how they are typed.

Introduced in PR #601 (`d2bee765`, `add Worker modules`, 5 Oct 2025) and
never corrected during the v3→v4 rename pass. `RpcServer.Protocol`'s tag
predates `RpcWorker.ts` and has always used the canonical
`"effect/rpc/RpcServer/Protocol"`.

## Fix

```diff
-const ProtocolTag: typeof Protocol = Context.Service("@effect/rpc/RpcServer/Protocol") as any
+const ProtocolTag = Context.Service<Protocol, Protocol["Service"]>("effect/rpc/RpcServer/Protocol")
```

Two changes:

1. Drop the `@` prefix from the tag string. After the fix
   `ProtocolTag.key === RpcServer.Protocol.key`, so any layer providing
   `RpcServer.Protocol` satisfies `RpcWorker.initialMessage`'s
   requirement.
2. Remove the `as any` cast in favour of the canonical typed
   `Context.Service<Self, Shape>(key)` form. The function-style
   `Context.Service<I, S>(key)` returns a `Service<I, S>`; passing
   `Protocol` as the identifier parameter ensures the resulting Key
   shares an `Identifier` with `RpcServer.Protocol` so a future
   divergence of the literal string is caught at compile time, not at
   runtime. The annotation `typeof Protocol` was structurally
   incompatible (`ServiceClass<Self, Id, Shape>` adds `new(_: never)`
   and `readonly make` over `Service<Self, Shape>`), which is the
   pressure that the original `as any` was bleeding off.

## Regression test

Added `packages/effect/test/rpc/RpcWorker.test.ts`:

```ts
import { assert, describe, it } from "@effect/vitest"
import * as Cause from "effect/Cause"
import * as Effect from "effect/Effect"
import * as Exit from "effect/Exit"
import * as Layer from "effect/Layer"
import * as Option from "effect/Option"
import * as Queue from "effect/Queue"
import * as Schema from "effect/Schema"
import { RpcServer, RpcWorker } from "effect/unstable/rpc"

const InitialPayload = Schema.Struct({
  workerId: Schema.String,
  count: Schema.Number
})

const makeProtocolLayer = (
  encodedInitialMessage: Option.Option<unknown>
): Layer.Layer<RpcServer.Protocol> =>
  Layer.effect(RpcServer.Protocol)(
    Effect.gen(function*() {
      const disconnects = yield* Queue.unbounded<number>()
      return RpcServer.Protocol.of({
        run: () => Effect.never,
        disconnects,
        send: () => Effect.void,
        end: () => Effect.void,
        clientIds: Effect.succeed(new Set<number>()),
        initialMessage: Effect.succeed(encodedInitialMessage),
        supportsAck: false,
        supportsTransferables: false,
        supportsSpanPropagation: false
      })
    })
  )

describe("RpcWorker", () => {
  describe("initialMessage", () => {
    it.effect("decodes the encoded initial message produced by the provided Protocol", () =>
      Effect.gen(function*() {
        const decoded = yield* RpcWorker.initialMessage(InitialPayload)
        assert.deepStrictEqual(decoded, { workerId: "alpha", count: 7 })
      }).pipe(
        Effect.provide(makeProtocolLayer(Option.some({ workerId: "alpha", count: 7 })))
      ))

    it.effect("fails with NoSuchElementError when the Protocol has no initial message", () =>
      Effect.gen(function*() {
        const exit = yield* Effect.exit(RpcWorker.initialMessage(InitialPayload))
        assert.isTrue(Exit.isFailure(exit))
        if (Exit.isFailure(exit)) {
          const error = Cause.squash(exit.cause)
          assert.isTrue(Cause.isNoSuchElementError(error))
        }
      }).pipe(
        Effect.provide(makeProtocolLayer(Option.none()))
      ))
  })
})
```

The test is behavioural: it provides a hand-rolled `RpcServer.Protocol`
implementation through `Layer.effect` and runs the public
`RpcWorker.initialMessage` end-to-end. Confirmed locally to:

- **fail** against the unpatched source with `Service not found: @effect/rpc/RpcServer/Protocol`
  (both `it.effect` cases)
- **pass** against the patched source (both `it.effect` cases)

## Why upstream tests did not catch this

Searched `packages/effect/test/` at SHA `8d71e545`:

```
$ grep -rn "RpcWorker" packages/effect/test/
(no results)

$ grep -rn "initialMessage" packages/effect/test/
(no results)
```

No test imports `RpcWorker`, and no test exercises any
`initialMessage`-shaped code path. The only existing RPC tests are
`Rpc.test.ts`, `RpcClient.test.ts`, `RpcSerialization.test.ts`, and
`AtomRpc.test.ts`; none of them touch the worker initial-message flow.
Result: the v3→v4 rename pass had no test to fail when the prefix on
the worker side was missed.

## Lint rule preventing reintroduction (second commit, `22d79792`)

The `as any` cast is what made this bug slip past type-checking, but the
shape of the bug — a hand-written `Context.Service`/`Context.Tag` tag
string that carries the v3 `@<pkg>/` prefix — exists in three other
sites within `packages/effect/src/` that the audit identified. None
were producing a runtime mismatch today (they are accessed by class
identity, not by string lookup), but the latent landmine is identical.

This second commit:

1. Adds a new oxlint rule `effect/no-at-prefix-in-tag-string` under
   `packages/tools/oxc/src/oxlint/rules/`. The rule walks
   `CallExpression` nodes and flags two AST shapes:
   - **Direct form** — `Context.Service("@effect/foo")` /
     `Context.Tag(…)` / `Context.Key(…)` / `Context.GenericTag(…)`
     and the same four on `ServiceMap`
   - **Class-extends form** — `class X extends Context.Service<…>()("@effect/foo") {}`
     (outer `CallExpression` whose callee is itself a `CallExpression`
     whose callee is the qualified member access)

   The auto-fix drops the leading `@` and preserves quote style.

2. Scopes the rule to `packages/effect/src/**` via
   `.oxlintrc.json` overrides. Other packages in the monorepo
   (`packages/ai/*`, `packages/sql/*`, `packages/platform-*`,
   `packages/opentelemetry`, etc.) still use the legacy
   `@<pkg>/...` prefix convention extensively (auto-fixing them
   would have produced 50 additional file changes across 14
   packages, and is a separate convention discussion). The
   plugin-level default is `"off"`; only the root `.oxlintrc.json`
   override turns it on for `packages/effect/src/**`.

3. Applies the auto-fix to the three sites within
   `packages/effect/src/` that match the pattern:

   | File | Tag before → after |
   | --- | --- |
   | `unstable/socket/Socket.ts` | `"@effect/platform/Socket/WebSocketConstructor"` → `"effect/platform/Socket/WebSocketConstructor"` |
   | `unstable/socket/SocketServer.ts` | `"@effect/platform/SocketServer"` → `"effect/platform/SocketServer"` |
   | `unstable/ai/IdGenerator.ts` | `"@effect/ai/IdGenerator"` → `"effect/ai/IdGenerator"` |

4. Adds a test file
   `packages/tools/oxc/test/no-at-prefix-in-tag-string.test.ts`
   with 17 tests covering direct form, class-extends form,
   quote-style preservation, and the non-violation cases (canonical
   `"effect/..."` strings, unrelated APIs, `Schema.Class`,
   non-string first argument, computed property access,
   non-tag `Context.SomethingElse` calls).

The rule fires only on the four explicit constructor names listed
above, so unrelated `@effect/...` strings (JSDoc `@example` imports,
`Schema.Class("@effect/cluster/K8sHttpClient/Pod")`, error
`package` fields, `Symbol.for("@effect/platform/HttpApp/resolve")`,
etc.) are unaffected.

## Changeset

`.changeset/fix-rpc-worker-protocol-tag.md`:

```md
---
"effect": patch
---

Fix `RpcWorker.initialMessage` looking up the wrong service identity, and add a lint rule preventing reintroduction of the bug class.

The internal `ProtocolTag` in `RpcWorker` was created with the v3 package-name string `"@effect/rpc/RpcServer/Protocol"`, while `RpcServer.Protocol` is keyed by the v4 canonical `"effect/rpc/RpcServer/Protocol"`. At runtime Effect's `ServiceMap` keys by tag string, so the two tags resolved to distinct service identities and any call to `RpcWorker.initialMessage(schema)` failed with `Service not found: @effect/rpc/RpcServer/Protocol` even when a properly-provided `RpcServer.Protocol` was in context.

The `as any` cast on the same line erased the string-literal type, hiding the mismatch from the type-checker. The cast has been removed in favour of the canonical typed `Context.Service<Self, Shape>(key)` form, restoring compile-time detection of this class of error.

A new oxlint rule, `effect/no-at-prefix-in-tag-string`, flags any `Context.{Service,Tag,Key,GenericTag}` or `ServiceMap.{Service,Tag,Key,GenericTag}` constructor (call form and class-extends form) whose tag string starts with `@effect/`, with an auto-fix that drops the leading `@`. The rule is scoped to `packages/effect/src/**` via `.oxlintrc.json` overrides (other packages in the monorepo still use the legacy `@<pkg>/...` convention and are out of scope for this fix). Applying the rule produced three additional auto-fixes in `packages/effect/src/`:

- `unstable/socket/Socket.ts` (`WebSocketConstructor` tag)
- `unstable/socket/SocketServer.ts` (`SocketServer` tag)
- `unstable/ai/IdGenerator.ts` (`IdGenerator` tag)

These were latent landmines: the tags are currently accessed by class identity rather than by string lookup, so no consumer was observing a service-identity mismatch yet. Aligning them with the canonical convention removes the hazard and matches the rest of `packages/effect/src/`, where the canonical `"effect/..."` prefix outnumbers the legacy form by ~40:1.
```

## Validation commands run

Per `AGENTS.md` validation table (this is a `Code changes` row):

- `pnpm lint-fix` — clean (0 warnings, 0 errors)
- `pnpm test packages/effect/test/rpc/RpcWorker.test.ts` — `2 passed (2)`
- `pnpm check:tsgo` — clean (exits 0, no diagnostics)

## Affected versions

Every published `effect@4.0.0-beta.*` that contains
`packages/effect/src/unstable/rpc/RpcWorker.ts`, i.e. from PR #601
(commit `d2bee765`, 5 Oct 2025) onward. Locally confirmed in
`effect@4.0.0-beta.66` and `effect@4.0.0-beta.68`. No published v4 stable
yet.

## How this was found

Migrating a large LiveStore-backed codebase from `@effect/rpc` v3 to
`effect/unstable/rpc` v4-beta.68. Five Worker-Store integration tests
began timing out at 5–10 s wall-clock with the same stack:

```
Service not found: @effect/rpc/RpcServer/Protocol
  defined at .../effect/dist/unstable/rpc/RpcWorker.js:14:42
```

A one-character `pnpm patch` against the installed `effect@4.0.0-beta.68`
made the five tests run instantly.

## Out of scope

- Replacing the local `ProtocolTag` re-declaration entirely with a value
  import of `Protocol` from `./RpcServer.ts` (`import { Protocol as
  ProtocolTag }`) — this eliminates the duplicated tag string and the
  opportunity for it to drift again. Left out of this PR because it
  changes the module's runtime import graph (currently `import type`),
  which is a structural cleanup worth landing separately after this
  one-line bugfix.
- Hardening `Context.Service`'s public surface so that two identifiers
  with the same nominal type but different `.key` strings cannot be
  silently equated — this is the root cause that made the `as any` slip
  past review, and is a separate, larger discussion.
