### PR TITLE
EFF-814 Use predicate for Argument.variadic

### DIFF
--- a/.changeset/quick-falcons-travel.md
+++ b/.changeset/quick-falcons-travel.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Argument.variadic(argument)` so it supports direct calls without options.

--- a/packages/effect/src/unstable/cli/Argument.ts
+++ b/packages/effect/src/unstable/cli/Argument.ts
@@ -432,7 +432,7 @@ export const withFallbackPrompt: {
 export const variadic: {
   (options?: Param.VariadicParamOptions | undefined): <A>(self: Argument<A>) => Argument<ReadonlyArray<A>>
   <A>(self: Argument<A>, options?: Param.VariadicParamOptions | undefined): Argument<ReadonlyArray<A>>
-} = dual(2, <A>(
+} = dual((args) => Param.isParam(args[0]), <A>(
   self: Argument<A>,
   options?: Param.VariadicParamOptions | undefined
 ): Argument<ReadonlyArray<A>> => Param.variadic(self, options))


### PR DESCRIPTION
## Summary
- Updated `Argument.variadic` to use a predicate-based `dual` dispatch so `Argument.variadic(argument)` is treated as a direct call when options are omitted.
- Added a patch changeset for the runtime API fix.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/cli/Arguments.test.ts`
- `pnpm check:tsgo`

Fixed #2247