### PR TITLE
EFF-820 Add Prompt.file default support

### DIFF
--- a/.changeset/perfect-buckets-tickle.md
+++ b/.changeset/perfect-buckets-tickle.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add default value support to `Prompt.file`.

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -361,6 +361,10 @@ export interface FileOptions {
    */
   readonly startingPath?: string
   /**
+   * The default path to select when the prompt is first displayed.
+   */
+  readonly default?: string
+  /**
    * The number of choices to display at one time, defaulting to `10`.
    */
   readonly maxPerPage?: number
@@ -838,6 +842,7 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
     type: options.type ?? "file",
     message: options.message ?? `Choose a file`,
     startingPath: Option.fromUndefinedOr(options.startingPath),
+    default: Option.fromUndefinedOr(options.default),
     maxPerPage: options.maxPerPage ?? 10,
     filter: options.filter ?? (() => Effect.succeed(true))
   }
@@ -847,9 +852,22 @@ export const file = (options: FileOptions = {}): Prompt<string> => {
     Environment
   > = Effect.gen(function*() {
     const currentPath = yield* resolveCurrentPath(Option.none(), opts)
-    const files = yield* getFileList(currentPath, opts)
+    const path = yield* Path.Path
+    const defaultPath = Option.map(opts.default, (defaultValue) => path.resolve(currentPath, defaultValue))
+    const initialPath = Option.match(defaultPath, {
+      onNone: () => currentPath,
+      onSome: (defaultPath) => path.dirname(defaultPath)
+    })
+    const files = yield* getFileList(initialPath, opts)
+    const cursor = Option.match(defaultPath, {
+      onNone: () => 0,
+      onSome: (defaultPath) => {
+        const index = files.indexOf(path.basename(defaultPath))
+        return index === -1 ? 0 : index
+      }
+    })
     const confirm = Confirm.Hide()
-    return { cursor: 0, files, allFiles: files, query: "", path: Option.none(), confirm }
+    return { cursor, files, allFiles: files, query: "", path: Option.map(defaultPath, path.dirname), confirm }
   })
   return custom(initialState, {
     render: handleFileRender(opts),
@@ -2007,8 +2025,9 @@ class Meridiem extends DatePart {
   }
 }
 
-interface FileOptionsReq extends Required<Omit<FileOptions, "startingPath">> {
+interface FileOptionsReq extends Required<Omit<FileOptions, "startingPath" | "default">> {
   readonly startingPath: Option.Option<string>
+  readonly default: Option.Option<string>
 }
 
 interface FileState {

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -388,6 +388,19 @@ describe("Prompt.file", () => {
     TerminalLayer
   )
 
+  it.effect("starts from the default value so it can be submitted", () =>
+    Effect.gen(function*() {
+      const prompt = Prompt.file({
+        message: "Pick file",
+        default: "/workspace/banana.txt"
+      })
+
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "/workspace/banana.txt")
+    }).pipe(Effect.provide(FilePromptLayer)))
+
   it.effect("filters files as you type", () =>
     Effect.gen(function*() {
       const prompt = Prompt.file({


### PR DESCRIPTION
## Summary
- Add a `default` option to `Prompt.file` and use it to select the initial file path.
- Initialize the file prompt in the default path's directory and position the cursor on the default basename when present.
- Add a regression test and changeset.

## Validation
- `pnpm test packages/effect/test/unstable/cli/Prompt.test.ts`
- `pnpm lint-fix`
- `cd packages/effect && pnpm docgen`
- `pnpm check:tsgo` *(fails: existing typetest errors in `packages/effect/typetest/Effect.tst.ts` lines 323, 342, 417, and 454 report missing `OtherError` in expected Effect types)*
