### PR TITLE
fix: stop catch* combinators from erasing unhandled error types

### DIFF
--- a/.changeset/fix-catch-orelse-error-erasure.md
+++ b/.changeset/fix-catch-orelse-error-erasure.md
@@ -1,0 +1,12 @@
+---
+"effect": patch
+---
+
+Fixed the `catch*` combinators silently dropping unhandled error types, closes #2142.
+
+Affected: `catchTag`, `catchTags`, `catchIf`, `catchFilter`, `catchReason`, and `catchReasons` on `Effect`, `Stream`, and `Channel`.
+
+Two related soundness bugs are fixed:
+
+- The unhandled-error type was a defaulted-but-inferable type parameter, so an explicit result annotation (or any contextual type) could collapse it to `never`, hiding errors that were never handled. These combinators now use the `unassigned` sentinel (matching `catchReason`) so the omitted-`orElse` path always reports the unhandled errors.
+- A re-failing `orElse` (one whose success type is `never`, e.g. `Effect.fail`) caused the sentinel's conditional type to distribute over `never` and erase the still-unhandled error tags. The error channel is now structured so those tags are preserved regardless of the `orElse` return type.

--- a/.changeset/fix-catch-orelse-error-erasure.md
+++ b/.changeset/fix-catch-orelse-error-erasure.md
@@ -10,3 +10,4 @@ Two related soundness bugs are fixed:
 
 - The unhandled-error type was a defaulted-but-inferable type parameter, so an explicit result annotation (or any contextual type) could collapse it to `never`, hiding errors that were never handled. These combinators now use the `unassigned` sentinel (matching `catchReason`) so the omitted-`orElse` path always reports the unhandled errors.
 - A re-failing `orElse` (one whose success type is `never`, e.g. `Effect.fail`) caused the sentinel's conditional type to distribute over `never` and erase the still-unhandled error tags. The error channel is now structured so those tags are preserved regardless of the `orElse` return type.
+- `Stream.catchTags` additionally omitted the `orElse`'s own error type from its result, so a re-failing `orElse` erased that error too. Its error channel now keeps it, matching `Effect.catchTags`.

--- a/.changeset/fix-catch-orelse-error-erasure.md
+++ b/.changeset/fix-catch-orelse-error-erasure.md
@@ -2,12 +2,4 @@
 "effect": patch
 ---
 
-Fixed the `catch*` combinators silently dropping unhandled error types, closes #2142.
-
-Affected: `catchTag`, `catchTags`, `catchIf`, `catchFilter`, `catchReason`, and `catchReasons` on `Effect`, `Stream`, and `Channel`.
-
-Two related soundness bugs are fixed:
-
-- The unhandled-error type was a defaulted-but-inferable type parameter, so an explicit result annotation (or any contextual type) could collapse it to `never`, hiding errors that were never handled. These combinators now use the `unassigned` sentinel (matching `catchReason`) so the omitted-`orElse` path always reports the unhandled errors.
-- A re-failing `orElse` (one whose success type is `never`, e.g. `Effect.fail`) caused the sentinel's conditional type to distribute over `never` and erase the still-unhandled error tags. The error channel is now structured so those tags are preserved regardless of the `orElse` return type.
-- `Stream.catchTags` additionally omitted the `orElse`'s own error type from its result, so a re-failing `orElse` erased that error too. Its error channel now keeps it, matching `Effect.catchTags`.
+Fixed the `catch*` combinators silently dropping unhandled error types

