### PR TITLE
fix(cli): use predicate dual for Argument.variadic to support no-options pipe form

### DIFF
--- a/.changeset/fix-argument-variadic-pipe-form.md
+++ b/.changeset/fix-argument-variadic-pipe-form.md
@@ -3,26 +3,3 @@
 ---
 
 Fix `Argument.variadic` no-options pipe form returning `{}` instead of an array
-
-`Argument.variadic` was declared as `dual(2, ...)`, which requires two arguments for
-the data-first call form. When used as `.pipe(Argument.variadic)` (no options, no call),
-the piped value was incorrectly treated as the options argument, returning a partially-applied
-function instead of the expected `Argument<ReadonlyArray<A>>`.
-
-Replaced `dual(2, body)` with the predicate-based overload `dual((args) => Param.isParam(args[0]), body)`,
-which detects the data-first form by checking whether the first argument is a `Param`. All four
-call forms now work correctly:
-
-```ts
-// piped, no options
-Argument.string("files").pipe(Argument.variadic)
-
-// piped, with options
-Argument.string("files").pipe(Argument.variadic({ min: 1 }))
-
-// direct, no options
-Argument.variadic(Argument.string("files"))
-
-// direct, with options
-Argument.variadic(Argument.string("files"), { min: 1 })
-```

--- a/.changeset/fix-argument-variadic-pipe-form.md
+++ b/.changeset/fix-argument-variadic-pipe-form.md
@@ -1,0 +1,28 @@
+---
+"effect": patch
+---
+
+Fix `Argument.variadic` no-options pipe form returning `{}` instead of an array
+
+`Argument.variadic` was declared as `dual(2, ...)`, which requires two arguments for
+the data-first call form. When used as `.pipe(Argument.variadic)` (no options, no call),
+the piped value was incorrectly treated as the options argument, returning a partially-applied
+function instead of the expected `Argument<ReadonlyArray<A>>`.
+
+Replaced `dual(2, body)` with the predicate-based overload `dual((args) => Param.isParam(args[0]), body)`,
+which detects the data-first form by checking whether the first argument is a `Param`. All four
+call forms now work correctly:
+
+```ts
+// piped, no options
+Argument.string("files").pipe(Argument.variadic)
+
+// piped, with options
+Argument.string("files").pipe(Argument.variadic({ min: 1 }))
+
+// direct, no options
+Argument.variadic(Argument.string("files"))
+
+// direct, with options
+Argument.variadic(Argument.string("files"), { min: 1 })
+```

