### PR TITLE
EFF-819: Fix workflow durable shard group routing

### DIFF
--- a/.changeset/eff-819-cluster-workflow-shard-groups.md
+++ b/.changeset/eff-819-cluster-workflow-shard-groups.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Ensure ClusterWorkflowEngine routes durable clock wakeups and registered workflow deferred completions through the owning workflow's shard group.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -37,6 +37,7 @@ import type * as Record from "../../Record.ts"
 import * as Schedule from "../../Schedule.ts"
 import * as Schema from "../../Schema.ts"
 import type * as Scope from "../../Scope.ts"
+import * as Headers from "../http/Headers.ts"
 import * as Rpc from "../rpc/Rpc.ts"
 import { ClientAbort } from "../rpc/RpcSchema.ts"
 import * as Activity from "../workflow/Activity.ts"
@@ -159,8 +160,6 @@ export const make = Effect.gen(function*() {
     }),
     idleTimeToLive: "5 minutes"
   })
-  const clockClient = yield* ClockEntity.client
-
   const entityAddressFor = (options: {
     readonly workflow: Workflow.Any
     readonly entityType: string
@@ -176,6 +175,35 @@ export const make = Effect.gen(function*() {
       shardId: sharding.getShardId(entityId, shardGroup)
     })
   }
+
+  const sendDiscard = Effect.fnUntraced(function*(options: {
+    readonly rpc: Rpc.AnyWithProps
+    readonly address: EntityAddress.EntityAddress
+    readonly payload: unknown
+  }) {
+    const payload = (options.rpc.payloadSchema as any).make(options.payload)
+    const envelope = Envelope.makeRequest<any>({
+      requestId: yield* sharding.getSnowflake,
+      address: options.address,
+      tag: options.rpc._tag as any,
+      payload,
+      headers: Headers.empty
+    })
+    yield* sharding.sendOutgoing(
+      new Message.OutgoingRequest({
+        envelope,
+        context: Context.empty() as Context.Context<any>,
+        lastReceivedReply: Option.none(),
+        rpc: options.rpc,
+        respond: () => Effect.void,
+        annotations: Context.get(options.rpc.annotations, ClusterSchema.Dynamic)(
+          options.rpc.annotations,
+          envelope as any
+        )
+      }),
+      true
+    )
+  })
 
   const requestIdFor = Effect.fnUntraced(function*(options: {
     readonly workflow: Workflow.Any
@@ -562,6 +590,21 @@ export const make = Effect.gen(function*() {
 
     deferredDone: Effect.fnUntraced(
       function*({ deferredName, executionId, exit, workflowName }) {
+        const workflow = workflows.get(workflowName)
+        if (workflow) {
+          return yield* Effect.orDie(sendDiscard({
+            rpc: DeferredRpc,
+            address: entityAddressFor({
+              workflow,
+              entityType: `Workflow/${workflowName}`,
+              executionId
+            }),
+            payload: {
+              name: deferredName,
+              exit
+            }
+          }))
+        }
         const client = yield* RcMap.get(clientsPartial, workflowName)
         return yield* Effect.orDie(
           client(executionId).deferred({
@@ -574,14 +617,21 @@ export const make = Effect.gen(function*() {
     ),
 
     scheduleClock(workflow, options) {
-      const client = clockClient(options.executionId)
       return DateTime.now.pipe(
         Effect.flatMap((now) =>
-          client.run({
-            name: options.clock.name,
-            workflowName: workflow.name,
-            wakeUp: DateTime.addDuration(now, options.clock.duration)
-          }, { discard: true })
+          sendDiscard({
+            rpc: ClockRpc,
+            address: entityAddressFor({
+              workflow,
+              entityType: ClockEntity.type,
+              executionId: options.executionId
+            }),
+            payload: {
+              name: options.clock.name,
+              workflowName: workflow.name,
+              wakeUp: DateTime.addDuration(now, options.clock.duration)
+            }
+          })
         ),
         Effect.orDie
       )
@@ -696,10 +746,12 @@ class ClockPayload extends Schema.Class<ClockPayload>(`Workflow/DurableClock/Run
   }
 }
 
+const ClockRpc = Rpc.make("run", { payload: ClockPayload })
+  .annotate(ClusterSchema.Persisted, true)
+  .annotate(ClusterSchema.Uninterruptible, true)
+
 const ClockEntity = Entity.make("Workflow/-/DurableClock", [
-  Rpc.make("run", { payload: ClockPayload })
-    .annotate(ClusterSchema.Persisted, true)
-    .annotate(ClusterSchema.Uninterruptible, true)
+  ClockRpc
 ])
 
 const ClockEntityLayer = ClockEntity.toLayer(Effect.gen(function*() {

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, expect, it } from "@effect/vitest"
 import { Cause, Context, DateTime, Duration, Effect, Exit, Fiber, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  ClusterSchema,
   ClusterWorkflowEngine,
   MessageStorage,
   RunnerHealth,
@@ -11,7 +12,7 @@ import {
   ShardingConfig
 } from "effect/unstable/cluster"
 import { Activity, DurableClock, DurableDeferred, Workflow } from "effect/unstable/workflow"
-import { WorkflowInstance } from "effect/unstable/workflow/WorkflowEngine"
+import { WorkflowEngine, WorkflowInstance } from "effect/unstable/workflow/WorkflowEngine"
 
 describe.concurrent("ClusterWorkflowEngine", () => {
   it.effect("executes, resumes, deduplicates, and polls a suspended workflow", () =>
@@ -220,6 +221,64 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.isTrue(flags.get("child-end"))
     }).pipe(Effect.provide(TestWorkflowLayer)))
 
+  it.effect("routes durable clock wakeups to the workflow shard group", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const sharding = yield* Sharding.Sharding
+
+      const fiber = yield* ShardedClockWorkflow.execute({
+        id: "sharded-clock"
+      }).pipe(Effect.forkChild({ startImmediately: true }))
+
+      yield* TestClock.adjust(1)
+
+      const envelope = driver.journal.find((envelope) =>
+        envelope._tag === "Request" && envelope.address.entityType === "Workflow/-/DurableClock"
+      )
+      assert(envelope)
+      assert.strictEqual(envelope.address.shardId.group, "workflow")
+
+      yield* TestClock.adjust("10 seconds")
+      yield* sharding.pollStorage
+      yield* TestClock.adjust(5000)
+      yield* Fiber.join(fiber)
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("routes durable deferred completions to the workflow shard group after a partial client is cached", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const engine = yield* WorkflowEngine
+      const executionIdBeforeRegister = yield* ShardedDeferredWorkflow.executionId({ id: "before-register" })
+      const tokenBeforeRegister = DurableDeferred.tokenFromExecutionId(ShardedDeferred, {
+        workflow: ShardedDeferredWorkflow,
+        executionId: executionIdBeforeRegister
+      })
+
+      yield* DurableDeferred.done(ShardedDeferred, {
+        token: tokenBeforeRegister,
+        exit: Exit.void
+      })
+
+      yield* engine.register(ShardedDeferredWorkflow, () => Effect.void)
+
+      const executionIdAfterRegister = yield* ShardedDeferredWorkflow.executionId({ id: "after-register" })
+      const tokenAfterRegister = DurableDeferred.tokenFromExecutionId(ShardedDeferred, {
+        workflow: ShardedDeferredWorkflow,
+        executionId: executionIdAfterRegister
+      })
+      const journalLength = driver.journal.length
+      yield* DurableDeferred.done(ShardedDeferred, {
+        token: tokenAfterRegister,
+        exit: Exit.void
+      })
+
+      const envelope = driver.journal.slice(journalLength).find((envelope) =>
+        envelope._tag === "Request" && envelope.address.entityType === "Workflow/ShardedDeferredWorkflow"
+      )
+      assert(envelope)
+      assert.strictEqual(envelope.address.shardId.group, "workflow")
+    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+
   it.effect("SuspendOnFailure", () =>
     Effect.gen(function*() {
       const flags = yield* Flags
@@ -252,6 +311,8 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
 const TestShardingConfig = ShardingConfig.layer({
   shardsPerGroup: 300,
+  availableShardGroups: ["default", "workflow"],
+  assignedShardGroups: ["default", "workflow"],
   entityMailboxCapacity: 10,
   entityTerminationTimeout: 0,
   entityMessagePollInterval: 5000,
@@ -504,6 +565,36 @@ const ChildWorkflowLayer = ChildWorkflow.toLayer(Effect.fnUntraced(function*() {
   flags.set("child-end", true)
 }))
 
+const ShardedClockWorkflow = Workflow.make({
+  name: "ShardedClockWorkflow",
+  payload: {
+    id: Schema.String
+  },
+  idempotencyKey(payload) {
+    return payload.id
+  }
+}).annotate(ClusterSchema.ShardGroup, () => "workflow")
+
+const ShardedClockWorkflowLayer = ShardedClockWorkflow.toLayer(Effect.fnUntraced(function*() {
+  yield* DurableClock.sleep({
+    name: "ShardedClock",
+    duration: "10 seconds",
+    inMemoryThreshold: Duration.zero
+  })
+}))
+
+const ShardedDeferred = DurableDeferred.make("ShardedDeferred")
+
+const ShardedDeferredWorkflow = Workflow.make({
+  name: "ShardedDeferredWorkflow",
+  payload: {
+    id: Schema.String
+  },
+  idempotencyKey(payload) {
+    return payload.id
+  }
+}).annotate(ClusterSchema.ShardGroup, () => "workflow")
+
 const SuspendOnFailureWorkflow = Workflow.make({
   name: "SuspendOnFailureWorkflow",
   payload: {
@@ -562,6 +653,7 @@ const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(DurableRaceWorkflowLayer),
   Layer.merge(ParentWorkflowLayer),
   Layer.merge(ChildWorkflowLayer),
+  Layer.merge(ShardedClockWorkflowLayer),
   Layer.merge(SuspendOnFailureWorkflowLayer),
   Layer.merge(CatchWorkflowLayer),
   Layer.provideMerge(Flags.layer),


### PR DESCRIPTION
## Summary

- Route ClusterWorkflowEngine durable clock wakeup messages through the owning workflow's shard group instead of the default clock entity shard group.
- Route registered workflow DurableDeferred completions through the workflow shard group, avoiding stale partial-client routing.
- Add regression coverage for durable clock routing and cached partial DurableDeferred clients.

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
- pnpm check:tsgo (completed, but printed existing TS377003 diagnostics in packages/effect/typetest/Effect.tst.ts)
