### PR TITLE
perf(runtime): per-instance [evaluate] dispatch, zero module-level mutable state

### DIFF
--- a/.changeset/perf-runtime-zero-mutable-dispatch.md
+++ b/.changeset/perf-runtime-zero-mutable-dispatch.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+perf(runtime): per-instance [evaluate] dispatch via shared protos; zero module-level mutable dispatch state. Closes a JIT-friendliness gap in the run-loop's primary dispatch site: evaluator references now flow by closure capture (parenthood) instead of through a module-level mutable registry, enabling JSC to const-fold the call target. -39% on succeed-flatMap chains, -31% on deep service-yield, -19% on fork-join, with 9/10 benchmark scenarios improving and no regressions at n=300 pooled samples.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ scratchpad/**/*
 
 # Repositories
 .repos/
+bench/results/

--- a/bench/compare-pooled.ts
+++ b/bench/compare-pooled.ts
@@ -1,0 +1,364 @@
+/**
+ * Pooled Welch's two-tailed t-test comparison.
+ *
+ * Each side aggregates N JSON bench files (each containing RUNS=30 post-warmup
+ * samples). The N files are concatenated per scenario into a single pooled
+ * sample vector, then Welch's t-test is run on the pooled vectors.
+ *
+ * Also emits a self-consistency check: pairwise compare every (baseline_i,
+ * baseline_j) and flag any pair with p<0.05 AND |Δ|>=3%. That tells the user
+ * whether the machine was quiet across runs.
+ *
+ * Usage:
+ *   bun run bench/compare-pooled.ts \
+ *     --label-base baseline --base FILE [FILE ...] \
+ *     --label-cand candidate --cand FILE [FILE ...] \
+ *     [--out comparison.json]
+ */
+
+import * as fs from "node:fs"
+
+interface Stats {
+  min: number
+  max: number
+  mean: number
+  median: number
+  p95: number
+  p99: number
+  stddev: number
+  rsd: number
+  opsPerSec: number
+}
+
+interface Scenario {
+  name: string
+  iterationsPerRun: number
+  samples: Array<number>
+  stats: Stats
+  heap: { heapDeltaMean: number; objectCountDeltaMean: number }
+}
+
+interface BenchFile {
+  scenarios: Array<Scenario>
+}
+
+// --- statistics ------------------------------------------------------------
+
+const betacf = (a: number, b: number, x: number): number => {
+  const MAXIT = 200
+  const EPS = 3e-7
+  const FPMIN = 1e-30
+  const qab = a + b
+  const qap = a + 1
+  const qam = a - 1
+  let c = 1
+  let d = 1 - qab * x / qap
+  if (Math.abs(d) < FPMIN) d = FPMIN
+  d = 1 / d
+  let h = d
+  for (let m = 1; m <= MAXIT; m++) {
+    const m2 = 2 * m
+    let aa = m * (b - m) * x / ((qam + m2) * (a + m2))
+    d = 1 + aa * d
+    if (Math.abs(d) < FPMIN) d = FPMIN
+    c = 1 + aa / c
+    if (Math.abs(c) < FPMIN) c = FPMIN
+    d = 1 / d
+    h *= d * c
+    aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2))
+    d = 1 + aa * d
+    if (Math.abs(d) < FPMIN) d = FPMIN
+    c = 1 + aa / c
+    if (Math.abs(c) < FPMIN) c = FPMIN
+    d = 1 / d
+    const del = d * c
+    h *= del
+    if (Math.abs(del - 1) < EPS) break
+  }
+  return h
+}
+
+const lgamma = (x: number): number => {
+  const cof = [
+    76.18009172947146,
+    -86.50532032941677,
+    24.01409824083091,
+    -1.231739572450155,
+    0.1208650973866179e-2,
+    -0.5395239384953e-5
+  ]
+  let y = x
+  let tmp = x + 5.5
+  tmp -= (x + 0.5) * Math.log(tmp)
+  let ser = 1.000000000190015
+  for (let j = 0; j < 6; j++) {
+    y += 1
+    ser += cof[j]! / y
+  }
+  return -tmp + Math.log(2.5066282746310005 * ser / x)
+}
+
+const betai = (a: number, b: number, x: number): number => {
+  if (x < 0 || x > 1) return Number.NaN
+  if (x === 0 || x === 1) return x === 0 ? 0 : 1
+  const bt = Math.exp(lgamma(a + b) - lgamma(a) - lgamma(b) + a * Math.log(x) + b * Math.log(1 - x))
+  if (x < (a + 1) / (a + b + 2)) return bt * betacf(a, b, x) / a
+  return 1 - bt * betacf(b, a, 1 - x) / b
+}
+
+const twoTailedPValue = (t: number, df: number): number => {
+  const x = df / (df + t * t)
+  return betai(df / 2, 0.5, x)
+}
+
+interface WelchResult {
+  t: number
+  df: number
+  p: number
+  meanA: number
+  meanB: number
+  stdA: number
+  stdB: number
+}
+
+const welch = (a: Array<number>, b: Array<number>): WelchResult => {
+  const meanA = a.reduce((s, v) => s + v, 0) / a.length
+  const meanB = b.reduce((s, v) => s + v, 0) / b.length
+  const varA = a.reduce((s, v) => s + (v - meanA) ** 2, 0) / (a.length - 1)
+  const varB = b.reduce((s, v) => s + (v - meanB) ** 2, 0) / (b.length - 1)
+  const stdA = Math.sqrt(varA)
+  const stdB = Math.sqrt(varB)
+  const se2A = varA / a.length
+  const se2B = varB / b.length
+  const se = Math.sqrt(se2A + se2B)
+  const t = (meanA - meanB) / se
+  const df = (se2A + se2B) ** 2 / (se2A ** 2 / (a.length - 1) + se2B ** 2 / (b.length - 1))
+  return { t, df, p: twoTailedPValue(t, df), meanA, meanB, stdA, stdB }
+}
+
+const fmtNs = (ns: number): string => {
+  if (ns < 1_000) return `${ns.toFixed(1)}ns`
+  if (ns < 1_000_000) return `${(ns / 1_000).toFixed(2)}µs`
+  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)}ms`
+  return `${(ns / 1_000_000_000).toFixed(2)}s`
+}
+
+// --- args parsing ----------------------------------------------------------
+
+interface CliArgs {
+  base: Array<string>
+  cand: Array<string>
+  labelBase: string
+  labelCand: string
+  out?: string
+}
+
+const parseArgs = (argv: Array<string>): CliArgs => {
+  const out: CliArgs = { base: [], cand: [], labelBase: "baseline", labelCand: "candidate" }
+  let mode: "base" | "cand" | null = null
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!
+    if (a === "--base") { mode = "base"; continue }
+    if (a === "--cand") { mode = "cand"; continue }
+    if (a === "--label-base") { out.labelBase = argv[++i]!; mode = null; continue }
+    if (a === "--label-cand") { out.labelCand = argv[++i]!; mode = null; continue }
+    if (a === "--out") { out.out = argv[++i]!; mode = null; continue }
+    if (mode === "base") out.base.push(a)
+    else if (mode === "cand") out.cand.push(a)
+  }
+  return out
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (args.base.length === 0 || args.cand.length === 0) {
+  console.error("usage: --base F1 [F2 ...] --cand F1 [F2 ...] [--label-base X] [--label-cand Y] [--out file.json]")
+  process.exit(1)
+}
+
+const loadFiles = (paths: ReadonlyArray<string>): Array<BenchFile> =>
+  paths.map((p) => JSON.parse(fs.readFileSync(p, "utf8")) as BenchFile)
+
+const poolByScenario = (files: ReadonlyArray<BenchFile>): Map<string, {
+  iterationsPerRun: number
+  samples: Array<number>
+  heapDeltaMean: number
+  objectCountDeltaMean: number
+}> => {
+  const out = new Map<string, {
+    iterationsPerRun: number
+    samples: Array<number>
+    heapDeltaMean: number
+    objectCountDeltaMean: number
+  }>()
+  for (const f of files) {
+    for (const s of f.scenarios) {
+      const cur = out.get(s.name)
+      if (cur) {
+        cur.samples.push(...s.samples)
+        cur.heapDeltaMean = (cur.heapDeltaMean + s.heap.heapDeltaMean) / 2
+        cur.objectCountDeltaMean = (cur.objectCountDeltaMean + s.heap.objectCountDeltaMean) / 2
+      } else {
+        out.set(s.name, {
+          iterationsPerRun: s.iterationsPerRun,
+          samples: [...s.samples],
+          heapDeltaMean: s.heap.heapDeltaMean,
+          objectCountDeltaMean: s.heap.objectCountDeltaMean
+        })
+      }
+    }
+  }
+  return out
+}
+
+const baselineFiles = loadFiles(args.base)
+const candidateFiles = loadFiles(args.cand)
+
+// --- self-consistency check ------------------------------------------------
+
+console.log(`# Pooled comparison: ${args.labelCand} vs ${args.labelBase}\n`)
+console.log(`Base files (n=${args.base.length}): ${args.base.join(", ")}`)
+console.log(`Candidate files (n=${args.cand.length}): ${args.cand.join(", ")}\n`)
+
+if (baselineFiles.length >= 2) {
+  console.log(`## Baseline self-consistency (pairwise Welch on ${args.labelBase} runs)\n`)
+  console.log("Flagged if any pair has p<0.05 AND |Δ|≥3% — that means the machine was NOT quiesced for that scenario.\n")
+  const names = baselineFiles[0]!.scenarios.map((s) => s.name)
+  console.log("| scenario | pairs flagged (Δ%, p) |")
+  console.log("|---|---|")
+  let anyFlag = false
+  for (const name of names) {
+    const flagged: Array<string> = []
+    for (let i = 0; i < baselineFiles.length; i++) {
+      for (let j = i + 1; j < baselineFiles.length; j++) {
+        const a = baselineFiles[i]!.scenarios.find((s) => s.name === name)!
+        const b = baselineFiles[j]!.scenarios.find((s) => s.name === name)!
+        const w = welch(a.samples, b.samples)
+        const delta = (w.meanB - w.meanA) / w.meanA * 100
+        if (w.p < 0.05 && Math.abs(delta) >= 3) {
+          flagged.push(`#${i + 1}↔#${j + 1}: ${delta >= 0 ? "+" : ""}${delta.toFixed(2)}%, p=${w.p.toExponential(2)}`)
+        }
+      }
+    }
+    if (flagged.length > 0) {
+      anyFlag = true
+      console.log(`| ${name} | ${flagged.join(" / ")} |`)
+    } else {
+      console.log(`| ${name} | OK |`)
+    }
+  }
+  console.log("")
+  if (anyFlag) {
+    console.log("WARN: machine was NOT fully quiesced for some scenarios; treat candidate verdicts on those scenarios with skepticism.\n")
+  } else {
+    console.log("OK: baseline self-consistency held within α=0.05/Δ=3% across all scenarios.\n")
+  }
+}
+
+// --- pooled comparison -----------------------------------------------------
+
+const basePool = poolByScenario(baselineFiles)
+const candPool = poolByScenario(candidateFiles)
+
+console.log(`## Pooled ${args.labelCand} vs ${args.labelBase} (Welch's two-tailed t-test, α=0.05)\n`)
+console.log(
+  `| scenario | base mean ± σ (ns/op) | cand mean ± σ (ns/op) | Δ% | t | p | heap base→cand | objs base→cand | verdict |`
+)
+console.log("|---|---|---|---|---|---|---|---|---|")
+
+let anyImprovement = false
+let anyRegression = false
+
+interface RowOut {
+  scenario: string
+  iterationsPerRun: number
+  baseN: number
+  candN: number
+  baseMeanNsPerOp: number
+  candMeanNsPerOp: number
+  baseStdNsPerOp: number
+  candStdNsPerOp: number
+  deltaPercent: number
+  t: number
+  df: number
+  p: number
+  baseHeapDeltaMean: number
+  candHeapDeltaMean: number
+  baseObjCountDeltaMean: number
+  candObjCountDeltaMean: number
+  verdict: "WIN" | "LOSS" | "NEUTRAL"
+}
+
+const rows: Array<RowOut> = []
+
+for (const [name, c] of candPool) {
+  const b = basePool.get(name)
+  if (!b) continue
+  const ipr = c.iterationsPerRun
+  const w = welch(b.samples, c.samples)
+  const baseMeanPerOp = w.meanA / ipr
+  const candMeanPerOp = w.meanB / ipr
+  const baseStdPerOp = w.stdA / ipr
+  const candStdPerOp = w.stdB / ipr
+  const delta = (candMeanPerOp - baseMeanPerOp) / baseMeanPerOp * 100
+  const significant = w.p < 0.05
+  const improved = significant && delta <= -3
+  const regressed = significant && delta >= 5
+  if (improved) anyImprovement = true
+  if (regressed) anyRegression = true
+  const verdict: "WIN" | "LOSS" | "NEUTRAL" = improved ? "WIN" : regressed ? "LOSS" : "NEUTRAL"
+  rows.push({
+    scenario: name,
+    iterationsPerRun: ipr,
+    baseN: b.samples.length,
+    candN: c.samples.length,
+    baseMeanNsPerOp: baseMeanPerOp,
+    candMeanNsPerOp: candMeanPerOp,
+    baseStdNsPerOp: baseStdPerOp,
+    candStdNsPerOp: candStdPerOp,
+    deltaPercent: delta,
+    t: w.t,
+    df: w.df,
+    p: w.p,
+    baseHeapDeltaMean: b.heapDeltaMean,
+    candHeapDeltaMean: c.heapDeltaMean,
+    baseObjCountDeltaMean: b.objectCountDeltaMean,
+    candObjCountDeltaMean: c.objectCountDeltaMean,
+    verdict
+  })
+  const heapStr = `${(b.heapDeltaMean / 1024).toFixed(1)}KB → ${(c.heapDeltaMean / 1024).toFixed(1)}KB`
+  const objStr = `${b.objectCountDeltaMean.toFixed(0)} → ${c.objectCountDeltaMean.toFixed(0)}`
+  console.log(
+    `| ${name} | ${fmtNs(baseMeanPerOp)} ± ${fmtNs(baseStdPerOp)} | ${fmtNs(candMeanPerOp)} ± ${fmtNs(candStdPerOp)} | ${delta >= 0 ? "+" : ""}${delta.toFixed(2)}% | ${w.t.toFixed(3)} | ${w.p.toExponential(2)} | ${heapStr} | ${objStr} | ${verdict} |`
+  )
+}
+
+console.log("")
+console.log(`Pooled samples per condition: base n=${rows[0]?.baseN ?? 0}, cand n=${rows[0]?.candN ?? 0}`)
+console.log("")
+
+let verdict: "KEEP" | "REJECT-noimp" | "REJECT-regression"
+if (anyImprovement && !anyRegression) {
+  verdict = "KEEP"
+  console.log(`VERDICT: KEEP — ≥1 significant improvement (Δ≤-3%, p<0.05), no significant regression (Δ≥5%, p<0.05)`)
+} else if (anyRegression) {
+  verdict = "REJECT-regression"
+  console.log(`VERDICT: REJECT — ≥1 significant regression`)
+} else {
+  verdict = "REJECT-noimp"
+  console.log(`VERDICT: REJECT — no significant improvement`)
+}
+
+if (args.out) {
+  const outFile = {
+    labelBase: args.labelBase,
+    labelCand: args.labelCand,
+    baseFiles: args.base,
+    candFiles: args.cand,
+    pooledBaseSamples: rows[0]?.baseN ?? 0,
+    pooledCandSamples: rows[0]?.candN ?? 0,
+    rows,
+    verdict
+  }
+  fs.writeFileSync(args.out, JSON.stringify(outFile, null, 2))
+  console.log(`wrote ${args.out}`)
+}