--- a/packages/effect/src/unstable/cli/Argument.ts
+++ b/packages/effect/src/unstable/cli/Argument.ts
@@ -383,10 +383,11 @@ export const withFallbackPrompt: {
 export const variadic: {
   (options?: Param.VariadicParamOptions | undefined): <A>(self: Argument<A>) => Argument<ReadonlyArray<A>>
   <A>(self: Argument<A>, options?: Param.VariadicParamOptions | undefined): Argument<ReadonlyArray<A>>
-} = dual(2, <A>(
-  self: Argument<A>,
-  options?: Param.VariadicParamOptions | undefined
-): Argument<ReadonlyArray<A>> => Param.variadic(self, options))
+} = dual(
+  (args) => Param.isParam(args[0]),
+  <A>(self: Argument<A>, options?: Param.VariadicParamOptions | undefined): Argument<ReadonlyArray<A>> =>
+    Param.variadic(self, options)
+)
 
 /**
  * Transforms the parsed value of a positional argument.

--- a/packages/effect/test/unstable/cli/Arguments.test.ts
+++ b/packages/effect/test/unstable/cli/Arguments.test.ts
@@ -177,7 +177,7 @@ describe("Command arguments", () => {
 
   it("should handle variadic in pipe form without options", () =>
     Effect.gen(function*() {
-      let result: { readonly files: ReadonlyArray<string> } | undefined
+      let result: { readonly files: ReadonlyArray<unknown> } | undefined
 
       const testCommand = Command.make("test", {
         files: Argument.string("files").pipe(Argument.variadic)

--- a/packages/effect/test/unstable/cli/Arguments.test.ts
+++ b/packages/effect/test/unstable/cli/Arguments.test.ts
@@ -179,7 +179,6 @@ describe("Command arguments", () => {
     Effect.gen(function*() {
       let result: { readonly files: ReadonlyArray<string> } | undefined
 
-      // Regression: dual(2,...) with optional arg treats the piped self as options, returning {} instead of an array.
       const testCommand = Command.make("test", {
         files: Argument.string("files").pipe(Argument.variadic)
       }, (parsedConfig) =>

--- a/packages/effect/test/unstable/cli/Arguments.test.ts
+++ b/packages/effect/test/unstable/cli/Arguments.test.ts
@@ -175,6 +175,46 @@ describe("Command arguments", () => {
       assert.deepStrictEqual(result.files, ["file1.txt", "file2.txt", "file3.txt"])
     }).pipe(Effect.provide(TestLayer)))
 
+  it("should handle variadic in pipe form without options", () =>
+    Effect.gen(function*() {
+      let result: { readonly files: ReadonlyArray<string> } | undefined
+
+      // Regression: dual(2,...) with optional arg treats the piped self as options, returning {} instead of an array.
+      const testCommand = Command.make("test", {
+        files: Argument.string("files").pipe(Argument.variadic)
+      }, (parsedConfig) =>
+        Effect.sync(() => {
+          result = parsedConfig
+        }))
+
+      yield* Command.runWith(testCommand, { version: "1.0.0" })([
+        "a",
+        "b",
+        "c"
+      ])
+
+      assert.isDefined(result)
+      assert.isTrue(Array.isArray(result!.files), "files should be an array, not a function/object")
+      assert.deepStrictEqual(result!.files, ["a", "b", "c"])
+    }).pipe(Effect.provide(TestLayer)))
+
+  it("should handle variadic in pipe form with options", () =>
+    Effect.gen(function*() {
+      let result: { readonly files: ReadonlyArray<string> } | undefined
+
+      const testCommand = Command.make("test", {
+        files: Argument.string("files").pipe(Argument.variadic({ min: 1, max: 3 }))
+      }, (parsedConfig) =>
+        Effect.sync(() => {
+          result = parsedConfig
+        }))
+
+      yield* Command.runWith(testCommand, { version: "1.0.0" })(["x", "y"])
+
+      assert.isDefined(result)
+      assert.deepStrictEqual(result!.files, ["x", "y"])
+    }).pipe(Effect.provide(TestLayer)))
+
   it("should handle choiceWithValue", () =>
     Effect.gen(function*() {
       const resultRef = yield* Ref.make<any>(null)

--- a/packages/effect/typetest/unstable/cli/Param.tst.ts
+++ b/packages/effect/typetest/unstable/cli/Param.tst.ts
@@ -3,6 +3,10 @@ import { Argument, Flag, Prompt } from "effect/unstable/cli"
 import { describe, expect, it } from "tstyche"
 
 describe("Param", () => {
+  it("variadic direct-call form preserves generic type parameter", () => {
+    expect(Argument.variadic(Argument.string("name"))).type.toBe<Argument.Argument<ReadonlyArray<string>>>()
+  })
+
   it("accepts effectful fallback prompts for flags and arguments", () => {
     const prompt = Effect.succeed(Prompt.text({ message: "Name" }))
     const integerPrompt = Effect.succeed(Prompt.integer({ message: "Count" }))


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Closes Effect-TS/effect#6228.

The no-options pipe form silently returns `{}` instead of an array:

```ts
Argument.string("files").pipe(Argument.variadic)
// files is {}, not string[]
```

`variadic` is declared as `dual(2, body)`. When `.pipe(fn)` calls `fn(self)` with one argument, `dual(2, ...)` treats it as the `options` argument and returns a partially-applied function. `self` never reaches the body.

Switching to the predicate overload fixes it:

```ts
// before
dual(2, body)

// after
dual((args) => Param.isParam(args[0]), body)
```

If the first argument is a `Param`, it's data-first. Otherwise, data-last. `Channel.ts`, `FiberHandle.ts`, and `Graph.ts` use this same pattern for the same reason.

All four call forms now work:

```ts
Argument.string("files").pipe(Argument.variadic)              // pipe, no options
Argument.string("files").pipe(Argument.variadic({ min: 1 }))  // pipe, with options
Argument.variadic(Argument.string("files"))                    // direct, no options
Argument.variadic(Argument.string("files"), { min: 1 })        // direct, with options
```

Added two regression tests, one per pipe form.