--- a/packages/effect/src/Channel.ts
+++ b/packages/effect/src/Channel.ts
@@ -4468,8 +4468,8 @@ export const catchIf: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = Exclude<OutErr, EB>,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4491,8 +4491,8 @@ export const catchIf: {
     InDone,
     Env
   >(self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>) => Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? Exclude<OutErr, EB> : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4508,8 +4508,8 @@ export const catchIf: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = OutErr,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4531,8 +4531,8 @@ export const catchIf: {
     InDone,
     Env
   >(self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>) => Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? OutErr : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4555,8 +4555,8 @@ export const catchIf: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = Exclude<OutErr, EB>,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4572,8 +4572,8 @@ export const catchIf: {
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? Exclude<OutErr, EB> : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4595,8 +4595,8 @@ export const catchIf: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = OutErr,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4612,8 +4612,8 @@ export const catchIf: {
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? OutErr : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4703,8 +4703,8 @@ export const catchFilter: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = X,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4726,8 +4726,8 @@ export const catchFilter: {
     InDone,
     Env
   >(self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>) => Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? X : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4751,8 +4751,8 @@ export const catchFilter: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = X,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4768,8 +4768,8 @@ export const catchFilter: {
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    OutErr1 | OutErr2 | (OutElem2 extends Types.unassigned ? X : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4861,8 +4861,8 @@ export const catchTag: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = Types.ExcludeTag<OutErr, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4886,8 +4886,12 @@ export const catchTag: {
     InDone,
     Env
   >(self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>) => Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    | OutErr1
+    | OutErr2
+    | (OutElem2 extends Types.unassigned
+      ? Types.ExcludeTag<OutErr, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>
+      : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -4910,8 +4914,8 @@ export const catchTag: {
     InErr1,
     InDone1,
     Env1,
-    OutElem2 = never,
-    OutErr2 = Types.ExcludeTag<OutErr, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    OutElem2 = Types.unassigned,
+    OutErr2 = never,
     OutDone2 = never,
     InElem2 = unknown,
     InErr2 = unknown,
@@ -4929,8 +4933,12 @@ export const catchTag: {
       ) => Channel<OutElem2, OutErr2, OutDone2, InElem2, InErr2, InDone2, Env2>)
       | undefined
   ): Channel<
-    OutElem | OutElem1 | OutElem2,
-    OutErr1 | OutErr2,
+    OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
+    | OutErr1
+    | OutErr2
+    | (OutElem2 extends Types.unassigned
+      ? Types.ExcludeTag<OutErr, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>
+      : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -5063,7 +5071,10 @@ export const catchReason: {
     self: Channel<OutElem, OutErr, OutDone, InElem, InErr, InDone, Env>
   ) => Channel<
     OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
-    (OutElem2 extends Types.unassigned ? OutErr : Types.ExcludeTag<OutErr, K>) | OutErr1 | OutErr2,
+    | Types.ExcludeTag<OutErr, K>
+    | OutErr1
+    | OutErr2
+    | (OutElem2 extends Types.unassigned ? Types.ExtractTag<OutErr, K> : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -5110,7 +5121,10 @@ export const catchReason: {
       | undefined
   ): Channel<
     OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
-    (OutElem2 extends Types.unassigned ? OutErr : Types.ExcludeTag<OutErr, K>) | OutErr1 | OutErr2,
+    | Types.ExcludeTag<OutErr, K>
+    | OutErr1
+    | OutErr2
+    | (OutElem2 extends Types.unassigned ? Types.ExtractTag<OutErr, K> : never),
     OutDone | OutDone1 | OutDone2,
     InElem & InElem1 & InElem2,
     InErr & InErr1 & InErr2,
@@ -5157,7 +5171,10 @@ export const catchReason: {
     | undefined
 ): Channel<
   OutElem | OutElem1 | Exclude<OutElem2, Types.unassigned>,
-  (OutElem2 extends Types.unassigned ? OutErr : Types.ExcludeTag<OutErr, K>) | OutErr1 | OutErr2,
+  | Types.ExcludeTag<OutErr, K>
+  | OutErr1
+  | OutErr2
+  | (OutElem2 extends Types.unassigned ? Types.ExtractTag<OutErr, K> : never),
   OutDone | OutDone1 | OutDone2,
   InElem & InElem1 & InElem2,
   InErr & InErr1 & InErr2,
@@ -5227,8 +5244,9 @@ export const catchReasons: {
       [RK in keyof Cases]: Cases[RK] extends
         (...args: Array<any>) => Channel<infer OutElem1, any, any, any, any, any, any> ? OutElem1 : never
     }[keyof Cases],
-    | (OutElem2 extends Types.unassigned ? OutErr : Types.ExcludeTag<OutErr, K>)
+    | Types.ExcludeTag<OutErr, K>
     | OutErr2
+    | (OutElem2 extends Types.unassigned ? Types.ExtractTag<OutErr, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends
         (...args: Array<any>) => Channel<any, infer OutErr1, any, any, any, any, any> ? OutErr1 : never
@@ -5303,8 +5321,9 @@ export const catchReasons: {
       [RK in keyof Cases]: Cases[RK] extends
         (...args: Array<any>) => Channel<infer OutElem1, any, any, any, any, any, any> ? OutElem1 : never
     }[keyof Cases],
-    | (OutElem2 extends Types.unassigned ? OutErr : Types.ExcludeTag<OutErr, K>)
+    | Types.ExcludeTag<OutErr, K>
     | OutErr2
+    | (OutElem2 extends Types.unassigned ? Types.ExtractTag<OutErr, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends
         (...args: Array<any>) => Channel<any, infer OutErr1, any, any, any, any, any> ? OutErr1 : never

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -2580,8 +2580,8 @@ export const catchTag: {
     A1,
     E1,
     R1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends readonly [string, ...string[]] ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     k: K,
@@ -2589,7 +2589,15 @@ export const catchTag: {
     orElse?:
       | ((e: ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect<A2, E2, R2>)
       | undefined
-  ): <A, R>(self: Effect<A, E, R>) => Effect<A | A1 | A2, E1 | E2, R | R1 | R2>
+  ): <A, R>(
+    self: Effect<A, E, R>
+  ) => Effect<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
   <
     A,
     E,
@@ -2598,8 +2606,8 @@ export const catchTag: {
     R1,
     E1,
     A1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends readonly [string, ...string[]] ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Effect<A, E, R>,
@@ -2608,7 +2616,13 @@ export const catchTag: {
     orElse?:
       | ((e: ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect<A2, E2, R2>)
       | undefined
-  ): Effect<A | A1 | A2, E1 | E2, R | R1 | R2>
+  ): Effect<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
 } = internal.catchTag
 
 /**
@@ -2660,8 +2674,8 @@ export const catchTags: {
     Cases extends
       & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
       & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     cases: Cases,
@@ -2670,11 +2684,12 @@ export const catchTags: {
     self: Effect<A, E, R>
   ) => Effect<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
     | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
@@ -2691,8 +2706,8 @@ export const catchTags: {
     Cases extends
       & { [K in Extract<E, { _tag: string }>["_tag"]]+?: ((error: Extract<E, { _tag: K }>) => Effect<any, any, any>) }
       & (unknown extends E ? {} : { [K in Exclude<keyof Cases, Extract<E, { _tag: string }>["_tag"]>]: never }),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Effect<A, E, R>,
@@ -2700,11 +2715,12 @@ export const catchTags: {
     orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Effect<A2, E2, R2>) | undefined
   ): Effect<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
     | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
@@ -2780,7 +2796,11 @@ export const catchReason: {
       | undefined
   ): <A, R>(
     self: Effect<A, E, R>
-  ) => Effect<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
+  ) => Effect<
+    A | A2 | Exclude<A3, unassigned>,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
+    R | R2 | R3
+  >
   <
     A,
     E,
@@ -2801,7 +2821,11 @@ export const catchReason: {
     orElse?:
       | ((reasons: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Effect<A3, E3, R3>)
       | undefined
-  ): Effect<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
+  ): Effect<
+    A | A2 | Exclude<A3, unassigned>,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
+    R | R2 | R3
+  >
 } = internal.catchReason
 
 /**
@@ -2869,8 +2893,9 @@ export const catchReasons: {
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
@@ -2910,8 +2935,9 @@ export const catchReasons: {
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect<infer A, any, any> ? A : never
     }[keyof Cases],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect<any, infer E, any> ? E : never
     }[keyof Cases],
@@ -3127,28 +3153,32 @@ export const catchDefect: {
  * @since 2.0.0
  */
 export const catchIf: {
-  <E, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  <E, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     refinement: Predicate.Refinement<NoInfer<E>, EB>,
     f: (e: EB) => Effect<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect<A, E, R>) => Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <E, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): <A, R>(
+    self: Effect<A, E, R>
+  ) => Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never), R | R2 | R3>
+  <E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     predicate: Predicate.Predicate<NoInfer<E>>,
     f: (e: NoInfer<E>) => Effect<A2, E2, R2>,
     orElse?: ((e: NoInfer<E>) => Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect<A, E, R>) => Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  ): <A, R>(
+    self: Effect<A, E, R>
+  ) => Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
+  <A, E, R, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect<A, E, R>,
     refinement: Predicate.Refinement<E, EB>,
     f: (e: EB) => Effect<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Effect<A3, E3, R3>) | undefined
-  ): Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never), R | R2 | R3>
+  <A, E, R, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect<A, E, R>,
     predicate: Predicate.Predicate<E>,
     f: (e: E) => Effect<A2, E2, R2>,
     orElse?: ((e: E) => Effect<A3, E3, R3>) | undefined
-  ): Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
 } = internal.catchIf
 
 /**
@@ -3158,17 +3188,19 @@ export const catchIf: {
  * @since 4.0.0
  */
 export const catchFilter: {
-  <E, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  <E, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (e: EB) => Effect<A2, E2, R2>,
     orElse?: ((e: X) => Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect<A, E, R>) => Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  ): <A, R>(
+    self: Effect<A, E, R>
+  ) => Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
+  <A, E, R, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect<A, E, R>,
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (e: EB) => Effect<A2, E2, R2>,
     orElse?: ((e: X) => Effect<A3, E3, R3>) | undefined
-  ): Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
 } = internal.catchFilter
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5278,6 +5278,7 @@ export const catchTags: {
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<infer A, any, any>) ? A : never
     }[keyof Cases],
+    | E2
     | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<any, infer E, any>) ? E : never
@@ -5309,6 +5310,7 @@ export const catchTags: {
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<infer A, any, any>) ? A : never
     }[keyof Cases],