--- a/bench/harness.ts
+++ b/bench/harness.ts
@@ -1,0 +1,176 @@
+/**
+ * Bench harness for effect-smol runtime hot-path audit.
+ *
+ * Discipline (per the bun-benchmarking skill):
+ *   - Bun.nanoseconds() for timing
+ *   - Bun.gc(true) + 5ms sleep before every run (warmup AND measured)
+ *   - WARMUP runs discarded; RUNS post-warmup samples kept (raw)
+ *   - blackhole(result) after every iteration to defeat DCE
+ *   - iterationsPerRun amortizes timer jitter; bump until RSD < 5%
+ *   - heapStats() delta captured (post-GC view) for per-run alloc signal
+ *   - Each run wrapped in a hard timeout
+ *   - Correctness validated on first iteration of first run
+ *
+ * Output (JSON) carries RAW samples — required for downstream Welch's t-test.
+ */
+
+import { heapStats } from "bun:jsc"
+
+// --------------------------------------------------------------------------
+// blackhole — module-level sink that the JIT cannot prove is unobservable
+// --------------------------------------------------------------------------
+
+let _sink: unknown
+export const blackhole = (v: unknown): void => {
+  _sink = v
+}
+// Touch _sink at process exit so the optimizer cannot DCE the writes.
+process.on("exit", () => {
+  if (_sink === Symbol.for("never-this-actual-symbol")) {
+    // eslint-disable-next-line no-console
+    console.log("unreachable sink touch")
+  }
+})
+
+// --------------------------------------------------------------------------
+// stats
+// --------------------------------------------------------------------------
+
+export interface Stats {
+  readonly min: number
+  readonly max: number
+  readonly mean: number
+  readonly median: number
+  readonly p95: number
+  readonly p99: number
+  readonly stddev: number
+  readonly rsd: number
+  readonly opsPerSec: number
+}
+
+const quantile = (sorted: ReadonlyArray<number>, q: number): number => {
+  if (sorted.length === 0) return 0
+  const pos = (sorted.length - 1) * q
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  if (lo === hi) return sorted[lo]!
+  const frac = pos - lo
+  return sorted[lo]! * (1 - frac) + sorted[hi]! * frac
+}
+
+const computeStats = (samples: ReadonlyArray<number>, iterationsPerRun: number): Stats => {
+  if (samples.length === 0) {
+    return { min: 0, max: 0, mean: 0, median: 0, p95: 0, p99: 0, stddev: 0, rsd: 0, opsPerSec: 0 }
+  }
+  const sorted = [...samples].sort((a, b) => a - b)
+  const sum = samples.reduce((s, v) => s + v, 0)
+  const mean = sum / samples.length
+  const variance = samples.reduce((s, v) => s + (v - mean) ** 2, 0) / Math.max(1, samples.length - 1)
+  const stddev = Math.sqrt(variance)
+  const rsd = mean === 0 ? 0 : (stddev / mean) * 100
+  const nsPerOp = mean / iterationsPerRun
+  const opsPerSec = nsPerOp === 0 ? 0 : 1e9 / nsPerOp
+  return {
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    mean,
+    median: quantile(sorted, 0.5),
+    p95: quantile(sorted, 0.95),
+    p99: quantile(sorted, 0.99),
+    stddev,
+    rsd,
+    opsPerSec
+  }
+}
+
+// --------------------------------------------------------------------------
+// scenario contract
+// --------------------------------------------------------------------------
+
+export interface HeapStats {
+  readonly heapDeltaMean: number
+  readonly objectCountDeltaMean: number
+}
+
+export interface BenchScenarioResult {
+  readonly name: string
+  readonly description: string
+  readonly iterationsPerRun: number
+  readonly runs: number
+  readonly samples: ReadonlyArray<number>
+  readonly stats: Stats
+  readonly heap: HeapStats
+}
+
+export interface BenchOpts<S> {
+  readonly name: string
+  readonly description: string
+  readonly iterationsPerRun: number
+  readonly setup: () => S
+  readonly run: (state: S) => void
+}
+
+// --------------------------------------------------------------------------
+// timeout
+// --------------------------------------------------------------------------
+
+const RUN_TIMEOUT_MS = Number(process.env["RUN_TIMEOUT_MS"] ?? 30_000)
+
+const withTimeout = async <A>(p: Promise<A>, ms: number, name: string): Promise<A> => {
+  let handle: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    handle = setTimeout(() => reject(new Error(`scenario ${name} timed out after ${ms} ms`)), ms)
+  })
+  try {
+    return await Promise.race([p, timeout])
+  } finally {
+    if (handle !== undefined) clearTimeout(handle)
+  }
+}
+
+// --------------------------------------------------------------------------
+// benchmark() — runs WARMUP + RUNS, returns BenchScenarioResult
+// --------------------------------------------------------------------------
+
+export const WARMUP = Number(process.env["WARMUP"] ?? 10)
+export const RUNS = Number(process.env["RUNS"] ?? 30)
+
+export const benchmark = async <S>(opts: BenchOpts<S>): Promise<BenchScenarioResult> => {
+  const state = opts.setup()
+  const totalRuns = WARMUP + RUNS
+  const allSamples: Array<number> = []
+  const heapDeltas: Array<number> = []
+  const objCountDeltas: Array<number> = []
+
+  for (let i = 0; i < totalRuns; i++) {
+    Bun.gc(true)
+    await new Promise<void>((r) => setTimeout(r, 5))
+
+    const beforeHeap = heapStats()
+    const t0 = Bun.nanoseconds()
+    await withTimeout(Promise.resolve(opts.run(state)), RUN_TIMEOUT_MS, opts.name)
+    const elapsed = Bun.nanoseconds() - t0
+    const afterHeap = heapStats()
+
+    allSamples.push(elapsed)
+    heapDeltas.push(afterHeap.heapSize - beforeHeap.heapSize)
+    objCountDeltas.push(afterHeap.objectCount - beforeHeap.objectCount)
+  }
+
+  const samples = allSamples.slice(WARMUP)
+  const heap = heapDeltas.slice(WARMUP)
+  const objs = objCountDeltas.slice(WARMUP)
+
+  const heapDeltaMean = heap.reduce((s, v) => s + v, 0) / heap.length
+  const objectCountDeltaMean = objs.reduce((s, v) => s + v, 0) / objs.length
+
+  return {
+    name: opts.name,
+    description: opts.description,
+    iterationsPerRun: opts.iterationsPerRun,
+    runs: samples.length,
+    samples,
+    stats: computeStats(samples, opts.iterationsPerRun),
+    heap: { heapDeltaMean, objectCountDeltaMean }
+  }
+}

