### PR TITLE
EFF-818 Fix logger string formatter quoting

### DIFF
--- a/.changeset/sharp-singers-sort.md
+++ b/.changeset/sharp-singers-sort.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix string messages and annotations being double-quoted by simple and logfmt loggers.

--- a/packages/effect/src/Logger.ts
+++ b/packages/effect/src/Logger.ts
@@ -474,6 +474,8 @@ const format = (
   space?: number | string | undefined
 ) =>
 ({ cause, date, fiber, logLevel, message }: Options<unknown>): string => {
+  const formatUnknown = (value: unknown): string =>
+    typeof value === "string" ? value : Formatter.format(value, { space })
   const formatValue = (value: string): string => value.match(textOnly) ? value : quoteValue(value)
   const format = (label: string, value: string): string => `${effect.formatLabel(label)}=${formatValue(value)}`
   const append = (label: string, value: string): string => " " + format(label, value)
@@ -484,7 +486,7 @@ const format = (
 
   const messages = Array.ensure(message)
   for (let i = 0; i < messages.length; i++) {
-    out += append("message", Formatter.format(messages[i], { space }))
+    out += append("message", formatUnknown(messages[i]))
   }
 
   if (cause.reasons.length > 0) {
@@ -499,7 +501,7 @@ const format = (
 
   const annotations = fiber.getRef(CurrentLogAnnotations)
   for (const [label, value] of Object.entries(annotations)) {
-    out += append(label, Formatter.format(value, { space }))
+    out += append(label, formatUnknown(value))
   }
 
   return out

--- a/packages/effect/test/Logger.test.ts
+++ b/packages/effect/test/Logger.test.ts
@@ -40,6 +40,56 @@ describe("Logger", () => {
     })
   )
 
+  it.effect("formatLogFmt does not double quote string messages or annotations", () =>
+    Effect.gen(function*() {
+      const result: Array<string> = []
+      const logger = Logger.formatLogFmt.pipe(
+        Logger.map((output): void => {
+          result.push(output)
+        })
+      )
+
+      yield* Effect.logInfo("Welcome to the Effect Playground!").pipe(
+        Effect.annotateLogs({
+          annotation1: "first",
+          annotation2: "second",
+          annotation3: "\"omg\""
+        }),
+        Effect.provide(Logger.layer([logger]))
+      )
+
+      assert.strictEqual(result.length, 1)
+      const output = result[0] as string
+      assert.match(output, /message="Welcome to the Effect Playground!"/)
+      assert.match(output, /annotation1=first/)
+      assert.match(output, /annotation2=second/)
+      assert.match(output, /annotation3="\\"omg\\""/)
+      assert.ok(!output.includes("message=\"\\\"Welcome to the Effect Playground!\\\"\""))
+      assert.ok(!output.includes("annotation1=\"\\\"first\\\"\""))
+    }))
+
+  it.effect("formatSimple does not double quote string messages or annotations", () =>
+    Effect.gen(function*() {
+      const result: Array<string> = []
+      const logger = Logger.formatSimple.pipe(
+        Logger.map((output): void => {
+          result.push(output)
+        })
+      )
+
+      yield* Effect.logInfo("hello world").pipe(
+        Effect.annotateLogs("annotation", "value with spaces"),
+        Effect.provide(Logger.layer([logger]))
+      )
+
+      assert.strictEqual(result.length, 1)
+      const output = result[0] as string
+      assert.match(output, /message="hello world"/)
+      assert.match(output, /annotation="value with spaces"/)
+      assert.ok(!output.includes("message=\"\\\"hello world\\\"\""))
+      assert.ok(!output.includes("annotation=\"\\\"value with spaces\\\"\""))
+    }))
+
   it.effect("annotateLogsScoped applies annotations only while scoped", () =>
     Effect.gen(function*() {
       const annotations: Array<Record<string, unknown>> = []


### PR DESCRIPTION
## Summary
- Fix Logger.formatSimple and Logger.formatLogFmt so raw string messages and annotations are not pre-formatted with Formatter.format before final formatter quoting.
- Add regression coverage for string messages and annotations, including already-quoted annotation values.
- Add a patch changeset for the effect package.

## Validation
- pnpm test packages/effect/test/Logger.test.ts
- pnpm lint-fix
- pnpm check:tsgo (fails on existing packages/effect/typetest/Effect.tst.ts TS377003 missing OtherError diagnostics, unrelated to this change)