+    | E2
     | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<any, infer E, any>) ? E : never

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -5009,28 +5009,32 @@ export const tapError: {
  * @since 4.0.0
  */
 export const catchIf: {
-  <E, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  <E, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     refinement: Refinement<NoInfer<E>, EB>,
     f: (e: EB) => Stream<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Stream<A3, E3, R3>) | undefined
-  ): <A, R>(self: Stream<A, E, R>) => Stream<A2 | A | A3, E2 | E3, R2 | R | R3>
-  <E, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): <A, R>(
+    self: Stream<A, E, R>
+  ) => Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never), R | R2 | R3>
+  <E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     predicate: Predicate<NoInfer<E>>,
     f: (e: NoInfer<E>) => Stream<A2, E2, R2>,
     orElse?: ((e: NoInfer<E>) => Stream<A3, E3, R3>) | undefined
-  ): <A, R>(self: Stream<A, E, R>) => Stream<A2 | A | A3, E2 | E3, R2 | R | R3>
-  <A, E, R, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  ): <A, R>(
+    self: Stream<A, E, R>
+  ) => Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
+  <A, E, R, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Stream<A, E, R>,
     refinement: Refinement<E, EB>,
     f: (e: EB) => Stream<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Stream<A3, E3, R3>) | undefined
-  ): Stream<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never), R | R2 | R3>
+  <A, E, R, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Stream<A, E, R>,
     predicate: Predicate<E>,
     f: (e: E) => Stream<A2, E2, R2>,
     orElse?: ((e: E) => Stream<A3, E3, R3>) | undefined
-  ): Stream<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
 } = dual((args) => isStream(args[0]), <
   A,
   E,
@@ -5064,17 +5068,19 @@ export const catchIf: {
  * @since 4.0.0
  */
 export const catchFilter: {
-  <E, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  <E, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (failure: EB) => Stream<A2, E2, R2>,
     orElse?: ((failure: X) => Stream<A3, E3, R3>) | undefined
-  ): <A, R>(self: Stream<A, E, R>) => Stream<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  ): <A, R>(
+    self: Stream<A, E, R>
+  ) => Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
+  <A, E, R, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     self: Stream<A, E, R>,
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (failure: EB) => Stream<A2, E2, R2>,
     orElse?: ((failure: X) => Stream<A3, E3, R3>) | undefined
-  ): Stream<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Stream<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
 } = dual((args) => isStream(args[0]), <
   A,
   E,
@@ -5143,8 +5149,8 @@ export const catchTag: {
     A1,
     E1,
     R1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     k: K,
@@ -5156,7 +5162,13 @@ export const catchTag: {
       | undefined
   ): <A, R>(
     self: Stream<A, E, R>
-  ) => Stream<A1 | A | A2, E1 | E2, R1 | R | R2>
+  ) => Stream<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
   <
     A,
     E,
@@ -5165,8 +5177,8 @@ export const catchTag: {
     R1,
     E1,
     A1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Stream<A, E, R>,
@@ -5175,7 +5187,13 @@ export const catchTag: {
     orElse?:
       | ((e: ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Stream<A2, E2, R2>)
       | undefined
-  ): Stream<A1 | A | A2, E1 | E2, R1 | R | R2>
+  ): Stream<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
 } = dual(
   (args) => isStream(args[0]),
   <
@@ -5248,19 +5266,19 @@ export const catchTags: {
         [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Stream<any, any, any>
       } :
       {}),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     cases: Cases,
     orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Stream<A2, E2, R2>) | undefined
   ): <A, R>(self: Stream<A, E, R>) => Stream<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<infer A, any, any>) ? A : never
     }[keyof Cases],
