### PR TITLE
EFF-821: Add default support to integer prompts

### DIFF
--- a/.changeset/thick-pandas-wait.md
+++ b/.changeset/thick-pandas-wait.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add default value support to CLI integer prompts.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -279,6 +279,10 @@ export interface IntegerOptions {
    */
   readonly message: string
   /**
+   * The default value of the integer prompt.
+   */
+  readonly default?: number
+  /**
    * The minimum value that can be entered by the user (defaults to `-Infinity`).
    */
   readonly min?: number
@@ -896,6 +900,7 @@ export const flatMap: {
  */
 export const float = (options: FloatOptions): Prompt<number> => {
   const opts: FloatOptionsReq = {
+    default: 0,
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -912,9 +917,10 @@ export const float = (options: FloatOptions): Prompt<number> => {
     },
     ...options
   }
+  const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
-    cursor: 0,
-    value: "",
+    cursor: initialValue.length,
+    value: initialValue,
     error: Option.none()
   }
   return custom(initialState, {
@@ -947,6 +953,7 @@ export const hidden = (
  */
 export const integer = (options: IntegerOptions): Prompt<number> => {
   const opts: IntegerOptionsReq = {
+    default: 0,
     min: Number.NEGATIVE_INFINITY,
     max: Number.POSITIVE_INFINITY,
     incrementBy: 1,
@@ -962,9 +969,10 @@ export const integer = (options: IntegerOptions): Prompt<number> => {
     },
     ...options
   }
+  const initialValue = options.default === undefined ? "" : `${opts.default}`
   const initialState: NumberState = {
-    cursor: 0,
-    value: "",
+    cursor: initialValue.length,
+    value: initialValue,
     error: Option.none()
   }
   return custom(initialState, {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -51,6 +51,41 @@ const toRawFrames = (lines: ReadonlyArray<unknown>) =>
 
 const findFrame = (frames: ReadonlyArray<string>, text: string) => frames.find((frame) => frame.includes(text))
 
+describe("Prompt.integer", () => {
+  it.effect("submits the default value", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.integer({ message: "Count", default: 42 })
+
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, 42)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("starts from the default value so it can be edited", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.integer({ message: "Count", default: 4 })
+
+      yield* MockTerminal.inputText("2")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, 42)
+    }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("clears the default value on ctrl-u", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.integer({ message: "Count", default: 42 })
+
+      yield* MockTerminal.inputKey("u", { ctrl: true })
+      yield* MockTerminal.inputText("7")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, 7)
+    }).pipe(Effect.provide(TestLayer)))
+})
+
 describe("Prompt.float", () => {
   it.effect("renders appended input without literal parsed", () =>
     Effect.gen(function*() {


### PR DESCRIPTION
## Summary
- Add `default?: number` to CLI integer prompt options and seed the number prompt state from it when provided.
- Preserve prior empty input behavior when no default is supplied.
- Add Prompt.integer tests for submitting, editing, and clearing the default value.
- Add a patch changeset for effect.

## Validation
- `pnpm test packages/effect/test/unstable/cli/Prompt.test.ts`
- `pnpm lint-fix`
- `pnpm --dir packages/effect check`
- `pnpm check:tsgo` (fails in existing `packages/effect/typetest/Effect.tst.ts` missing OtherError expected Effect type errors, unrelated to this change)
