### PR TITLE
fix(stream): provide scope to scoped pulls

### DIFF
--- a/.changeset/fix-stream-scoped-scope.md
+++ b/.changeset/fix-stream-scoped-scope.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Stream.scoped` and `Channel.scoped` so pull effects run with the scoped resource scope.

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -6459,7 +6459,12 @@ export const unwrap = <OutElem, OutErr, OutDone, InElem, InErr, InDone, R2, E, R
 export const scoped = <OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>(
   self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>
 ): Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Exclude<Env, Scope.Scope>> =>
-  fromTransformBracket((upstream, scope, forkedScope) => Scope.provide(toTransform(self)(upstream, scope), forkedScope))
+  fromTransformBracket((upstream, scope, forkedScope) =>
+    Effect.map(
+      Scope.provide(toTransform(self)(upstream, scope), forkedScope),
+      Scope.provide(forkedScope)
+    )
+  )
 
 /**
  * Runs an input handler against the upstream pull while the wrapped channel

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -203,6 +203,41 @@ describe("Stream", () => {
         )
         assert.deepStrictEqual(result, [[1, 2], [3, 4], [5]])
       }))
+
+    it.effect("scoped - provides scope to fromEffect pull effects", () =>
+      Effect.gen(function*() {
+        const releases = yield* Ref.make(0)
+        const result = yield* Stream.fromEffect(
+          Effect.acquireRelease(
+            Effect.succeed("resource"),
+            () => Ref.update(releases, (n) => n + 1)
+          )
+        ).pipe(
+          Stream.scoped,
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, ["resource"])
+        assert.strictEqual(yield* Ref.get(releases), 1)
+      }))
+
+    it.effect("scoped - provides scope to sequential mapEffect pull effects", () =>
+      Effect.gen(function*() {
+        const releases = yield* Ref.make(0)
+        const result = yield* Stream.fromIterable([1, 2]).pipe(
+          Stream.mapEffect((n) =>
+            Effect.acquireRelease(
+              Effect.succeed(n * 2),
+              () => Ref.update(releases, (count) => count + 1)
+            )
+          ),
+          Stream.scoped,
+          Stream.runCollect
+        )
+
+        assert.deepStrictEqual(result, [2, 4])
+        assert.strictEqual(yield* Ref.get(releases), 2)
+      }))
   })
 
   describe("encoding", () => {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes `Channel.scoped` so the pull returned by the wrapped channel runs with the forked scoped resource scope. This also fixes `Stream.scoped` for pull-time effects, such as `Stream.fromEffect` and sequential `Stream.mapEffect`, when those effects require `Scope`.

Includes regression tests and a patch changeset.

## Related

- Closes #2236