-    | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<any, infer E, any>) ? E : never
     }[keyof Cases],
@@ -5278,8 +5296,8 @@ export const catchTags: {
         [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Stream<any, any, any>
       } :
       {}),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Stream<A, E, R>,
@@ -5287,11 +5305,11 @@ export const catchTags: {
     orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Stream<A2, E2, R2>) | undefined
   ): Stream<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<infer A, any, any>) ? A : never
     }[keyof Cases],
-    | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Stream<any, infer E, any>) ? E : never
     }[keyof Cases],
@@ -5388,7 +5406,11 @@ export const catchReason: {
       | undefined
   ): <A, R>(
     self: Stream<A, E, R>
-  ) => Stream<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
+  ) => Stream<
+    A | A2 | Exclude<A3, unassigned>,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
+    R | R2 | R3
+  >
   <
     A,
     E,
@@ -5409,7 +5431,11 @@ export const catchReason: {
     orElse?:
       | ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Stream<A3, E3, R3>)
       | undefined
-  ): Stream<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3>
+  ): Stream<
+    A | A2 | Exclude<A3, unassigned>,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
+    R | R2 | R3
+  >
 } = dual(
   (args) => isStream(args[0]),
   <
@@ -5432,7 +5458,11 @@ export const catchReason: {
     orElse?:
       | ((reason: ExcludeReason<ExtractTag<E, K>, RK>, error: OmitReason<ExtractTag<E, K>, RK>) => Stream<A3, E3, R3>)
       | undefined
-  ): Stream<A | A2 | Exclude<A3, unassigned>, (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3, R | R2 | R3> =>
+  ): Stream<
+    A | A2 | Exclude<A3, unassigned>,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
+    R | R2 | R3
+  > =>
     fromChannel(
       Channel.catchReason(
         toChannel(self),
@@ -5514,8 +5544,9 @@ export const catchReasons: {
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Stream<infer A, any, any> ? A : never
     }[keyof Cases],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Stream<any, infer E, any> ? E : never
     }[keyof Cases],
@@ -5555,8 +5586,9 @@ export const catchReasons: {
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Stream<infer A, any, any> ? A : never
     }[keyof Cases],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | {
       [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Stream<any, infer E, any> ? E : never
     }[keyof Cases],

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2643,28 +2643,40 @@ export const tapDefect: {
 
 /** @internal */
 export const catchIf: {
-  <E, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  <E, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     refinement: Predicate.Refinement<NoInfer<E>, EB>,
     f: (e: EB) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Effect.Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <E, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): <A, R>(
+    self: Effect.Effect<A, E, R>
+  ) => Effect.Effect<
+    A | A2 | Exclude<A3, unassigned>,
+    E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never),
+    R | R2 | R3
+  >
+  <E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     predicate: Predicate.Predicate<NoInfer<E>>,
     f: (e: NoInfer<E>) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: NoInfer<E>) => Effect.Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, EB extends E, A2, E2, R2, A3 = never, E3 = Exclude<E, EB>, R3 = never>(
+  ): <A, R>(
+    self: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
+  <A, E, R, EB extends E, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect.Effect<A, E, R>,
     refinement: Predicate.Refinement<E, EB>,
     f: (e: EB) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: Exclude<E, EB>) => Effect.Effect<A3, E3, R3>) | undefined
-  ): Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
+  ): Effect.Effect<
+    A | A2 | Exclude<A3, unassigned>,
+    E2 | E3 | (A3 extends unassigned ? Exclude<E, EB> : never),
+    R | R2 | R3
+  >
+  <A, E, R, A2, E2, R2, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect.Effect<A, E, R>,
     predicate: Predicate.Predicate<E>,
     f: (e: E) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: E) => Effect.Effect<A3, E3, R3>) | undefined
-  ): Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Effect.Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? E : never), R | R2 | R3>
 } = dual(
   (args) => isEffect(args[0]),
   <A, E, R, A2, E2, R2, A3 = never, E3 = E, R3 = never>(
@@ -2685,17 +2697,19 @@ export const catchIf: {
 
 /** @internal */
 export const catchFilter: {
-  <E, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  <E, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (e: EB) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: X) => Effect.Effect<A3, E3, R3>) | undefined
-  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
-  <A, E, R, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
+  ): <A, R>(
+    self: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
+  <A, E, R, EB, A2, E2, R2, X, A3 = unassigned, E3 = never, R3 = never>(
     self: Effect.Effect<A, E, R>,
     filter: Filter.Filter<NoInfer<E>, EB, X>,
     f: (e: EB) => Effect.Effect<A2, E2, R2>,
     orElse?: ((e: X) => Effect.Effect<A3, E3, R3>) | undefined
-  ): Effect.Effect<A | A2 | A3, E2 | E3, R | R2 | R3>
+  ): Effect.Effect<A | A2 | Exclude<A3, unassigned>, E2 | E3 | (A3 extends unassigned ? X : never), R | R2 | R3>
 } = dual(
   (args) => isEffect(args[0]),
   <A, E, R, EB, A2, E2, R2, X, A3 = never, E3 = X, R3 = never>(
@@ -2723,8 +2737,8 @@ export const catchTag: {
     A1,
     E1,
     R1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     k: K,
@@ -2736,7 +2750,13 @@ export const catchTag: {
       | undefined
   ): <A, R>(
     self: Effect.Effect<A, E, R>
-  ) => Effect.Effect<A | A1 | A2, E1 | E2, R | R1 | R2>
+  ) => Effect.Effect<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
   <
     A,
     E,
@@ -2745,8 +2765,8 @@ export const catchTag: {
     R1,
     E1,
     A1,
-    A2 = never,
-    E2 = ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Effect.Effect<A, E, R>,
@@ -2755,7 +2775,13 @@ export const catchTag: {
     orElse?:
       | ((e: ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K>) => Effect.Effect<A2, E2, R2>)
       | undefined
-  ): Effect.Effect<A | A1 | A2, E1 | E2, R | R1 | R2>
+  ): Effect.Effect<
+    A | A1 | Exclude<A2, unassigned>,
+    | E1
+    | E2
+    | (A2 extends unassigned ? ExcludeTag<E, K extends Arr.NonEmptyReadonlyArray<string> ? K[number] : K> : never),
+    R | R1 | R2
+  >
 } = dual(
   (args) => isEffect(args[0]),
   <
@@ -2792,19 +2818,20 @@ export const catchTags: {
         [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>
       } :
       {}),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     cases: Cases,
     orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<A2, E2, R2>) | undefined
   ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<infer A, any, any>) ? A : never
     }[keyof Cases],
     | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
     }[keyof Cases],
