### PR TITLE
EFF-815 Add Schedule.tap

### DIFF
--- a/.changeset/add-schedule-tap.md
+++ b/.changeset/add-schedule-tap.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Added `Schedule.tap`, which allows observing full schedule metadata without altering schedule inputs or outputs.

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -2619,6 +2619,60 @@ export const spaced = (duration: Duration.Input): Schedule<number> => {
 
 /**
  * Returns a new `Schedule` that allows execution of an effectful function for
+ * every decision of the schedule, but does not alter the inputs and outputs of
+ * the schedule.
+ *
+ * **Details**
+ *
+ * The callback receives the full schedule metadata, including the input, output,
+ * computed delay duration, current attempt, and elapsed timing information.
+ *
+ * **Example** (Tapping schedule metadata)
+ *
+ * ```ts
+ * import { Console, Effect, Schedule } from "effect"
+ *
+ * const monitoredSchedule = Schedule.exponential("100 millis").pipe(
+ *   Schedule.take(5),
+ *   Schedule.tap((metadata) =>
+ *     Console.log(
+ *       `Attempt ${metadata.attempt} produced ${metadata.output} ` +
+ *         `after ${metadata.elapsed}ms; next delay is ${metadata.duration}`
+ *     )
+ *   )
+ * )
+ *
+ * const program = Effect.retry(
+ *   Effect.fail("transient error"),
+ *   monitoredSchedule
+ * )
+ * ```
+ *
+ * @category sequencing
+ * @since 4.0.0
+ */
+export const tap: {
+  <Output, Input, X, Error2, Env2>(
+    f: (metadata: Metadata<Output, Input>) => Effect<X, Error2, Env2>
+  ): <Error, Env>(
+    self: Schedule<Output, Input, Error, Env>
+  ) => Schedule<Output, Input, Error | Error2, Env | Env2>
+  <Output, Input, Error, Env, X, Error2, Env2>(
+    self: Schedule<Output, Input, Error, Env>,
+    f: (metadata: Metadata<Output, Input>) => Effect<X, Error2, Env2>
+  ): Schedule<Output, Input, Error | Error2, Env | Env2>
+} = dual(2, <Output, Input, Error, Env, X, Error2, Env2>(
+  self: Schedule<Output, Input, Error, Env>,
+  f: (metadata: Metadata<Output, Input>) => Effect<X, Error2, Env2>
+): Schedule<Output, Input, Error | Error2, Env | Env2> =>
+  fromStep(effect.map(toStep(self), (step) => {
+    const meta = metadataFn()
+    return (now, input) =>
+      effect.tap(step(now, input), ([output, duration]) => f({ ...meta(now, input), output, duration }))
+  })))
+
+/**
+ * Returns a new `Schedule` that allows execution of an effectful function for
  * every input to the schedule, but does not alter the inputs and outputs of
  * the schedule.
  *

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -39,6 +39,46 @@ describe("Schedule", () => {
   })
 
   describe("sequencing", () => {
+    it.effect("tap - provides full metadata", () =>
+      Effect.gen(function*() {
+        const observed: Array<Schedule.Metadata<number, string>> = []
+        const schedule = Schedule.spaced(Duration.millis(250)).pipe(
+          Schedule.tap((metadata: Schedule.Metadata<number, string>) =>
+            Effect.sync(() => {
+              observed.push(metadata)
+            })
+          )
+        )
+        const step = yield* Schedule.toStep(schedule)
+        const first = yield* step(1_000, "a")
+        const second = yield* step(1_250, "b")
+
+        expect(first).toEqual([0, Duration.millis(250)])
+        expect(second).toEqual([1, Duration.millis(250)])
+        expect(observed).toEqual([
+          {
+            input: "a",
+            output: 0,
+            duration: Duration.millis(250),
+            attempt: 1,
+            start: 1_000,
+            now: 1_000,
+            elapsed: 0,
+            elapsedSincePrevious: 0
+          },
+          {
+            input: "b",
+            output: 1,
+            duration: Duration.millis(250),
+            attempt: 2,
+            start: 1_000,
+            now: 1_250,
+            elapsed: 250,
+            elapsedSincePrevious: 250
+          }
+        ])
+      }))
+
     it.effect("andThenResult - executes schedules sequentially to completion", () =>
       Effect.gen(function*() {
         const left = Schedule.fixed("500 millis").pipe(

--- a/packages/effect/typetest/Schedule.tst.ts
+++ b/packages/effect/typetest/Schedule.tst.ts
@@ -1,4 +1,4 @@
-import { hole } from "effect"
+import { type Effect, hole } from "effect"
 import * as Schedule from "effect/Schedule"
 import { describe, expect, it } from "tstyche"
 
@@ -8,5 +8,14 @@ describe("Schedule", () => {
     if (Schedule.isSchedule(input)) {
       expect(input).type.toBe<Schedule.Schedule<string, number, never, never>>()
     }
+  })
+
+  it("tap", () => {
+    const self = hole<Schedule.Schedule<number, string, "error", "service">>()
+    const schedule = Schedule.tap(self, (metadata) => {
+      expect(metadata).type.toBe<Schedule.Metadata<number, string>>()
+      return hole<Effect.Effect<void, "tapError", "tapService">>()
+    })
+    expect(schedule).type.toBe<Schedule.Schedule<number, string, "error" | "tapError", "service" | "tapService">>()
   })
 })


### PR DESCRIPTION
## Summary

- Added `Schedule.tap` to observe full `Schedule.Metadata` for each schedule decision without changing inputs or outputs.
- Added runtime and type coverage for metadata access, error, and service type propagation.
- Added a changeset for the new public API.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/effect/test/Schedule.test.ts`
- `pnpm test-types Schedule.tst.ts`
- `cd packages/effect && pnpm docgen`
- `pnpm check:tsgo`