### PR TITLE
EFF-810 Fix IndexedDB bulk writes in transactions

### DIFF
--- a/.changeset/silver-bulk-indexeddb.md
+++ b/.changeset/silver-bulk-indexeddb.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-browser": patch
+---
+
+Fix IndexedDB bulk writes so `insertAll` and `upsertAll` resume when used inside `withTransaction`.

--- a/packages/platform-browser/src/IndexedDbQueryBuilder.ts
+++ b/packages/platform-browser/src/IndexedDbQueryBuilder.ts
@@ -1136,13 +1136,18 @@ const applyModifyAll = Effect.fnUntraced(
       Array<globalThis.IDBValidKey>,
       IndexedDbQueryError
     >((resume) => {
+      if (encodedValues.length === 0) {
+        return resume(Effect.succeed([]))
+      }
+
       const database = query.from.database
       const transaction = getOrCreateTransaction(database.current, [query.from.table.tableName], "readwrite", {
         durability: query.from.table.durability
       })
       const objectStore = transaction.objectStore(query.from.table.tableName)
 
-      const results: Array<globalThis.IDBValidKey> = []
+      const results: Array<globalThis.IDBValidKey> = new Array(encodedValues.length)
+      let remaining = encodedValues.length
 
       if (query.operation === "add") {
         for (let i = 0; i < encodedValues.length; i++) {
@@ -1163,7 +1168,11 @@ const applyModifyAll = Effect.fnUntraced(
           }
 
           request.onsuccess = () => {
-            results.push(request.result)
+            results[i] = request.result
+            remaining -= 1
+            if (remaining === 0) {
+              resume(Effect.succeed(results))
+            }
           }
         }
       } else if (query.operation === "put") {
@@ -1185,7 +1194,11 @@ const applyModifyAll = Effect.fnUntraced(
           }
 
           request.onsuccess = () => {
-            results.push(request.result)
+            results[i] = request.result
+            remaining -= 1
+            if (remaining === 0) {
+              resume(Effect.succeed(results))
+            }
           }
         }
       } else {
@@ -1201,10 +1214,6 @@ const applyModifyAll = Effect.fnUntraced(
             })
           )
         )
-      }
-
-      objectStore.transaction.oncomplete = () => {
-        resume(Effect.succeed(results))
       }
     })
   },

--- a/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts
+++ b/packages/platform-browser/test/IndexedDbQueryBuilder.test.ts
@@ -1205,6 +1205,41 @@ describe.sequential("IndexedDbQueryBuilder", () => {
       }).pipe(provideDb(Db))
     })
 
+    it.effect("upsertAll withTransaction", () => {
+      class Db extends IndexedDbDatabase.make(
+        V1,
+        Effect.fn(function*(api) {
+          yield* api.createObjectStore("todo")
+          yield* api.createIndex("todo", "titleIndex")
+          yield* api.createIndex("todo", "countIndex")
+          yield* api.from("todo").insertAll([
+            { id: 10, title: "insert1", count: 10, completed: true },
+            { id: 11, title: "insert2", count: 11, completed: true }
+          ])
+        })
+      ) {}
+
+      return Effect.gen(function*() {
+        const api = yield* Db.getQueryBuilder
+        const addedKeys = yield* api.withTransaction({ tables: ["todo"], mode: "readwrite" })(
+          Effect.gen(function*() {
+            return yield* api.from("todo").upsertAll([
+              { id: 10, title: "update1", count: -10, completed: false },
+              { id: 11, title: "update2", count: -11, completed: false }
+            ]).invalidate()
+          })
+        )
+        const data = yield* api.from("todo").select()
+
+        assert.deepStrictEqual(addedKeys, [10, 11])
+        assert.equal(data.length, 2)
+        assert.deepStrictEqual(data, [
+          { id: 10, title: "update1", count: -10, completed: false },
+          { id: 11, title: "update2", count: -11, completed: false }
+        ])
+      }).pipe(provideDb(Db))
+    })
+
     it.effect("upsertAll same key", () => {
       class Db extends IndexedDbDatabase.make(
         V1,


### PR DESCRIPTION
## Summary
- Fix IndexedDB bulk `insertAll` / `upsertAll` to resume after all individual requests succeed instead of waiting for transaction completion.
- Return `[]` immediately for empty bulk writes.
- Add regression coverage for `upsertAll(...).invalidate()` inside `withTransaction`.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/platform-browser/test/IndexedDbQueryBuilder.test.ts`
- `pnpm check:tsgo`

Fixes #2238.