@@ -2822,8 +2849,8 @@ export const catchTags: {
         [K in E["_tag"]]+?: (error: Extract<E, { _tag: K }>) => Effect.Effect<any, any, any>
       } :
       {}),
-    A2 = never,
-    E2 = Exclude<E, { _tag: keyof Cases }>,
+    A2 = unassigned,
+    E2 = never,
     R2 = never
   >(
     self: Effect.Effect<A, E, R>,
@@ -2831,11 +2858,12 @@ export const catchTags: {
     orElse?: ((e: Exclude<E, { _tag: keyof Cases }>) => Effect.Effect<A2, E2, R2>) | undefined
   ): Effect.Effect<
     | A
-    | A2
+    | Exclude<A2, unassigned>
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<infer A, any, any>) ? A : never
     }[keyof Cases],
     | E2
+    | (A2 extends unassigned ? Exclude<E, { _tag: keyof Cases }> : never)
     | {
       [K in keyof Cases]: Cases[K] extends ((...args: Array<any>) => Effect.Effect<any, infer E, any>) ? E : never
     }[keyof Cases],
@@ -2889,7 +2917,7 @@ export const catchReason: {
     self: Effect.Effect<A, E, R>
   ) => Effect.Effect<
     A | A2 | Exclude<A3, unassigned>,
