### PR TITLE
EFF-812: Accept .mts and .mjs SQL migrations

### DIFF
--- a/.changeset/sql-migrator-mjs-mts.md
+++ b/.changeset/sql-migrator-mjs-mts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Accept `.mjs` and `.mts` migration files in SQL migrator loaders.

--- a/packages/effect/src/unstable/sql/Migrator.ts
+++ b/packages/effect/src/unstable/sql/Migrator.ts
@@ -341,8 +341,8 @@ const isConstraintConflict = (error: SqlError): boolean =>
 
 /**
  * Creates a migration loader from a glob record of dynamic import functions,
- * parsing files named `<id>_<name>.js` or `<id>_<name>.ts` and sorting
- * migrations by id.
+ * parsing files named `<id>_<name>.js`, `<id>_<name>.ts`,
+ * `<id>_<name>.mjs`, or `<id>_<name>.mts` and sorting migrations by id.
  *
  * @category loaders
  * @since 4.0.0
@@ -352,7 +352,7 @@ export const fromGlob = (
 ): Loader =>
   pipe(
     Object.keys(migrations),
-    Arr.flatMapNullishOr((_) => _.match(/^(?:.*\/)?(\d+)_([^.]+)\.(js|ts)$/)),
+    Arr.flatMapNullishOr((_) => _.match(/^(?:.*\/)?(\d+)_([^.]+)\.(js|ts|mjs|mts)$/)),
     Arr.map(
       ([key, id, name]): ResolvedMigration => [
         Number(id),
@@ -366,7 +366,8 @@ export const fromGlob = (
 
 /**
  * Creates a migration loader from a Babel-style glob record, parsing keys such
- * as `_<id>_<name>Js` or `_<id>_<name>Ts` and sorting migrations by id.
+ * as `_<id>_<name>Js`, `_<id>_<name>Ts`, `_<id>_<name>Mjs`, or
+ * `_<id>_<name>Mts` and sorting migrations by id.
  *
  * @category loaders
  * @since 4.0.0
@@ -374,7 +375,7 @@ export const fromGlob = (
 export const fromBabelGlob = (migrations: Record<string, any>): Loader =>
   pipe(
     Object.keys(migrations),
-    Arr.flatMapNullishOr((_) => _.match(/^_(\d+)_([^.]+?)(Js|Ts)?$/)),
+    Arr.flatMapNullishOr((_) => _.match(/^_(\d+)_([^.]+?)(Js|Ts|Mjs|Mts)?$/)),
     Arr.map(
       ([key, id, name]): ResolvedMigration => [
         Number(id),
@@ -410,7 +411,8 @@ export const fromRecord = (migrations: Record<string, Effect.Effect<void, unknow
 
 /**
  * Creates a migration loader that reads a directory with `FileSystem`, imports
- * files named `<id>_<name>.js` or `<id>_<name>.ts`, and sorts migrations by id.
+ * files named `<id>_<name>.js`, `<id>_<name>.ts`,
+ * `<id>_<name>.mjs`, or `<id>_<name>.mts`, and sorts migrations by id.
  *
  * @category loaders
  * @since 4.0.0
@@ -427,7 +429,7 @@ export const fromFileSystem: (directory: string) => Loader<FileSystem> = Effect.
       })
   )
   return files
-    .map((file) => Option.fromNullishOr(file.match(/^(?:.*\/)?(\d+)_([^.]+)\.(js|ts)$/)))
+    .map((file) => Option.fromNullishOr(file.match(/^(?:.*\/)?(\d+)_([^.]+)\.(js|ts|mjs|mts)$/)))
     .flatMap(
       Option.match({
         onNone: () => [],

--- a/packages/effect/test/Migrator.test.ts
+++ b/packages/effect/test/Migrator.test.ts
@@ -1,0 +1,69 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, FileSystem } from "effect"
+import * as Migrator from "effect/unstable/sql/Migrator"
+
+const migrationNames = (
+  migrations: ReadonlyArray<Migrator.ResolvedMigration>
+): ReadonlyArray<readonly [id: number, name: string]> => migrations.map(([id, name]) => [id, name] as const)
+
+describe("Migrator", () => {
+  describe("loaders", () => {
+    it.effect("fromGlob accepts js, ts, mjs, and mts files", () =>
+      Effect.gen(function*() {
+        const migrations = yield* Migrator.fromGlob({
+          "./migrations/0004_fourth.mts": () => Promise.resolve(Effect.void),
+          "./migrations/0002_second.ts": () => Promise.resolve(Effect.void),
+          "./migrations/0003_third.mjs": () => Promise.resolve(Effect.void),
+          "./migrations/0001_first.js": () => Promise.resolve(Effect.void),
+          "./migrations/0005_ignored.cjs": () => Promise.resolve(Effect.void)
+        })
+
+        assert.deepStrictEqual(migrationNames(migrations), [
+          [1, "first"],
+          [2, "second"],
+          [3, "third"],
+          [4, "fourth"]
+        ])
+      }))
+
+    it.effect("fromBabelGlob accepts Js, Ts, Mjs, and Mts suffixes", () =>
+      Effect.gen(function*() {
+        const migrations = yield* Migrator.fromBabelGlob({
+          _0004_fourthMts: Effect.void,
+          _0002_secondTs: Effect.void,
+          _0003_thirdMjs: Effect.void,
+          _0001_firstJs: Effect.void
+        })
+
+        assert.deepStrictEqual(migrationNames(migrations), [
+          [1, "first"],
+          [2, "second"],
+          [3, "third"],
+          [4, "fourth"]
+        ])
+      }))
+
+    it.effect("fromFileSystem accepts js, ts, mjs, and mts files", () =>
+      Effect.gen(function*() {
+        const migrations = yield* Migrator.fromFileSystem("/migrations").pipe(
+          Effect.provide(FileSystem.layerNoop({
+            readDirectory: () =>
+              Effect.succeed([
+                "0004_fourth.mts",
+                "0002_second.ts",
+                "0003_third.mjs",
+                "0001_first.js",
+                "0005_ignored.cjs"
+              ])
+          }))
+        )
+
+        assert.deepStrictEqual(migrationNames(migrations), [
+          [1, "first"],
+          [2, "second"],
+          [3, "third"],
+          [4, "fourth"]
+        ])
+      }))
+  })
+})


### PR DESCRIPTION
## Summary
- Accept `.mjs` and `.mts` SQL migration files in fromGlob and fromFileSystem loaders.
- Accept `Mjs` and `Mts` Babel-style migration suffixes.
- Add loader tests and a changeset for the runtime behavior change.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Migrator.test.ts
- pnpm check:tsgo
- cd packages/effect && pnpm docgen