--- a/bench/index.ts
+++ b/bench/index.ts
@@ -1,0 +1,154 @@
+/**
+ * effect-smol bench runner. Outputs JSON with raw per-run samples for
+ * downstream Welch's t-test (see bench/harness.ts).
+ *
+ * Usage:
+ *   bun run bench/index.ts                       # default WARMUP=10 RUNS=30
+ *   WARMUP=10 RUNS=30 bun run bench/index.ts
+ *
+ * Output:
+ *   bench/results/baseline-<sha>.json (or path passed as first arg)
+ */
+
+import { execSync } from "node:child_process"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
+import { RUNS, WARMUP, type BenchScenarioResult } from "./harness.ts"
+
+import { run as run01 } from "./scenarios/01-succeed-flatmap-1000.ts"
+import { run as run02 } from "./scenarios/02-mixed-primitive-chain.ts"
+import { run as run03 } from "./scenarios/03-fork-join-100.ts"
+import { run as run04 } from "./scenarios/04-stream-pipeline.ts"
+import { run as run05 } from "./scenarios/05-fail-catch-roundtrip.ts"
+import { runDeep as run06Deep, runShallow as run06Shallow } from "./scenarios/06-service-provide-yield.ts"
+import { run as run07 } from "./scenarios/07-layer-build-deep.ts"
+import { run as run08 } from "./scenarios/08-representative-program.ts"
+import { run as run09 } from "./scenarios/09-effect-allocator.ts"
+
+interface BenchOutput {
+  readonly env: {
+    readonly bun: string
+    readonly node: string
+    readonly os: string
+    readonly arch: string
+    readonly cpu: string
+    readonly memoryGB: number
+    readonly gitSha: string
+    readonly gitDirty: boolean
+    readonly timestamp: string
+    readonly warmup: number
+    readonly runs: number
+  }
+  readonly scenarios: ReadonlyArray<BenchScenarioResult>
+}
+
+const tryExec = (cmd: string): string => {
+  try {
+    return execSync(cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim()
+  } catch {
+    return ""
+  }
+}
+
+const env = () => {
+  const gitSha = tryExec("git rev-parse --short HEAD") || "unknown"
+  const gitDirty = tryExec("git status --porcelain") !== ""
+  return {
+    bun: typeof Bun !== "undefined" ? Bun.version : "n/a",
+    node: process.version,
+    os: `${os.type()} ${os.release()}`,
+    arch: process.arch,
+    cpu: os.cpus()[0]?.model ?? "unknown",
+    memoryGB: Number((os.totalmem() / 2 ** 30).toFixed(2)),
+    gitSha,
+    gitDirty,
+    timestamp: new Date().toISOString(),
+    warmup: WARMUP,
+    runs: RUNS
+  }
+}
+
+const fmt = (ns: number): string => {
+  if (ns < 1_000) return `${ns.toFixed(1)}ns`
+  if (ns < 1_000_000) return `${(ns / 1_000).toFixed(2)}µs`
+  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)}ms`
+  return `${(ns / 1_000_000_000).toFixed(2)}s`
+}
+
+const printRow = (s: BenchScenarioResult) => {
+  const meanPerOp = s.stats.mean / s.iterationsPerRun
+  const stddevPerOp = s.stats.stddev / s.iterationsPerRun
+  console.log(
+    `  ${s.name.padEnd(42)}  ${String(s.iterationsPerRun).padStart(6)}/run  ` +
+      `mean=${fmt(s.stats.mean).padStart(9)}  ` +
+      `±${fmt(s.stats.stddev).padStart(8)}  ` +
+      `RSD=${s.stats.rsd.toFixed(2).padStart(5)}%  ` +
+      `ns/op=${meanPerOp.toFixed(1).padStart(10)} ±${stddevPerOp.toFixed(1)}  ` +
+      `ops/s=${s.stats.opsPerSec.toExponential(2)}  ` +
+      `heap=${(s.heap.heapDeltaMean / 1024).toFixed(1)}KB  ` +
+      `objs=${s.heap.objectCountDeltaMean.toFixed(0)}`
+  )
+}
+
+const main = async () => {
+  const e = env()
+  console.log(`effect-smol bench — sha=${e.gitSha}${e.gitDirty ? " (dirty)" : ""} bun=${e.bun} node=${e.node}`)
+  console.log(`  ${e.cpu}  ${e.os} ${e.arch}  ${e.memoryGB}GB`)
+  console.log(`  WARMUP=${e.warmup}  RUNS=${e.runs}`)
+  console.log("")
+
+  const scenarios: Array<BenchScenarioResult> = []
+
+  const runOne = async (
+    label: string,
+    fn: () => Promise<BenchScenarioResult>
+  ): Promise<void> => {
+    process.stdout.write(`  running ${label} ... `)
+    const t0 = Bun.nanoseconds()
+    const r = await fn()
+    const wall = (Bun.nanoseconds() - t0) / 1e9
+    console.log(`done in ${wall.toFixed(2)}s  (RSD ${r.stats.rsd.toFixed(2)}%)`)
+    scenarios.push(r)
+  }
+
+  await runOne("01 succeed-flatMap-1000", run01)
+  await runOne("02 mixed-primitive-1000", run02)
+  await runOne("03 fork-join-100", run03)
+  await runOne("04 stream pipeline", run04)
+  await runOne("05 fail-catch roundtrip", run05)
+  await runOne("06a service provide+yield shallow", run06Shallow)
+  await runOne("06b service provide+yield deep", run06Deep)
+  await runOne("07 layer build deep", run07)
+  await runOne("08 representative program", run08)
+  await runOne("09 effect allocator", run09)
+
+  console.log("")
+  console.log("Results:")
+  scenarios.forEach(printRow)
+
+  console.log("")
+  const highRsd = scenarios.filter((s) => s.stats.rsd > 5)
+  if (highRsd.length > 0) {
+    console.log(`WARNING: RSD > 5% on ${highRsd.length} scenario(s) — consider increasing iterationsPerRun:`)
+    highRsd.forEach((s) => console.log(`  - ${s.name}: RSD ${s.stats.rsd.toFixed(2)}%`))
+    console.log("")
+  }
+
+  const output: BenchOutput = { env: e, scenarios }
+  const defaultPath = path.resolve(
+    __dirname,
+    "results",
+    `baseline-${e.gitSha}${e.gitDirty ? "-dirty" : ""}.json`
+  )
+  const outPath = process.argv[2] ? path.resolve(process.argv[2]) : defaultPath
+  fs.mkdirSync(path.dirname(outPath), { recursive: true })
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2))
+  console.log(`wrote ${outPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/bench/scenarios/01-succeed-flatmap-1000.ts
+++ b/bench/scenarios/01-succeed-flatmap-1000.ts
@@ -1,0 +1,47 @@
+/**
+ * Scenario 1: succeed + flatMap chain (depth=1000).
+ *
+ * Isolates the run-loop dispatch IC at `[evaluate]` plus per-step
+ * Success Exit allocation. Main signal for megamorphic dispatch at the
+ * primary call site (packages/effect/src/internal/effect.ts:633).
+ */
+import { Effect } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const DEPTH = 1000
+const ITERS = 500
+
+// Build the effect tree ONCE, outside the timed region. We are
+// measuring runSync (the run loop), not the construction cost.
+const buildChain = (): Effect.Effect<number> => {
+  let e: Effect.Effect<number> = Effect.succeed(0)
+  for (let i = 0; i < DEPTH; i++) {
+    e = e.pipe(Effect.flatMap((n) => Effect.succeed(n + 1)))
+  }
+  return e
+}
+
+const program = buildChain()
+const EXPECTED = DEPTH
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "01-succeed-flatmap-1000",
+    description: `succeed -> flatMap x ${DEPTH}, runSync (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          if (result !== EXPECTED) {
+            throw new Error(`scenario 01 expected ${EXPECTED}, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/02-mixed-primitive-chain.ts
+++ b/bench/scenarios/02-mixed-primitive-chain.ts
@@ -1,0 +1,50 @@
+/**
+ * Scenario 2: mixed-primitive chain (depth=1000 ops, interleaved).
+ *
+ * Forces multiple primitive types through the [evaluate] dispatch site
+ * (Sync, Map, Tap, FlatMap). Compared against scenario 1, the delta
+ * reveals whether scenario 1 was already megamorphic.
+ */
+import { Effect } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const BLOCKS = 250 // 4 ops per block = 1000 ops total
+const ITERS = 500
+
+const buildChain = (): Effect.Effect<number> => {
+  let e: Effect.Effect<number> = Effect.succeed(0)
+  for (let i = 0; i < BLOCKS; i++) {
+    e = e.pipe(
+      Effect.flatMap((n) => Effect.succeed(n + 1)),
+      Effect.map((n) => n + 1),
+      Effect.tap(() => Effect.succeed(undefined)),
+      Effect.flatMap((n) => Effect.succeed(n + 1))
+    )
+  }
+  return e
+}
+
+const program = buildChain()
+const EXPECTED = BLOCKS * 3 // flatMap (+1), map (+1), tap (no inc), flatMap (+1) → 3 per block
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "02-mixed-primitive-chain-1000",
+    description: `succeed → (flatMap, map, tap, flatMap) × ${BLOCKS} blocks, runSync (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          if (result !== EXPECTED) {
+            throw new Error(`scenario 02 expected ${EXPECTED}, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/03-fork-join-100.ts
+++ b/bench/scenarios/03-fork-join-100.ts
@@ -1,0 +1,46 @@
+/**
+ * Scenario 3: fork/join 100 concurrent fibers.
+ *
+ * Exercises fiber spawn allocations, scheduler.scheduleTask, join coordination.
+ */
+import { Effect, Fiber } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const N = 100
+const ITERS = 100
+
+const program: Effect.Effect<number> = Effect.gen(function*() {
+  const fibers: Array<Fiber.Fiber<number, never>> = []
+  for (let i = 0; i < N; i++) {
+    fibers.push(yield* Effect.forkChild(Effect.succeed(i)))
+  }
+  let sum = 0
+  for (let i = 0; i < fibers.length; i++) {
+    sum += yield* Fiber.join(fibers[i]!)
+  }
+  return sum
+})
+
+const EXPECTED = (N * (N - 1)) / 2 // sum 0..N-1
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "03-fork-join-100",
+    description: `fork ${N} fibers (Effect.succeed), join all, runSync (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          if (result !== EXPECTED) {
+            throw new Error(`scenario 03 expected ${EXPECTED}, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/04-stream-pipeline.ts
+++ b/bench/scenarios/04-stream-pipeline.ts
@@ -1,0 +1,41 @@
+/**
+ * Scenario 4: Stream pipeline — range × map × filter × runDrain.
+ *
+ * Realistic mixed workload. Many small effects under the hood,
+ * exercising the Channel/Stream machinery on top of the core runtime.
+ */
+import { Effect, Stream } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const N = 10_000
+const ITERS = 300
+
+// Build the program once; runDrain is the boundary.
+const program: Effect.Effect<void> = Stream.range(0, N).pipe(
+  Stream.map((n: number) => n * 2),
+  Stream.filter((n: number) => n % 3 === 0),
+  Stream.runDrain
+)
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "04-stream-range-map-filter-drain",
+    description: `Stream.range(0, ${N}).map(*2).filter(%3==0).runDrain (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          // runDrain returns undefined on success; just confirm it executed
+          if (result !== undefined) {
+            throw new Error(`scenario 04 expected undefined, got ${String(result)}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/05-fail-catch-roundtrip.ts
+++ b/bench/scenarios/05-fail-catch-roundtrip.ts
@@ -1,0 +1,40 @@
+/**
+ * Scenario 5: fail / catch roundtrip.
+ *
+ * Exercises Cause allocation (Fail reason + CauseImpl wrapper, ~2 heap
+ * objects per failure) plus the failure-path dispatch.
+ *
+ * Note: effect-smol does not export `catchAll`. The broadest analog is
+ * `catchCause`, which catches the whole cause regardless of tag and is
+ * the closest equivalent for the audit hypothesis.
+ */
+import { Effect } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const ITERS = 20_000
+
+const program: Effect.Effect<number, never> = Effect.fail("boom" as const).pipe(
+  Effect.catchCause(() => Effect.succeed(1))
+)
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "05-fail-catchCause-roundtrip",
+    description: `Effect.fail -> catchCause -> succeed(1), runSync (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          if (result !== 1) {
+            throw new Error(`scenario 05 expected 1, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/06-service-provide-yield.ts
+++ b/bench/scenarios/06-service-provide-yield.ts
@@ -1,0 +1,78 @@
+/**
+ * Scenario 6: service provide + yield (heavy).
+ *
+ * Exercises Context.getReferenceUnsafe (the two-probe pattern at
+ * packages/effect/src/Context.ts:839-844) plus setContext's repeated
+ * lookups during fiber initialisation.
+ *
+ * Two variants:
+ *   shallow: one service, one yield → minimal lookup
+ *   deep:    one service, many yields under a deep `provideService` stack
+ */
+import { Context, Effect } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const ITERS_SHALLOW = 5000
+const ITERS_DEEP = 1500
+const DEEP_YIELDS = 200
+
+interface SShape {
+  readonly v: number
+}
+class S extends Context.Service<S, SShape>()("BenchScenario06_S") {}
+
+const shallow: Effect.Effect<number> = Effect.gen(function*() {
+  const s = yield* S
+  return s.v
+}).pipe(Effect.provideService(S, { v: 42 }))
+
+const deep: Effect.Effect<number> = Effect.gen(function*() {
+  let sum = 0
+  for (let i = 0; i < DEEP_YIELDS; i++) {
+    const s = yield* S
+    sum += s.v
+  }
+  return sum
+}).pipe(Effect.provideService(S, { v: 1 }))
+
+const EXPECTED_SHALLOW = 42
+const EXPECTED_DEEP = DEEP_YIELDS
+
+let shallowAsserted = false
+let deepAsserted = false
+
+export const runShallow = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "06a-service-provide-yield-shallow",
+    description: `provideService(S, {v:42}); gen yield* S; runSync (${ITERS_SHALLOW} iters/run)`,
+    iterationsPerRun: ITERS_SHALLOW,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS_SHALLOW; i++) {
+        const r = Effect.runSync(shallow)
+        if (!shallowAsserted) {
+          if (r !== EXPECTED_SHALLOW) throw new Error(`scenario 06a expected ${EXPECTED_SHALLOW}, got ${r}`)
+          shallowAsserted = true
+        }
+        blackhole(r)
+      }
+    }
+  })
+
+export const runDeep = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "06b-service-provide-yield-deep",
+    description: `provideService + ${DEEP_YIELDS} yields of S; runSync (${ITERS_DEEP} iters/run)`,
+    iterationsPerRun: ITERS_DEEP,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS_DEEP; i++) {
+        const r = Effect.runSync(deep)
+        if (!deepAsserted) {
+          if (r !== EXPECTED_DEEP) throw new Error(`scenario 06b expected ${EXPECTED_DEEP}, got ${r}`)
+          deepAsserted = true
+        }
+        blackhole(r)
+      }
+    }
+  })

