### PR TITLE
fix(schema): preserve named-field decoded value on StructWithRest key overlap

### DIFF
--- a/.changeset/fix-structwithrest-shadow.md
+++ b/.changeset/fix-structwithrest-shadow.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Schema.StructWithRest` index signatures overwriting named-field decoded values on overlapping keys.

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -1763,10 +1763,10 @@ export class Objects extends Base {
         readonly options: ParseOptions
         readonly out: Record<PropertyKey, unknown>
         issues: Array<Issue.Issue> | undefined
-      }, [key: PropertyKey, is: IndexSignature]>()({
+      }, [key: PropertyKey, is: IndexSignature, validateOnly: boolean]>()({
         onItem: Effect.fnUntracedEager(function*(
           s,
-          [key, is]
+          [key, is, validateOnly]
         ) {
           const parserKey = recur(indexSignatureParameterFromString(is.parameter))
           const effKey = parserKey(Option.some(key), s.options)
@@ -1788,7 +1788,7 @@ export class Objects extends Base {
             const eff = wrapPropertyKeyIssue(s, ast, key, exitValue)
             if (eff) yield* eff
             return
-          } else if (exitKey.value._tag === "Some" && exitValue.value._tag === "Some") {
+          } else if (!validateOnly && exitKey.value._tag === "Some" && exitValue.value._tag === "Some") {
             const k2 = exitKey.value.value
             const v2 = exitValue.value.value
             if (is.merge && is.merge.decode && Object.hasOwn(s.out, k2)) {
@@ -1869,13 +1869,13 @@ export class Objects extends Base {
       // handle index signatures
       // ---------------------------------------------
       if (parseIndexes) {
-        const keyPairs = Arr.empty<[PropertyKey, IndexSignature]>()
+        const keyPairs = Arr.empty<[PropertyKey, IndexSignature, boolean]>()
         for (let i = 0; i < indexCount; i++) {
           const is = ast.indexSignatures[i]
           const keys = getIndexSignatureKeys(input, is.parameter)
           for (let j = 0; j < keys.length; j++) {
             const key = keys[j]
-            keyPairs.push([key, is])
+            keyPairs.push([key, is, expectedKeysSet.has(key)])
           }
         }
         const eff = parseIndexes(state, keyPairs, concurrency)

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3997,6 +3997,28 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
         `Expected bgt(1), got {"a":1,"b":1}`
       )
     })
+
+    it("named property signatures take precedence over overlapping index signature", async () => {
+      const NumberSchema = Schema.StructWithRest(
+        Schema.Struct({ count: Schema.NumberFromString }),
+        [Schema.Record(Schema.String, Schema.Unknown)]
+      )
+      const numberDecoding = new TestSchema.Asserts(NumberSchema).decoding()
+      await numberDecoding.succeed({ count: "42" }, { count: 42 })
+      await numberDecoding.succeed({ count: "42", extra: "x" }, { count: 42, extra: "x" })
+
+      const OptionSchema = Schema.StructWithRest(
+        Schema.Struct({ id: Schema.String.pipe(Schema.OptionFromOptionalKey) }),
+        [Schema.Record(Schema.String, Schema.Unknown)]
+      )
+      const optionDecoding = new TestSchema.Asserts(OptionSchema).decoding()
+      await optionDecoding.succeed({ id: "abc" }, { id: Option.some("abc") })
+      await optionDecoding.succeed({}, { id: Option.none() })
+      await optionDecoding.succeed(
+        { id: "abc", extra: 1 },
+        { id: Option.some("abc"), extra: 1 }
+      )
+    })
   })
 
   describe("NullOr", () => {


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a `Schema.StructWithRest` index signature's key domain overlapped a named property signature, the index signature's decoded value overwrote the property signature's transformed value. The declared type narrowed via intersection but the runtime did not.

```ts
const S = Schema.StructWithRest(
  Schema.Struct({ count: Schema.NumberFromString }),
  [Schema.Record(Schema.String, Schema.Unknown)]
)

Schema.decodeUnknownSync(S)({ count: "42" })
// before: { count: "42" }  (raw string)
// after:  { count: 42 }    (transformed number)
```

The index signature still runs for overlapping keys, its refinement checks (e.g. `Schema.Finite`) still apply and surface errors  but its decoded value is no longer written when a property signature has already produced one.

disclaimer: fix applied with Opus 4.7

## Related

- Closes #2245
