### PR TITLE
EFF-813 Fix TestClock layer Scope requirement

### DIFF
--- a/.changeset/sharp-pandas-care.md
+++ b/.changeset/sharp-pandas-care.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix TestClock adjustment when its layer is provided to programs run without an ambient Scope.

--- a/packages/effect/src/testing/TestClock.ts
+++ b/packages/effect/src/testing/TestClock.ts
@@ -330,7 +330,7 @@ export const make = Effect.fnUntraced(function*(
 
   const runSemaphore = yield* Semaphore.make(1)
   const run = Effect.fnUntraced(function*(step: (currentTimestamp: number) => number) {
-    yield* Fiber.await(yield* Effect.forkScoped(Effect.yieldNow))
+    yield* Fiber.await(yield* Effect.forkChild(Effect.yieldNow))
     const endTimestamp = step(currentTimestamp)
     while (Arr.isArrayNonEmpty(sleeps)) {
       if (Arr.lastNonEmpty(sleeps).timestamp > endTimestamp) break

--- a/packages/effect/test/TestClock.test.ts
+++ b/packages/effect/test/TestClock.test.ts
@@ -60,4 +60,12 @@ describe("TestClock", () => {
       yield* testClock.setTime(199023438.0000004)
       assert.strictEqual(testClock.currentTimeNanosUnsafe(), 199023438000000n)
     }))
+
+  it("layer - can adjust when provided without an ambient Scope", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust("1 second")
+    }).pipe(
+      Effect.provide(TestClock.layer({})),
+      Effect.runPromise
+    ))
 })


### PR DESCRIPTION
## Summary
- Fix TestClock.adjust/setTime so TestClock.layer can be provided to programs run without an ambient Scope
- Replace the internal one-shot scheduling fork with forkChild instead of forkScoped
- Add regression coverage for Effect.runPromise with TestClock.layer({})
- Add a patch changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/TestClock.test.ts
- pnpm check:tsgo