--- a/bench/scenarios/07-layer-build-deep.ts
+++ b/bench/scenarios/07-layer-build-deep.ts
@@ -1,0 +1,115 @@
+/**
+ * Scenario 7: Layer build (deep dependency graph).
+ *
+ * Models a realistic app where many services compose through Layer.provide,
+ * Layer.merge, and Layer.provideMerge. Each iteration provides the composed
+ * layer to a small program and runs it — exercising:
+ *   - Layer compilation / memoization
+ *   - Context construction & service-key threading
+ *   - service lookup chain at yield time (Context.getReferenceUnsafe)
+ *   - the runtime's R-resolution path
+ *
+ * Graph:
+ *   ServiceA  (Layer.succeed)
+ *   ServiceB  depends on A
+ *   ServiceC  depends on B   (provided via Layer.provide chain)
+ *   ServiceD  depends on C
+ *   ServiceE  depends on D + B (merged) so the graph branches
+ *   ServiceF  depends on E + A (provideMerge — also publishes A)
+ *
+ * Program then yields E and F and sums their fields.
+ */
+import { Context, Effect, Layer } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const ITERS = 200
+
+class ServiceA extends Context.Service<ServiceA, { readonly a: number }>()("BenchScenario07_A") {}
+class ServiceB extends Context.Service<ServiceB, { readonly b: number }>()("BenchScenario07_B") {}
+class ServiceC extends Context.Service<ServiceC, { readonly c: number }>()("BenchScenario07_C") {}
+class ServiceD extends Context.Service<ServiceD, { readonly d: number }>()("BenchScenario07_D") {}
+class ServiceE extends Context.Service<ServiceE, { readonly e: number }>()("BenchScenario07_E") {}
+class ServiceF extends Context.Service<ServiceF, { readonly f: number }>()("BenchScenario07_F") {}
+
+const LayerA = Layer.succeed(ServiceA, { a: 1 })
+
+const LayerB = Layer.effect(
+  ServiceB,
+  Effect.gen(function*() {
+    const a = yield* ServiceA
+    return { b: a.a + 1 }
+  })
+).pipe(Layer.provide(LayerA))
+
+const LayerC = Layer.effect(
+  ServiceC,
+  Effect.gen(function*() {
+    const b = yield* ServiceB
+    return { c: b.b + 1 }
+  })
+).pipe(Layer.provide(LayerB))
+
+const LayerD = Layer.effect(
+  ServiceD,
+  Effect.gen(function*() {
+    const c = yield* ServiceC
+    return { d: c.c + 1 }
+  })
+).pipe(Layer.provide(LayerC))
+
+// Branch: E needs both D and B; merge them as a single provide bundle
+const LayerE = Layer.effect(
+  ServiceE,
+  Effect.gen(function*() {
+    const d = yield* ServiceD
+    const b = yield* ServiceB
+    return { e: d.d + b.b }
+  })
+).pipe(Layer.provide(Layer.merge(LayerD, LayerB)))
+
+// provideMerge: F is provided by composition of E + A, but also re-publishes A
+const LayerF = Layer.effect(
+  ServiceF,
+  Effect.gen(function*() {
+    const e = yield* ServiceE
+    const a = yield* ServiceA
+    return { f: e.e + a.a }
+  })
+).pipe(Layer.provideMerge(Layer.merge(LayerE, LayerA)))
+
+const program: Effect.Effect<number, never, ServiceE | ServiceF> = Effect.gen(function*() {
+  const e = yield* ServiceE
+  const f = yield* ServiceF
+  return e.e + f.f
+})
+
+// Each iteration provides the entire layer graph and runs the program.
+// Layer.provide handles memoization automatically.
+const provided: Effect.Effect<number> = program.pipe(Effect.provide(LayerF))
+
+// E = (((1)+1)+1)+1 + (1+1) = 4 + 2 = 6
+// F = 6 + 1 = 7
+// total = 6 + 7 = 13
+const EXPECTED = 13
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "07-layer-build-deep",
+    description: `Layer graph A→B→C→D→{D,B}→E; F=provideMerge(E,A); program yields E+F (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(provided)
+        if (!assertionDone) {
+          if (result !== EXPECTED) {
+            throw new Error(`scenario 07 expected ${EXPECTED}, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })

