### PR TITLE
fix(effect): resume hang in iterateEager when paused-batch observer drains last

### DIFF
--- a/.changeset/fix-iterateEager-resume.md
+++ b/.changeset/fix-iterateEager-resume.md
@@ -1,0 +1,11 @@
+---
+"effect": patch
+---
+
+Fix resume hang in `iterateEager` (concurrent `Effect.forEach`) where the outer fiber could remain suspended on the async callback after all child fibers drained.
+
+Each `go()` invocation captured its own `paused` local. Observers forked during a paused call always entered the `if (paused)` branch and skipped the `else if (done && fibers.size === 0)` resume branch. In edge cases this left the request fiber suspended indefinitely, retaining `parentFiber`, items, schema state, and accumulated input across requests.
+
+Fix:
+- Make the `done && fibers.size === 0` resume check independent of the `paused` branch.
+- Read-clear `resume` before invoking it to make resume idempotent and release the closure reference earlier.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -4628,9 +4628,17 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
 
             if (paused) {
               const eff = go()
-              if (eff) resume!(eff)
-            } else if (done && fibers!.size === 0) {
-              resume!(terminal ?? void_)
+              if (eff && resume) {
+                const cb = resume
+                resume = undefined
+                cb(eff)
+                return
+              }
+            }
+            if (resume && done && fibers!.size === 0) {
+              const cb = resume
+              resume = undefined
+              cb(terminal ?? void_)
             }
           })
 
@@ -4650,14 +4658,22 @@ const iterateEagerImpl = <S, A, X, E, R, E2>(options: {
           fibers.forEach((f) => f.interruptUnsafe(parentFiber!.id, annotations))
           return
         }
-        if (resume || terminal._tag === "Failure") {
+        if (resume) {
+          const cb = resume
+          resume = undefined
+          cb(terminal)
+          return
+        }
+        if (terminal._tag === "Failure") {
           return terminal
         }
       } else if (resume) {
         if (!fibers) {
           return exitVoid
         } else if (fibers.size === 0) {
-          resume(void_)
+          const cb = resume
+          resume = undefined
+          cb(void_)
         }
       }
     }

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -280,6 +280,26 @@ describe("Effect", () => {
         assert.deepStrictEqual(done, [1, 2, 3])
       }))
 
+    it.effect("bounded fail interrupts paused-batch fibers", () =>
+      Effect.gen(function*() {
+        const completed: Array<number> = []
+        const handle = yield* Effect.forEach([1, 2, 3, 4], (i) =>
+          Effect.suspend(() =>
+            i === 2
+              ? Effect.fail("boom").pipe(Effect.delay(50))
+              : Effect.sync(() => {
+                completed.push(i)
+                return i
+              }).pipe(Effect.delay(i === 1 ? 500 : 100))
+          ), {
+          concurrency: 2
+        }).pipe(Effect.forkChild)
+        yield* TestClock.adjust(1000)
+        const result = yield* Fiber.await(handle)
+        assert.deepStrictEqual(result, Exit.fail("boom"))
+        assert.deepStrictEqual(completed, [])
+      }))
+
     it("length = 0", () =>
       Effect.gen(function*() {
         const results = yield* Effect.forEach([], (_) => Effect.succeed(_))


### PR DESCRIPTION
introduced in #2010 `iterateEagerImpl` observers captured a per-`go()` `paused` local. Observers forked during a paused call always took the `if (paused)` branch and skipped the `else if (done && fibers.size === 0)` resume path. When the last fiber to complete carried `paused = true`, `resume!` was never invoked, leaving the outer fiber suspended on the async callback and retaining `parentFiber`, items, and schema state.

Split the observer into two independent checks and read-clear `resume` on use so calls are idempotent and the closure reference is released early. Apply the same read-clear pattern to the resume paths inside `go()`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