-    (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
     R | R2 | R3
   >
   <
@@ -2920,7 +2948,7 @@ export const catchReason: {
       | undefined
   ): Effect.Effect<
     A | A2 | Exclude<A3, unassigned>,
-    (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
     R | R2 | R3
   >
 } = dual(
@@ -2950,7 +2978,7 @@ export const catchReason: {
       | undefined
   ): Effect.Effect<
     A | A2 | Exclude<A3, unassigned>,
-    (A3 extends unassigned ? E : ExcludeTag<E, K>) | E2 | E3,
+    ExcludeTag<E, K> | E2 | E3 | (A3 extends unassigned ? ExtractTag<E, K> : never),
     R | R2 | R3
   > =>
     catchIf(
@@ -2993,8 +3021,9 @@ export const catchReasons: {
     | { [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never }[
       keyof Cases
     ],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | { [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect.Effect<any, infer E, any> ? E : never }[
       keyof Cases
     ],
@@ -3034,8 +3063,9 @@ export const catchReasons: {
     | { [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect.Effect<infer A, any, any> ? A : never }[
       keyof Cases
     ],
-    | (A2 extends unassigned ? E : ExcludeTag<E, K>)
+    | ExcludeTag<E, K>
     | E2
+    | (A2 extends unassigned ? ExtractTag<E, K> : never)
     | { [RK in keyof Cases]: Cases[RK] extends (...args: Array<any>) => Effect.Effect<any, infer E, any> ? E : never }[
       keyof Cases
     ],

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -372,7 +372,15 @@ export const catchTag: {
       e: ExtractTag<E, K extends NonEmptyReadonlyArray<string> ? K[number] : K>
     ) => Effect.Effect<HttpClientResponse.HttpClientResponse, E1, R1>
   ): HttpClient.With<E1 | ExcludeTag<E, K extends NonEmptyReadonlyArray<string> ? K[number] : K>, R1 | R> =>
-    transformResponse(self, Effect.catchTag(tag, f))
+    transformResponse(
+      self,
+      (effect) =>
+        Effect.catchTag<HttpClientResponse.HttpClientResponse, E, R, K, R1, E1, HttpClientResponse.HttpClientResponse>(
+          effect,
+          tag,
+          f
+        )
+    )
 )
 
 /**

--- a/packages/effect/typetest/Channel.tst.ts
+++ b/packages/effect/typetest/Channel.tst.ts
@@ -1,0 +1,112 @@
+import { Channel, Data, pipe, Result } from "effect"
+import { describe, expect, it } from "tstyche"
+
+class ErrorA extends Data.TaggedError("ErrorA")<{ readonly message: string }> {}
+class ErrorB extends Data.TaggedError("ErrorB")<{ readonly code: number }> {}
+
+declare const channel: Channel.Channel<number, ErrorA | ErrorB>
+
+class RateLimit extends Data.TaggedError("RateLimit")<{ readonly retryAfter: number }> {}
+class Quota extends Data.TaggedError("Quota")<{ readonly limit: number }> {}
+class AiError extends Data.TaggedError("AiError")<{ readonly reason: RateLimit | Quota }> {}
+
+declare const aiChannel: Channel.Channel<number, AiError | ErrorB>
+
+describe("Channel.catchTag", () => {
+  it("removes the handled error when orElse is omitted", () => {
+    const result = pipe(channel, Channel.catchTag("ErrorA", () => Channel.succeed(1)))
+    expect(result).type.toBe<Channel.Channel<number, ErrorB>>()
+  })
+
+  it("supports orElse that re-fails", () => {
+    const result = pipe(
+      channel,
+      Channel.catchTag("ErrorA", () => Channel.succeed(1), () => Channel.fail(new ErrorB({ code: 1 })))
+    )
+    expect(result).type.toBe<Channel.Channel<number, ErrorB>>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Channel<number, never
+    const _c: Channel.Channel<number, never> = pipe(channel, Channel.catchTag("ErrorA", () => Channel.succeed(1)))
+    expect(_c).type.toBe<Channel.Channel<number, never>>()
+  })
+})
+
+describe("Channel.catchIf", () => {
+  it("removes the refined error when orElse is omitted", () => {
+    const result = pipe(
+      channel,
+      Channel.catchIf((e): e is ErrorA => e._tag === "ErrorA", () => Channel.succeed(1))
+    )
+    expect(result).type.toBe<Channel.Channel<number, ErrorB>>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Channel<number, never
+    const _c: Channel.Channel<number, never> = pipe(
+      channel,
+      Channel.catchIf((e): e is ErrorA => e._tag === "ErrorA", () => Channel.succeed(1))
+    )
+    expect(_c).type.toBe<Channel.Channel<number, never>>()
+  })
+})
+
+describe("Channel.catchFilter", () => {
+  it("removes the matched error when orElse is omitted", () => {
+    const result = pipe(
+      channel,
+      Channel.catchFilter(
+        (e) => (e._tag === "ErrorA" ? Result.succeed(e) : Result.fail(e)),
+        () => Channel.succeed(1)
+      )
+    )
+    expect(result).type.toBe<Channel.Channel<number, ErrorB>>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Channel<number, never
+    const _c: Channel.Channel<number, never> = pipe(
+      channel,
+      Channel.catchFilter(
+        (e) => (e._tag === "ErrorA" ? Result.succeed(e) : Result.fail(e)),
+        () => Channel.succeed(1)
+      )
+    )
+    expect(_c).type.toBe<Channel.Channel<number, never>>()
+  })
+})
+
+describe("Channel.catchReason", () => {
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing orElse
+  // (output element type `never`) must not erase the other unhandled error tags via conditional distribution.
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      aiChannel,
+      Channel.catchReason(
+        "AiError",
+        "RateLimit",
+        () => Channel.succeed(1),
+        () => Channel.fail(new ErrorA({ message: "x" }))
+      )
+    )
+    expect(result).type.toBe<Channel.Channel<number, ErrorA | ErrorB>>()
+  })
+})
+
+describe("Channel.catchReasons", () => {
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      aiChannel,
+      Channel.catchReasons(
+        "AiError",
+        { RateLimit: () => Channel.succeed(1) },
+        () => Channel.fail(new ErrorA({ message: "x" }))
+      )
+    )
+    expect(result).type.toBe<Channel.Channel<number, ErrorA | ErrorB>>()
+  })
+})

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -151,6 +151,21 @@ describe("Effect.catchReason", () => {
     )
     expect(result).type.toBe<Effect.Effect<string, AiError | OtherError>>()
   })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing `orElse`
+  // (success type `never`) must not erase the other unhandled error tags via conditional distribution.
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchReason(
+        "AiError",
+        "RateLimitError",
+        () => Effect.succeed("ok"),
+        () => Effect.fail(new SimpleError({ code: 1 }))
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError | SimpleError>>()
+  })
 })
 
 describe("Effect.firstSuccessOf", () => {
@@ -249,9 +264,93 @@ describe("Effect.catchReasons", () => {
     )
     expect(result).type.toBe<Effect.Effect<string>>()
   })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing `orElse`
+  // (success type `never`) must not erase the other unhandled error tags via conditional distribution.
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchReasons(
+        "AiError",
+        { RateLimitError: () => Effect.succeed("ok") },
+        () => Effect.fail(new SimpleError({ code: 1 }))
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError | SimpleError>>()
+  })
+})
+
+describe("Effect.catchTag", () => {
+  it("removes the handled error from the error channel when orElse is omitted", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchTag("AiError", () => Effect.succeed("ok"))
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError>>()
+  })
+
+  it("removes the handled error in data-first usage when orElse is omitted", () => {
+    const result = Effect.catchTag(mixedEffect, "AiError", () => Effect.succeed("ok"))
+    expect(result).type.toBe<Effect.Effect<string, OtherError>>()
+  })
+
+  it("handles an array of tags", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchTag(["AiError", "OtherError"], (error) => {
+        expect(error).type.toBe<AiError | OtherError>()
+        return Effect.succeed("ok")
+      })
+    )
+    expect(result).type.toBe<Effect.Effect<string>>()
+  })
+
+  it("supports orElse", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchTag(
+        "AiError",
+        () => Effect.succeed("ok"),
+        (error) => {
+          expect(error).type.toBe<OtherError>()
+          return Effect.fail(new SimpleError({ code: 1 }))
+        }
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142:
+  // an explicit result annotation must not let unhandled errors be silently dropped.
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
+    const _program: Effect.Effect<string, SimpleError> = pipe(
+      mixedEffect,
+      Effect.catchTag("AiError", () => Effect.fail(new SimpleError({ code: 1 })))
+    )
+    expect(_program).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
 })
 
 describe("Effect.catchTags", () => {
+  it("removes handled errors when orElse is omitted", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchTags({ AiError: () => Effect.succeed("ok") })
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError>>()
+  })
+
+  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
+    const _program: Effect.Effect<string, SimpleError> = pipe(
+      mixedEffect,
+      Effect.catchTags({ AiError: () => Effect.fail(new SimpleError({ code: 1 })) })
+    )
+    expect(_program).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
   it("supports fallback in data-last usage", () => {
     const result = pipe(
       mixedEffect,
@@ -283,6 +382,90 @@ describe("Effect.catchTags", () => {
       }
     )
     expect(result).type.toBe<Effect.Effect<string | number>>()
+  })
+})
+
+describe("Effect.catchIf", () => {
+  it("removes the refined error when orElse is omitted", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchIf((e): e is AiError => e._tag === "AiError", () => Effect.succeed("ok"))
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError>>()
+  })
+
+  it("keeps the full error type with a plain predicate", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchIf((e): boolean => e._tag === "AiError", () => Effect.succeed("ok"))
+    )
+    expect(result).type.toBe<Effect.Effect<string, AiError | OtherError>>()
+  })
+
+  it("supports orElse", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchIf(
+        (e): e is AiError => e._tag === "AiError",
+        () => Effect.succeed("ok"),
+        (error) => {
+          expect(error).type.toBe<OtherError>()
+          return Effect.fail(new SimpleError({ code: 1 }))
+        }
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
+    const _program: Effect.Effect<string, SimpleError> = pipe(
+      mixedEffect,
+      Effect.catchIf((e): e is AiError => e._tag === "AiError", () => Effect.fail(new SimpleError({ code: 1 })))
+    )
+    expect(_program).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+})
+
+describe("Effect.catchFilter", () => {
+  it("removes the matched error when orElse is omitted", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchFilter(
+        (e) => (e._tag === "AiError" ? Result.succeed(e) : Result.fail(e)),
+        () => Effect.succeed("ok")
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, OtherError>>()
+  })
+
+  it("supports orElse", () => {
+    const result = pipe(
+      mixedEffect,
+      Effect.catchFilter(
+        (e) => (e._tag === "AiError" ? Result.succeed(e) : Result.fail(e)),
+        () => Effect.succeed("ok"),
+        (error) => {
+          expect(error).type.toBe<OtherError>()
+          return Effect.fail(new SimpleError({ code: 1 }))
+        }
+      )
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
+    const _program: Effect.Effect<string, SimpleError> = pipe(
+      mixedEffect,
+      Effect.catchFilter(
+        (e) => (e._tag === "AiError" ? Result.succeed(e) : Result.fail(e)),
+        () => Effect.fail(new SimpleError({ code: 1 }))
+      )
+    )
+    expect(_program).type.toBe<Effect.Effect<string, SimpleError>>()
   })
 })
 

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -265,8 +265,6 @@ describe("Effect.catchReasons", () => {
     expect(result).type.toBe<Effect.Effect<string>>()
   })
 
-  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing `orElse`
-  // (success type `never`) must not erase the other unhandled error tags via conditional distribution.
   it("keeps other error tags when orElse re-fails", () => {
     const result = pipe(
       mixedEffect,
@@ -320,8 +318,6 @@ describe("Effect.catchTag", () => {
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
   })
 
-  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142:
-  // an explicit result annotation must not let unhandled errors be silently dropped.
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
     const _program: Effect.Effect<string, SimpleError> = pipe(
@@ -341,7 +337,6 @@ describe("Effect.catchTags", () => {
     expect(result).type.toBe<Effect.Effect<string, OtherError>>()
   })
 
-  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
     const _program: Effect.Effect<string, SimpleError> = pipe(
@@ -417,7 +412,6 @@ describe("Effect.catchIf", () => {
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
   })
 
-  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
     const _program: Effect.Effect<string, SimpleError> = pipe(
@@ -455,7 +449,6 @@ describe("Effect.catchFilter", () => {
     expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
   })
 
-  // Regression test for https://github.com/Effect-TS/effect-smol/issues/2142
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Effect<string, SimpleError, never>'
     const _program: Effect.Effect<string, SimpleError> = pipe(

--- a/packages/effect/typetest/Stream.tst.ts
+++ b/packages/effect/typetest/Stream.tst.ts
@@ -83,7 +83,6 @@ describe("Stream.catchFilter", () => {
     expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
   })
 
-  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
     const _s: Stream.Stream<string, never, "dep-1"> = pipe(
@@ -128,7 +127,6 @@ describe("Stream.catchTags", () => {
     expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
   })
 
-  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
   it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
     // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
     const _s: Stream.Stream<string, never, "dep-1"> = pipe(
@@ -154,8 +152,6 @@ describe("Stream.catchTags", () => {
 })
 
 describe("Stream.catchReason", () => {
-  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing orElse
-  // (success type `never`) must not erase the other unhandled error tags via conditional distribution.
   it("keeps other error tags when orElse re-fails", () => {
     const result = pipe(
       aiStream,

--- a/packages/effect/typetest/Stream.tst.ts
+++ b/packages/effect/typetest/Stream.tst.ts
@@ -1,4 +1,4 @@
-import { type Cause, Data, type Effect, pipe, type Queue, type Scope, Stream } from "effect"
+import { type Cause, Data, type Effect, pipe, type Queue, Result, type Scope, Stream } from "effect"
 import { describe, expect, it } from "tstyche"
 
 class ErrorA extends Data.TaggedError("ErrorA")<{
@@ -11,6 +11,12 @@ class ErrorB extends Data.TaggedError("ErrorB")<{
 
 declare const stream: Stream.Stream<string, ErrorA | ErrorB, "dep-1">
 declare const predicate: (error: ErrorA | ErrorB) => boolean
+
+class RateLimit extends Data.TaggedError("RateLimit")<{ readonly retryAfter: number }> {}
+class Quota extends Data.TaggedError("Quota")<{ readonly limit: number }> {}
+class AiError extends Data.TaggedError("AiError")<{ readonly reason: RateLimit | Quota }> {}
+
+declare const aiStream: Stream.Stream<string, AiError | ErrorB, "dep-1">
 
 describe("Stream.catchIf", () => {
   it("supports refinement in data-last usage", () => {
@@ -52,6 +58,115 @@ describe("Stream.catchIf", () => {
       }
     )
     expect(result).type.toBe<Stream.Stream<string | number, ErrorA | ErrorB, "dep-1">>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
+    const _s: Stream.Stream<string, never, "dep-1"> = pipe(
+      stream,
+      Stream.catchIf((error): error is ErrorA => error._tag === "ErrorA", () => Stream.succeed("ok"))
+    )
+    expect(_s).type.toBe<Stream.Stream<string, never, "dep-1">>()
+  })
+})
+
+describe("Stream.catchFilter", () => {
+  it("removes the matched error when orElse is omitted", () => {
+    const result = pipe(
+      stream,
+      Stream.catchFilter(
+        (error) => (error._tag === "ErrorA" ? Result.succeed(error) : Result.fail(error)),
+        () => Stream.succeed("ok")
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
+    const _s: Stream.Stream<string, never, "dep-1"> = pipe(
+      stream,
+      Stream.catchFilter(
+        (error) => (error._tag === "ErrorA" ? Result.succeed(error) : Result.fail(error)),
+        () => Stream.succeed("ok")
+      )
+    )
+    expect(_s).type.toBe<Stream.Stream<string, never, "dep-1">>()
+  })
+})
+
+describe("Stream.catchTag", () => {
+  it("removes the handled error when orElse is omitted", () => {
+    const result = pipe(stream, Stream.catchTag("ErrorA", () => Stream.succeed("ok")))
+    expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
+  })
+
+  it("supports orElse that re-fails", () => {
+    const result = pipe(
+      stream,
+      Stream.catchTag("ErrorA", () => Stream.succeed("ok"), () => Stream.fail(new ErrorB({ code: 1 })))
+    )
+    expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
+    const _s: Stream.Stream<string, never, "dep-1"> = pipe(
+      stream,
+      Stream.catchTag("ErrorA", () => Stream.succeed("ok"))
+    )
+    expect(_s).type.toBe<Stream.Stream<string, never, "dep-1">>()
+  })
+})
+
+describe("Stream.catchTags", () => {
+  it("removes handled errors when orElse is omitted", () => {
+    const result = pipe(stream, Stream.catchTags({ ErrorA: () => Stream.succeed("ok") }))
+    expect(result).type.toBe<Stream.Stream<string, ErrorB, "dep-1">>()
+  })
+
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142
+  it("keeps unhandled errors under an explicit annotation (orElse omitted)", () => {
+    // @ts-expect-error is not assignable to type 'Stream<string, never, "dep-1">'
+    const _s: Stream.Stream<string, never, "dep-1"> = pipe(
+      stream,
+      Stream.catchTags({ ErrorA: () => Stream.succeed("ok") })
+    )
+    expect(_s).type.toBe<Stream.Stream<string, never, "dep-1">>()
+  })
+})
+
+describe("Stream.catchReason", () => {
+  // Soundness guard for https://github.com/Effect-TS/effect-smol/issues/2142: a re-failing orElse
+  // (success type `never`) must not erase the other unhandled error tags via conditional distribution.
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      aiStream,
+      Stream.catchReason(
+        "AiError",
+        "RateLimit",
+        () => Stream.succeed("ok"),
+        () => Stream.fail(new ErrorA({ message: "x" }))
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string, ErrorA | ErrorB, "dep-1">>()
+  })
+})
+
+describe("Stream.catchReasons", () => {
+  it("keeps other error tags when orElse re-fails", () => {
+    const result = pipe(
+      aiStream,
+      Stream.catchReasons(
+        "AiError",
+        { RateLimit: () => Stream.succeed("ok") },
+        () => Stream.fail(new ErrorA({ message: "x" }))
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string, ErrorA | ErrorB, "dep-1">>()
   })
 })
 

--- a/packages/effect/typetest/Stream.tst.ts
+++ b/packages/effect/typetest/Stream.tst.ts
@@ -137,6 +137,20 @@ describe("Stream.catchTags", () => {
     )
     expect(_s).type.toBe<Stream.Stream<string, never, "dep-1">>()
   })
+
+  it("keeps the orElse error type when orElse re-fails", () => {
+    const result = pipe(
+      stream,
+      Stream.catchTags(
+        { ErrorA: () => Stream.succeed("ok") },
+        (error) => {
+          expect(error).type.toBe<ErrorB>()
+          return Stream.fail(new RateLimit({ retryAfter: 1 }))
+        }
+      )
+    )
+    expect(result).type.toBe<Stream.Stream<string, RateLimit, "dep-1">>()
+  })
 })
 
 describe("Stream.catchReason", () => {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `catch*` combinators dropped error types from their result when `orElse` was involved. Fixes #2142.

Affects `catchTag`, `catchTags`, `catchIf`, `catchFilter`, `catchReason`, and `catchReasons` on `Effect`, `Stream`, and `Channel`.

## Bugs fixed

All converge on the `unassigned` sentinel (matching `catchReason`):

  - **Omitted `orElse` + annotation.** The unhandled-error type was a
    defaulted-but-inferable type param, so a contextual type (e.g. an explicit
    result annotation) collapsed it to `never`, hiding errors that were never
    handled. Now uses the sentinel so the omitted-`orElse` path always reports
    unhandled errors.
  - **Re-failing `orElse`.** An `orElse` with success type `never` (e.g.
    `Effect.fail`) made the sentinel conditional distribute over `never` and
    erase the still-unhandled tags. Error channels are now structured so those
    tags survive regardless of the `orElse` return type.
  - **`Stream.catchTags` dropped the `orElse` error.** It omitted the
    unconditional `E2` term, so a re-failing `orElse`'s own error type was
    erased. Added `E2`, matching `Effect.catchTags`.

Also drops the `as any` in `HttpClient.catchTag`, using explicit type arguments to `Effect.catchTag` instead.

  ## Tests

Type-level regression tests in `Effect.tst.ts`, `Stream.tst.ts`, and `Channel.tst.ts` for the omitted, succeeding, and re-failing `orElse` paths.

## Related

- Closes #2142 

## Disclosure

Produced with assistance by Claude Code (Opus 4.7)