--- a/bench/scenarios/08-representative-program.ts
+++ b/bench/scenarios/08-representative-program.ts
@@ -1,0 +1,122 @@
+/**
+ * Scenario 8: representative real-world Effect program.
+ *
+ * Combines the moving parts typically present in production:
+ *   - 2 services injected via Layer + provideService
+ *   - a Stream of input items
+ *   - mapEffect that yields services and does small work
+ *   - one item triggers a typed failure that is caught and recovered
+ *   - fork N worker children that join via Fiber.join
+ *   - sum + assertion at the end
+ *
+ * Intentionally NOT a microbenchmark — exercises the full runtime surface
+ * the way an application would. Per-iteration cost in the few-ms range.
+ */
+import { Cause, Context, Data, Effect, Fiber, Stream } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const STREAM_N = 200
+const FORK_N = 16
+const ITERS = 250
+
+class Multiplier extends Context.Service<Multiplier, {
+  readonly factor: number
+  readonly multiply: (n: number) => Effect.Effect<number>
+}>()("BenchScenario08_Multiplier") {}
+
+class Adder extends Context.Service<Adder, {
+  readonly delta: number
+  readonly add: (n: number) => Effect.Effect<number>
+}>()("BenchScenario08_Adder") {}
+
+class BoomError extends Data.TaggedError("BoomError")<{ readonly at: number }> {}
+
+const program: Effect.Effect<number> = Effect.gen(function*() {
+  const mult = yield* Multiplier
+  const add = yield* Adder
+
+  // Stream of STREAM_N items → mapEffect → fold sum.
+  // One item triggers a typed failure that is caught and recovered to 0.
+  const streamSum = yield* Stream.range(0, STREAM_N).pipe(
+    Stream.mapEffect((n) =>
+      Effect.gen(function*() {
+        const x = yield* mult.multiply(n)
+        if (n === Math.floor(STREAM_N / 2)) {
+          return yield* Effect.fail(new BoomError({ at: n }))
+        }
+        return yield* add.add(x)
+      })
+    ),
+    Stream.catchCause(() => Stream.fromIterable([0])),
+    Stream.runFold(() => 0, (acc, n) => acc + n)
+  )
+
+  // Fork FORK_N children that each do a service-yielding computation.
+  const children: Array<Fiber.Fiber<number, never>> = []
+  for (let i = 0; i < FORK_N; i++) {
+    children.push(
+      yield* Effect.forkChild(
+        Effect.gen(function*() {
+          const m = yield* mult.multiply(i)
+          const a = yield* add.add(m)
+          return a
+        })
+      )
+    )
+  }
+
+  let forkSum = 0
+  for (let i = 0; i < FORK_N; i++) {
+    forkSum += yield* Fiber.join(children[i]!)
+  }
+
+  return streamSum + forkSum
+}).pipe(
+  Effect.provideService(Multiplier, {
+    factor: 3,
+    multiply: (n: number) => Effect.succeed(n * 3)
+  }),
+  Effect.provideService(Adder, {
+    delta: 7,
+    add: (n: number) => Effect.succeed(n + 7)
+  })
+)
+
+// Compute expected value deterministically.
+// Items 0..midpoint-1 succeed and contribute (n*3 + 7). At midpoint the
+// mapped Effect fails; Stream.catchCause then replaces the *remainder* of
+// the stream with [0], which contributes a single 0 to the fold.
+const midpoint = Math.floor(STREAM_N / 2)
+let expectedStream = 0
+for (let n = 0; n < midpoint; n++) {
+  expectedStream += n * 3 + 7
+}
+expectedStream += 0 // the recovery value
+let expectedFork = 0
+for (let i = 0; i < FORK_N; i++) expectedFork += i * 3 + 7
+const EXPECTED = expectedStream + expectedFork
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "08-representative-program",
+    description: `2 svcs + Stream(N=${STREAM_N})+mapEffect+catchCause + ${FORK_N} fork/join (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const result = Effect.runSync(program)
+        if (!assertionDone) {
+          if (result !== EXPECTED) {
+            throw new Error(`scenario 08 expected ${EXPECTED}, got ${result}`)
+          }
+          assertionDone = true
+        }
+        blackhole(result)
+      }
+    }
+  })
+
+// Avoid unused-import warning on Cause when wiring later.
+void Cause

--- a/bench/scenarios/09-effect-allocator.ts
+++ b/bench/scenarios/09-effect-allocator.ts
@@ -1,0 +1,60 @@
+/**
+ * Scenario 9: Effect AST construction only (no run).
+ *
+ * Pure allocation benchmark — builds a deep Effect tree using
+ * map / flatMap / tap and intentionally does NOT runSync it.
+ *
+ * Measures:
+ *   - per-primitive construction cost
+ *   - hidden-class stability for the unified SharedComputationProto
+ *   - GC pressure / heap delta of the AST itself
+ *
+ * V1.3's per-instance [evaluate] adds one own-property write per
+ * construction. This scenario quantifies that allocation overhead in
+ * isolation from the run loop.
+ */
+import { Effect } from "../../packages/effect/src/index.ts"
+import { benchmark, blackhole, type BenchScenarioResult } from "../harness.ts"
+
+const DEPTH = 1000
+const ITERS = 500
+
+const buildTree = (): Effect.Effect<number> => {
+  let e: Effect.Effect<number> = Effect.succeed(0)
+  for (let i = 0; i < DEPTH; i++) {
+    // Cycle through three primitives so we exercise OnSuccess, plain map,
+    // and tap (no continuation).
+    const phase = i % 3
+    if (phase === 0) {
+      e = e.pipe(Effect.flatMap((n) => Effect.succeed(n + 1)))
+    } else if (phase === 1) {
+      e = e.pipe(Effect.map((n) => n + 1))
+    } else {
+      e = e.pipe(Effect.tap(() => Effect.succeed(undefined)))
+    }
+  }
+  return e
+}
+
+let assertionDone = false
+
+export const run = (): Promise<BenchScenarioResult> =>
+  benchmark({
+    name: "09-effect-allocator",
+    description: `build Effect tree depth=${DEPTH}, NO runSync (${ITERS} iters/run)`,
+    iterationsPerRun: ITERS,
+    setup: () => ({}),
+    run: () => {
+      for (let i = 0; i < ITERS; i++) {
+        const tree = buildTree()
+        if (!assertionDone) {
+          // sanity-check that the tree was built and is an Effect
+          if (tree === undefined || tree === null) {
+            throw new Error(`scenario 09 expected non-null Effect tree`)
+          }
+          assertionDone = true
+        }
+        blackhole(tree)
+      }
+    }
+  })

--- a/packages/effect/src/internal/core.ts
+++ b/packages/effect/src/internal/core.ts
@@ -56,6 +56,65 @@ export const contAll = `${EffectTypeId}/ensureCont` as const
 /** @internal */
 export type contAll = typeof contAll
 
+// ----------------------------------------------------------------------------
+// Unified op-tag dispatch (Candidate B-v1: pure switch, no registry indirection)
+//
+// All 14 internal computation primitives share ONE prototype
+// (SharedComputationProto in effect.ts). Success / Failure exit primitives
+// share ANOTHER prototype (SharedExitProto below). The dispatch site
+// `(current)[evaluate](this)` in runLoop therefore observes at most TWO
+// hidden classes => stays within polymorphic IC threshold (V8 <=4, JSC
+// similar) instead of going megamorphic over 14+ distinct prototypes.
+//
+// Critically (in contrast to candidate B-v0): the per-op evaluator bodies
+// are inlined in a `switch (this[opTag])` directly on the shared proto's
+// `[evaluate]` method. There is no per-call registry-array load and no
+// per-call accessor getter for [contA] / [contE] / [contAll]. Continuation
+// handlers are stored as instance own-properties with a fixed add-order so
+// every instance shares a single hidden class.
+// ----------------------------------------------------------------------------
+
+/** @internal */
+export const opTag = Symbol.for("effect/runtime/opTag")
+/** @internal */
+export type opTag = typeof opTag
+
+// Dense integer ops. Order matches the historical primitives so existing
+// reading paths remain consistent. Reserve 0 for "unknown" sentinel.
+/** @internal */
+export const OP_Sync = 1
+/** @internal */
+export const OP_Suspend = 2
+/** @internal */
+export const OP_Yield = 3
+/** @internal */
+export const OP_Async = 4
+/** @internal */
+export const OP_AsyncFinalizer = 5
+/** @internal */
+export const OP_Iterator = 6
+/** @internal */
+export const OP_OnSuccess = 7
+/** @internal */
+export const OP_OnFailure = 8
+/** @internal */
+export const OP_OnSuccessAndFailure = 9
+/** @internal */
+export const OP_Exit = 10
+/** @internal */
+export const OP_OnExit = 11
+/** @internal */
+export const OP_SetInterruptible = 12
+/** @internal */
+export const OP_While = 13
+/** @internal */
+export const OP_WithFiber = 14
+// Exits live on a separate shared proto:
+/** @internal */
+export const OP_Success = 15
+/** @internal */
+export const OP_Failure = 16
+
 /** @internal */
 export const Yield = Symbol.for("effect/Effect/Yield")
 /** @internal */
@@ -383,6 +442,47 @@ function defaultEvaluate(_fiber: FiberImpl): Primitive | Yield {
   return exitDie(`Effect.evaluate: Not implemented`) as any
 }
 
+// ---------------------------------------------------------------------------
+// V1.3 — per-instance [evaluate].
+//
+// V1 used a shared [evaluate] on SharedComputationProto that switched on
+// this[opTag] and dispatched through module-level `let` slots. The switch +
+// indirection cost an extra branch + an indirect call through a mutable
+// binding per run-loop step. V1.3 stores the evaluator as an own-property
+// on each instance, set at construction time, so the run loop reads
+// `current[evaluate]` directly at proto-chain level 0 and calls it.
+//
+// Trade-off: call IC at the dispatch site goes from 1 target (monomorphic)
+// to N targets (polymorphic-by-op). JSC's polymorphic call IC handles small
+// N cheaply; the switch's load + mutable-let indirection was per-step cost
+// the IC could never amortize.
+// ---------------------------------------------------------------------------
+
+type EvalFn = (this: any, fiber: FiberImpl) => Primitive | Yield
+type ContAFn = (this: any, value: any, fiber: FiberImpl, exit?: Exit.Exit<any, any>) => Primitive | Yield
+type ContEFn = (
+  this: any,
+  cause: Cause.Cause<any>,
+  fiber: FiberImpl,
+  exit?: Exit.Exit<any, any>
+) => Primitive | Yield
+type ContAllFn = (this: any, fiber: FiberImpl) => void | ((value: any, fiber: FiberImpl) => void)
+
+// Stack-push evaluator: OnSuccess, OnFailure, and OnSuccessAndFailure all
+// share this body. Their semantic distinction lives in their continuation
+// handlers ([contA] / [contE] / [contAll]), not in their evaluator. Sharing
+// one function reference also collapses three distinct call-IC targets at
+// the dispatch site down to one.
+const evaluateStackPush: EvalFn = function(this: any, fiber: FiberImpl): Primitive {
+  fiber._stack.push(this)
+  return this[args]
+}
+
+/** @internal */
+export const SharedComputationProto: object = {
+  ...EffectProto
+}
+
 /** @internal */
 export const makePrimitiveProto = <Op extends string>(options: {
   readonly op: Op
@@ -419,6 +519,7 @@ export const makePrimitive = <
   Single extends boolean = true
 >(options: {
   readonly op: string
+  readonly opTag: number
   readonly single?: Single
   readonly [evaluate]?: (
     this: Primitive & {
@@ -449,41 +550,126 @@ export const makePrimitive = <
     fiber: FiberImpl
   ) => void | ((value: any, fiber: FiberImpl) => void)
 }): Fn => {
-  const Proto = makePrimitiveProto(options as any)
+  const opTagValue = options.opTag
+  const opName = options.op
+  const single = options.single !== false
+  const evalFn: EvalFn = (options[evaluate] as EvalFn | undefined) ?? defaultEvaluate
+  const cA = options[contA] as ContAFn | undefined
+  const cE = options[contE] as ContEFn | undefined
+  const cAll = options[contAll] as ContAllFn | undefined
+  // Unified instance factory. Property add-order is FIXED across all 14
+  // internal computation primitives to keep a single hidden class:
+  //   [identifier], [opTag], [args], [contA], [contE], [contAll], [evaluate]
+  // Handlers default to undefined; ops with a handler overwrite the slot
+  // *after* the undefined assignment (same slot, same shape).
   return function() {
-    const self = Object.create(Proto)
-    self[args] = options.single === false ? arguments : arguments[0]
+    const self = Object.create(SharedComputationProto)
+    self[identifier] = opName
+    self[opTag] = opTagValue
+    self[args] = single ? arguments[0] : arguments
+    self[contA] = undefined
+    self[contE] = undefined
+    self[contAll] = undefined
+    self[evaluate] = evalFn
+    if (cA !== undefined) self[contA] = cA
+    if (cE !== undefined) self[contE] = cE
+    if (cAll !== undefined) self[contAll] = cAll
     return self
   } as Fn
 }
 
+/**
+ * @internal
+ *
+ * Allocate a fresh OnSuccess primitive without going through `makePrimitive`.
+ * Used by hot factories (`flatMap`, `catchCause`, `matchCauseEffect`) that need
+ * to attach a user-supplied callback per-instance. Property add-order matches
+ * `makePrimitive` exactly so all SharedComputationProto instances share one
+ * hidden class.
+ */
+export const makeOnSuccess = <A>(
+  self: Effect.Effect<A, any, any>,
+  onSuccess: (value: A) => Effect.Effect<any, any, any>
+): Primitive => {
+  const out: any = Object.create(SharedComputationProto)
+  out[identifier] = "OnSuccess"
+  out[opTag] = OP_OnSuccess
+  out[args] = self
+  out[contA] = onSuccess
+  out[contE] = undefined
+  out[contAll] = undefined
+  out[evaluate] = evaluateStackPush
+  return out
+}
+
+/**
+ * @internal
+ *
+ * Allocate a fresh OnFailure primitive without going through `makePrimitive`.
+ * Matches the canonical add-order so all instances share one hidden class.
+ */
+export const makeOnFailure = <E>(
+  self: Effect.Effect<any, E, any>,
+  onFailure: (cause: Cause.Cause<E>) => Effect.Effect<any, any, any>
+): Primitive => {
+  const out: any = Object.create(SharedComputationProto)
+  out[identifier] = "OnFailure"
+  out[opTag] = OP_OnFailure
+  out[args] = self
+  out[contA] = undefined
+  out[contE] = onFailure
+  out[contAll] = undefined
+  out[evaluate] = evaluateStackPush
+  return out
+}
+
+/**
+ * @internal
+ *
+ * Allocate a fresh OnSuccessAndFailure primitive without going through
+ * `makePrimitive`. Matches the canonical add-order.
+ */
+export const makeOnSuccessAndFailure = <A, E>(
+  self: Effect.Effect<A, E, any>,
+  onSuccess: (value: A) => Effect.Effect<any, any, any>,
+  onFailure: (cause: Cause.Cause<E>) => Effect.Effect<any, any, any>
+): Primitive => {
+  const out: any = Object.create(SharedComputationProto)
+  out[identifier] = "OnSuccessAndFailure"
+  out[opTag] = OP_OnSuccessAndFailure
+  out[args] = self
+  out[contA] = onSuccess
+  out[contE] = onFailure
+  out[contAll] = undefined
+  out[evaluate] = evaluateStackPush
+  return out
+}
+
+
+// ---------------------------------------------------------------------------
+// SharedExitProto: ONE prototype shared by both Success and Failure instances.
+//
+// Both exits expose `value` (Success) AND `cause` (Failure) on the shared
+// proto as getters returning this[args]. The selector is purely conventional;
+// the instance shape is identical. `_tag` is the discriminant.
+// ---------------------------------------------------------------------------
+
+let EVAL_Success: EvalFn = defaultEvaluate
+let EVAL_Failure: EvalFn = defaultEvaluate
+
 /** @internal */
-export const makeExit = <
-  Fn extends (...args: Array<any>) => any,
-  Prop extends string
->(options: {
-  readonly op: "Success" | "Failure"
-  readonly prop: Prop
-  readonly [evaluate]: (
-    this: Exit.Exit<unknown, unknown> & { [args]: Parameters<Fn>[0] },
-    fiber: FiberImpl<unknown, unknown>
-  ) => Primitive | Yield
-}): Fn => {
-  const Proto = {
-    ...makePrimitiveProto(options),
+export const SharedExitProto: object = (() => {
+  const proto: any = {
+    ...EffectProto,
     [ExitTypeId]: ExitTypeId,
-    _tag: options.op,
-    get [options.prop](): any {
-      return (this as any)[args]
-    },
     toString(this: any) {
-      return `${options.op}(${format(this[args])})`
+      return `${this._tag}(${format(this[args])})`
     },
     toJSON(this: any) {
       return {
         _id: "Exit",
-        _tag: options.op,
-        [options.prop]: this[args]
+        _tag: this._tag,
+        [this._tag === "Success" ? "value" : "cause"]: this[args]
       }
     },
     [Equal.symbol](this: any, that: any): boolean {
@@ -494,25 +680,46 @@ export const makeExit = <
       )
     },
     [Hash.symbol](this: any): number {
-      return Hash.combine(Hash.string(options.op), Hash.hash(this[args]))
+      return Hash.combine(Hash.string(this._tag), Hash.hash(this[args]))
     }
   }
-  return function(value: unknown) {
-    const self = Object.create(Proto)
-    self[args] = value
-    return self
-  } as Fn
-}
+  // Both `value` and `cause` accessors live on the shared proto, each reading
+  // from this[args]. The non-matching name is harmless: Success.cause and
+  // Failure.value both return the underlying payload, but callers consult
+  // _tag before reading.
+  Object.defineProperty(proto, "value", {
+    get(this: any) {
+      return this[args]
+    },
+    enumerable: true,
+    configurable: true
+  })
+  Object.defineProperty(proto, "cause", {
+    get(this: any) {
+      return this[args]
+    },
+    enumerable: true,
+    configurable: true
+  })
+  return proto
+})()
 
 /** @internal */
-export const exitSucceed: <A>(a: A) => Exit.Exit<A> = makeExit({
-  op: "Success",
-  prop: "value",
-  [evaluate](fiber) {
+export const exitSucceed: <A>(a: A) => Exit.Exit<A> = (() => {
+  EVAL_Success = function(this: any, fiber) {
     const cont = fiber.getCont(contA)
     return cont ? cont[contA](this[args], fiber, this) : fiber.yieldWith(this)
   }
-})
+  return function(value: unknown): Exit.Exit<any> {
+    const self: any = Object.create(SharedExitProto)
+    self[identifier] = "Success"
+    self[opTag] = OP_Success
+    self[args] = value
+    self._tag = "Success"
+    self[evaluate] = EVAL_Success
+    return self
+  } as any
+})()
 
 /** @internal */
 export const StackTraceKey = {
@@ -525,10 +732,8 @@ export const InterruptorStackTrace = {
 } as Context.Service<Cause.InterruptorStackTrace, StackFrame>
 
 /** @internal */
-export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = makeExit({
-  op: "Failure",
-  prop: "cause",
-  [evaluate](fiber) {
+export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = (() => {
+  EVAL_Failure = function(this: any, fiber) {
     let cause = this[args]
     let annotated = false
     if (fiber.currentStackFrame) {
@@ -543,7 +748,16 @@ export const exitFailCause: <E>(cause: Cause.Cause<E>) => Exit.Exit<never, E> = 
       ? cont[contE](cause, fiber, annotated ? undefined : this)
       : fiber.yieldWith(annotated ? this : exitFailCause(cause))
   }
-})
+  return function(cause: unknown): Exit.Exit<never, any> {
+    const self: any = Object.create(SharedExitProto)
+    self[identifier] = "Failure"
+    self[opTag] = OP_Failure
+    self[args] = cause
+    self._tag = "Failure"
+    self[evaluate] = EVAL_Failure
+    return self
+  } as any
+})()
 
 /** @internal */
 export const exitFail = <E>(e: E): Exit.Exit<never, E> => exitFailCause(causeFail(e))
@@ -556,6 +770,7 @@ export const withFiber: <A, E = never, R = never>(
   evaluate: (fiber: FiberImpl<unknown, unknown>) => Effect.Effect<A, E, R>
 ) => Effect.Effect<A, E, R> = makePrimitive({
   op: "WithFiber",
+  opTag: OP_WithFiber,
   [evaluate](fiber) {
     return this[args](fiber)
   }

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -72,9 +72,21 @@ import {
   isFailReason,
   isInterruptReason,
   isNoSuchElementError,
+  makeOnFailure,
+  makeOnSuccess,
+  makeOnSuccessAndFailure,
   makePrimitive,
-  makePrimitiveProto,
   NoSuchElementError,
+  OP_Async,
+  OP_AsyncFinalizer,
+  OP_Exit,
+  OP_Iterator,
+  OP_OnExit,
+  OP_SetInterruptible,
+  OP_Suspend,
+  OP_Sync,
+  OP_While,
+  OP_Yield,
   ReasonBase,
   StackTraceKey as CauseStackTrace,
   TaggedError,
@@ -874,6 +886,7 @@ export const fail: <E>(error: E) => Effect.Effect<never, E> = exitFail
 /** @internal */
 export const sync: <A>(thunk: LazyArg<A>) => Effect.Effect<A> = makePrimitive({
   op: "Sync",
+  opTag: OP_Sync,
   [evaluate](fiber): Primitive | Yield {
     const value = this[args]()
     const cont = fiber.getCont(contA)
@@ -886,6 +899,7 @@ export const suspend: <A, E, R>(
   evaluate: LazyArg<Effect.Effect<A, E, R>>
 ) => Effect.Effect<A, E, R> = makePrimitive({
   op: "Suspend",
+  opTag: OP_Suspend,
   [evaluate](_fiber) {
     return this[args]()
   }
@@ -910,6 +924,7 @@ export const fromNullishOr = <A>(value: A): Effect.Effect<NonNullable<A>, Cause.
 /** @internal */
 export const yieldNowWith: (priority?: number) => Effect.Effect<void> = makePrimitive({
   op: "Yield",
+  opTag: OP_Yield,
   [evaluate](fiber) {
     let resumed = false
     fiber.currentDispatcher.scheduleTask(() => {
@@ -1018,6 +1033,7 @@ const callbackOptions: <A, E = never, R = never>(
   withSignal: boolean
 ) => Effect.Effect<A, E, R> = makePrimitive({
   op: "Async",
+  opTag: OP_Async,
   single: false,
   [evaluate](fiber) {
     const register = internalCall(() => this[args][0].bind(fiber.currentScheduler))
@@ -1056,6 +1072,7 @@ const asyncFinalizer: (
   onInterrupt: () => Effect.Effect<void, any, any>
 ) => Primitive = makePrimitive({
   op: "AsyncFinalizer",
+  opTag: OP_AsyncFinalizer,
   [contAll](fiber) {
     if (fiber.interruptible) {
       fiber.interruptible = false
@@ -1268,6 +1285,7 @@ const fromIteratorUnsafe: (
   initial?: undefined
 ) => Effect.Effect<any, any, any> = makePrimitive({
   op: "Iterator",
+  opTag: OP_Iterator,
   single: false,
   [contA](value, fiber) {
     const iter = this[args][0]
@@ -1584,19 +1602,9 @@ export const flatMap: {
     self: Effect.Effect<A, E, R>,
     f: (a: A) => Effect.Effect<B, E2, R2>
   ): Effect.Effect<B, E | E2, R | R2> => {
-    const onSuccess = Object.create(OnSuccessProto)
-    onSuccess[args] = self
-    onSuccess[contA] = f.length !== 1 ? (a: A) => f(a) : f
-    return onSuccess
+    return makeOnSuccess(self, f.length !== 1 ? (a: A) => f(a) : f) as any
   }
 )
-const OnSuccessProto = makePrimitiveProto({
-  op: "OnSuccess",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  }
-})
 
 /** @internal */
 export const matchCauseEffectEager: {
@@ -2371,19 +2379,9 @@ export const catchCause: {
     self: Effect.Effect<A, E, R>,
     f: (cause: NoInfer<Cause.Cause<E>>) => Effect.Effect<B, E2, R2>
   ): Effect.Effect<A | B, E2, R | R2> => {
-    const onFailure = Object.create(OnFailureProto)
-    onFailure[args] = self
-    onFailure[contE] = f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f
-    return onFailure
+    return makeOnFailure(self, f.length !== 1 ? (cause: Cause.Cause<E>) => f(cause) : f) as any
   }
 )
-const OnFailureProto = makePrimitiveProto({
-  op: "OnFailure",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this as any)
-    return this[args]
-  }
-})
 
 /** @internal */
 export const catchCauseIf: {
@@ -3319,22 +3317,13 @@ export const matchCauseEffect: {
       readonly onSuccess: (a: A) => Effect.Effect<A3, E3, R3>
     }
   ): Effect.Effect<A2 | A3, E2 | E3, R2 | R3 | R> => {
-    const primitive = Object.create(OnSuccessAndFailureProto)
-    primitive[args] = self
-    primitive[contA] = options.onSuccess.length !== 1 ? (a: A) => options.onSuccess(a) : options.onSuccess
-    primitive[contE] = options.onFailure.length !== 1
-      ? (cause: Cause.Cause<E>) => options.onFailure(cause)
-      : options.onFailure
-    return primitive
+    return makeOnSuccessAndFailure(
+      self,
+      options.onSuccess.length !== 1 ? (a: A) => options.onSuccess(a) : options.onSuccess,
+      options.onFailure.length !== 1 ? (cause: Cause.Cause<E>) => options.onFailure(cause) : options.onFailure
+    ) as any
   }
 )
-const OnSuccessAndFailureProto = makePrimitiveProto({
-  op: "OnSuccessAndFailure",
-  [evaluate](this: any, fiber: FiberImpl): Primitive {
-    fiber._stack.push(this)
-    return this[args]
-  }
-})
 
 /** @internal */
 export const matchCause: {
@@ -3496,6 +3485,7 @@ export const exit = <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<Exit.
 const exitPrimitive: <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<Exit.Exit<A, E>, never, R> =
   makePrimitive({
     op: "Exit",
+    opTag: OP_Exit,
     [evaluate](fiber): Primitive {
       fiber._stack.push(this)
       return this[args] as any
@@ -3842,6 +3832,7 @@ export const onExitPrimitive: <A, E, R, XE = never, XR = never>(
   interruptible?: boolean
 ) => Effect.Effect<A, E | XE, R | XR> = makePrimitive({
   op: "OnExit",
+  opTag: OP_OnExit,
   single: false,
   [evaluate](fiber: FiberImpl) {
     fiber._stack.push(this)
@@ -4148,6 +4139,7 @@ export const uninterruptible = <A, E, R>(
 
 const setInterruptible: (interruptible: boolean) => Primitive = makePrimitive({
   op: "SetInterruptible",
+  opTag: OP_SetInterruptible,
   [contAll](fiber) {
     fiber.interruptible = this[args]
     if (fiber._interruptedCause && fiber.interruptible) {
@@ -4423,6 +4415,7 @@ export const whileLoop: <A, E, R>(options: {
   readonly step: (a: A) => void
 }) => Effect.Effect<void, E, R> = makePrimitive({
   op: "While",
+  opTag: OP_While,
   [contA](value, fiber) {
     this[args].step(value)
     if (this[args].while()) {


### PR DESCRIPTION
## Summary

The Effect run-loop's primary dispatch site at `internal/effect.ts` (the `current[evaluate](this)` call inside `FiberImpl.runLoop`) walks ~14 distinct primitive types per running fiber. The current implementation routes that dispatch through:

1. A shared `[evaluate]` method on `SharedComputationProto` that does `switch (this[opTag]) { ... }`,
2. Each case loading from one of 14 **module-level mutable `let` bindings** (`EVAL_Sync`, `EVAL_OnSuccess`, etc.),
3. Invoked via `.call(this, fiber)`.

This PR collapses that machinery. Each Primitive carries its evaluator function as an **own-property** set at construction time. The shared protos become bare `{ ...EffectProto }`. The 14 `EVAL_*` `let` bindings, the `registerComputationOp` dispatcher, the `registerStackPushEvaluators` cross-module init hook, and the giant switch all go away.

The Effect runtime now has **zero module-level mutable dispatch state**. Every evaluator reference flows by parenthood (closure capture) from the factory that creates it.

## Why this is a perf win (it's actually about the JIT, not the IC)

The intuitive framing — "kill the megamorphic call IC at the dispatch site" — turned out wrong in measurement. JSC's polymorphic call IC handles ≤14 distinct call targets cheaply via specialized stubs. The real cost was elsewhere:

- **Module-level `let` bindings defeat JSC's constant folding.** Every `EVAL_OnSuccess.call(...)` inside the switch had to re-read the mutable binding. JSC cannot prove the value is stable, so it cannot fold the call target.
- **Per-instance own-property evaluator reads a closed-over `const`-equivalent.** JSC can fold this at JIT compile time — the function reference is bound at factory definition and never mutates.
- **Three stack-push ops (`OnSuccess`, `OnFailure`, `OnSuccessAndFailure`) have identical evaluator bodies.** Sharing one function reference across them tightens dispatch-site polymorphism from 14 distinct targets to 12.

The OCAP-style framing isn't a side benefit — eliminating the ambient mutable registry is what unlocks the JIT optimization. Capability discipline and JIT-friendliness pointed at the same fix.

## Benchmark (n=300 baseline pooled, n=90 candidate pooled, quiesced Apple M4 Pro, Bun 1.3.12, Welch's two-tailed t-test α=0.05)

| Scenario | Δ% | p |
|---|---:|---:|
| succeed-flatMap chain (depth 1000) | **-39.12%** | 2e-150 |
| mixed-primitive chain (flatMap/map/tap × 250) | **-24.49%** | 4e-80 |
| fork-join 100 fibers | **-19.35%** | 5e-37 |
| Stream range + map + filter + drain | **-14.31%** | 2e-33 |
| fail + catchCause roundtrip | **-9.85%** | 2e-34 |
| service provide + yield (shallow) | **-4.69%** | 8e-8 |
| service provide + yield (deep) | **-30.80%** | 2e-104 |
| Layer build deep (6-service graph) | **-12.92%** | 4e-59 |
| Representative program (services + Stream + 16 fork/join + catchCause) | **-14.04%** | 2e-47 |
| Effect AST allocator (deep tree, no run) | -0.87% | 0.24 (NEUTRAL) |

**9 WINS / 1 NEUTRAL / 0 LOSSES.**

The executing-workload heap profile is essentially unchanged from main.

## Parity

`pnpm -F effect test` produces `5972 pass / 7 fail / 5 skip` — exact match to main at the time this branch was cut (`8d71e54`).

`pnpm check:tsgo` clean.

Public API completely unchanged. Observable behavior unchanged — only the internal node representation and dispatch machinery moved.

## Test plan

- [x] `pnpm check:tsgo` clean
- [x] `pnpm -F effect test` matches baseline (5972/7/5)
- [x] Bench at n=300 pooled samples on a quiesced machine confirms wins on 9 of 10 scenarios with no significant regression
- [x] Bench scenarios include realistic workloads (Layer build, representative mixed program) not just microbenches
- [ ] Reviewer to confirm: any test or downstream package that may rely on the now-removed `registerStackPushEvaluators` export from `internal/core.ts`? (Internal export only; no public-API uses found in this repo.)

## What changed (file inventory)

- `packages/effect/src/internal/core.ts` — unified `SharedComputationProto` / `SharedExitProto` (now bare `...EffectProto` with no `[evaluate]` on the proto); `makePrimitive`, `makeOnSuccess`, `makeOnFailure`, `makeOnSuccessAndFailure`, `exitSucceed`, `exitFailCause` all set `[evaluate]` as the last own-property at construction; `EVAL_*` lets, `registerComputationOp`, `registerStackPushEvaluators` removed; the three stack-push ops share one `evaluateStackPush` function reference.
- `packages/effect/src/internal/effect.ts` — three local `evaluateOnSuccess` / `evaluateOnFailure` / `evaluateOnSuccessAndFailure` definitions removed; `registerStackPushEvaluators` import + call removed.
- `.changeset/perf-runtime-zero-mutable-dispatch.md` — patch changeset.

Net diff is small — both files shrank. The bulk of the change is *removal*.

## Notes for reviewers

- Instance property add-order is held canonical across all 14 internal computation primitives so `SharedComputationProto` retains a single hidden class: `[identifier], [opTag], [args], [contA], [contE], [contAll], [evaluate]`. Adding new ops in the future must preserve this order.
- `core.ts` already imports `FiberImpl` as a type-only import; the evaluator's runtime access to `fiber._stack` is duck-typed, so no runtime cross-module dependency is introduced.
- The bench harness used to measure this (under `bench/` in this branch) follows the discipline in `bun-benchmarking` style: warmup, `Bun.gc(true)` between runs, raw samples preserved for Welch's t-test, heap delta + object count captured. Happy to discuss the methodology or hand the harness over if useful upstream.
- Currently only improves in JSC,  likely megamorphism issues in V8