### PR TITLE
[codex] Add generic HttpApi HTTP security schemes

### DIFF
--- a/.changeset/dpop-security-scheme.md
+++ b/.changeset/dpop-security-scheme.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `HttpApiSecurity.dpop` for decoding DPoP-bound access tokens and generating the matching OpenAPI HTTP security scheme.

--- a/.changeset/dpop-security-scheme.md
+++ b/.changeset/dpop-security-scheme.md
@@ -3,4 +3,4 @@
 "@effect/openapi-generator": patch
 ---
 
-Add `HttpApiSecurity.dpop` for validating and decoding DPoP-bound access tokens, generating the matching OpenAPI HTTP security scheme, and preserving that scheme in generated `HttpApi` modules.
+Add `HttpApiSecurity.http` for arbitrary HTTP authorization schemes and `HttpApiSecurity.dpop` as a DPoP convenience declaration, with matching runtime decoding, OpenAPI generation, and generated `HttpApi` support.

--- a/.changeset/dpop-security-scheme.md
+++ b/.changeset/dpop-security-scheme.md
@@ -1,5 +1,6 @@
 ---
 "effect": patch
+"@effect/openapi-generator": patch
 ---
 
-Add `HttpApiSecurity.dpop` for decoding DPoP-bound access tokens and generating the matching OpenAPI HTTP security scheme.
+Add `HttpApiSecurity.dpop` for validating and decoding DPoP-bound access tokens, generating the matching OpenAPI HTTP security scheme, and preserving that scheme in generated `HttpApi` modules.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -446,13 +446,13 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
     case "Bearer": {
       return Effect.map(
         HttpServerRequest,
-        (request) => Redacted.make((request.headers.authorization ?? "").slice(bearerLen)) as any
+        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, "Bearer")) as any
       )
     }
     case "DPoP": {
       return Effect.map(
         HttpServerRequest,
-        (request) => Redacted.make((request.headers.authorization ?? "").slice(dpopLen)) as any
+        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, "DPoP")) as any
       )
     }
     case "ApiKey": {
@@ -481,7 +481,9 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
       } as any
       return HttpServerRequest.pipe(
         Effect.flatMap((request) =>
-          Effect.fromResult(Encoding.decodeBase64String((request.headers.authorization ?? "").slice(basicLen)))
+          Effect.fromResult(
+            Encoding.decodeBase64String(decodeAuthorizationToken(request.headers.authorization, "Basic"))
+          )
         ),
         Effect.match({
           onFailure: () => empty,
@@ -527,9 +529,12 @@ export const securitySetCookie = (
 // Internal
 // -----------------------------------------------------------------------------
 
-const bearerLen = `Bearer `.length
-const dpopLen = `DPoP `.length
-const basicLen = `Basic `.length
+const authorizationToken = /^([^ ]+) +([-A-Za-z0-9._~+/]+=*)$/
+
+const decodeAuthorizationToken = (authorization: string | undefined, scheme: string): string => {
+  const match = authorizationToken.exec(authorization ?? "")
+  return match !== null && match[1].toLowerCase() === scheme.toLowerCase() ? match[2] : ""
+}
 
 const HandlersProto = {
   [HandlersTypeId]: {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -430,7 +430,7 @@ export const endpoint = <
 
 /**
  * Decodes credentials for an HTTP API security scheme from the current request,
- * supporting bearer, API key, and basic authentication inputs.
+ * supporting bearer, DPoP, API key, and basic authentication inputs.
  *
  * @category security
  * @since 4.0.0
@@ -447,6 +447,12 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
       return Effect.map(
         HttpServerRequest,
         (request) => Redacted.make((request.headers.authorization ?? "").slice(bearerLen)) as any
+      )
+    }
+    case "DPoP": {
+      return Effect.map(
+        HttpServerRequest,
+        (request) => Redacted.make((request.headers.authorization ?? "").slice(dpopLen)) as any
       )
     }
     case "ApiKey": {
@@ -522,6 +528,7 @@ export const securitySetCookie = (
 // -----------------------------------------------------------------------------
 
 const bearerLen = `Bearer `.length
+const dpopLen = `DPoP `.length
 const basicLen = `Basic `.length
 
 const HandlersProto = {

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -430,7 +430,7 @@ export const endpoint = <
 
 /**
  * Decodes credentials for an HTTP API security scheme from the current request,
- * supporting bearer, DPoP, API key, and basic authentication inputs.
+ * supporting HTTP authorization, API key, and basic authentication inputs.
  *
  * @category security
  * @since 4.0.0
@@ -443,16 +443,10 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
   HttpServerRequest | Request.ParsedSearchParams
 > => {
   switch (self._tag) {
-    case "Bearer": {
+    case "Http": {
       return Effect.map(
         HttpServerRequest,
-        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, "Bearer")) as any
-      )
-    }
-    case "DPoP": {
-      return Effect.map(
-        HttpServerRequest,
-        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, "DPoP")) as any
+        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, self.scheme)) as any
       )
     }
     case "ApiKey": {

--- a/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
@@ -8,27 +8,30 @@
  *
  * **Mental model**
  *
- * Create a scheme with {@link bearer}, {@link apiKey}, or {@link basic}, attach
- * it to middleware, and let the HTTP API builder decode the matching credential
- * shape from each request. OpenAPI generation emits the same declaration as
- * `components.securitySchemes` plus operation security requirements.
+ * Create a scheme with {@link bearer}, {@link dpop}, {@link apiKey}, or
+ * {@link basic}, attach it to middleware, and let the HTTP API builder decode
+ * the matching credential shape from each request. OpenAPI generation emits
+ * the same declaration as `components.securitySchemes` plus operation security
+ * requirements.
  *
  * **Common tasks**
  *
- * Use {@link bearer} for `Authorization: Bearer ...` tokens, {@link basic} for
- * HTTP Basic username/password credentials, and {@link apiKey} for keys passed
- * through headers, query parameters, or cookies. Use {@link annotate} or
+ * Use {@link bearer} for `Authorization: Bearer ...` tokens, {@link dpop} for
+ * `Authorization: DPoP ...` access tokens, {@link basic} for HTTP Basic
+ * username/password credentials, and {@link apiKey} for keys passed through
+ * headers, query parameters, or cookies. Use {@link annotate} or
  * {@link annotateMerge} to add documentation metadata for generated OpenAPI
  * descriptions.
  *
  * **Gotchas**
  *
- * Middleware must reject empty or invalid credentials. Bearer tokens and API-key
- * values are delivered as `Redacted` values; Basic credentials expose the
- * username and redact the password. Bearer and Basic schemes read the
- * `Authorization` header, API-key headers use HTTP header name normalization,
- * and API-key query or cookie names are matched exactly. OpenAPI annotations do
- * not change runtime decoding.
+ * Middleware must reject empty or invalid credentials. Bearer and DPoP tokens
+ * and API-key values are delivered as `Redacted` values; Basic credentials
+ * expose the username and redact the password. Bearer, DPoP, and Basic schemes
+ * read the `Authorization` header, API-key headers use HTTP header name
+ * normalization, and API-key query or cookie names are matched exactly. A DPoP
+ * scheme does not decode or validate the required `DPoP` proof header. OpenAPI
+ * annotations do not change runtime decoding.
  *
  * **See also**
  *
@@ -51,7 +54,7 @@ const TypeId = "~effect/httpapi/HttpApiSecurity"
  * @category models
  * @since 4.0.0
  */
-export type HttpApiSecurity = Bearer | ApiKey | Basic
+export type HttpApiSecurity = Bearer | DPoP | ApiKey | Basic
 
 /**
  * Helper types for HTTP API security schemes.
@@ -89,6 +92,16 @@ export declare namespace HttpApiSecurity {
  */
 export interface Bearer extends HttpApiSecurity.Proto<Redacted> {
   readonly _tag: "Bearer"
+}
+
+/**
+ * DPoP-bound access-token security scheme whose decoded credential is a redacted token.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DPoP extends HttpApiSecurity.Proto<Redacted> {
+  readonly _tag: "DPoP"
 }
 
 /**
@@ -144,6 +157,7 @@ const Proto = {
  * Use `HttpApiBuilder.middlewareSecurity` to implement API middleware for this
  * security scheme.
  *
+ * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link apiKey} for an API-key security scheme
  * @see {@link basic} for an HTTP Basic security scheme
  * @category constructors
@@ -151,6 +165,29 @@ const Proto = {
  */
 export const bearer: Bearer = Object.assign(Object.create(Proto), {
   _tag: "Bearer",
+  annotations: Context.empty()
+})
+
+/**
+ * Creates a DPoP-bound access-token security scheme.
+ *
+ * **When to use**
+ *
+ * Use to require `Authorization: DPoP ...` credentials for an HTTP API group
+ * or endpoint.
+ *
+ * **Gotchas**
+ *
+ * This scheme extracts only the access-token parameter. Validate the required
+ * `DPoP` proof JWT header in middleware or request schemas.
+ *
+ * @see {@link bearer} for a Bearer token security scheme
+ * @see {@link apiKey} for an API-key security scheme
+ * @category constructors
+ * @since 4.0.0
+ */
+export const dpop: DPoP = Object.assign(Object.create(Proto), {
+  _tag: "DPoP",
   annotations: Context.empty()
 })
 
@@ -171,6 +208,7 @@ export const bearer: Bearer = Object.assign(Object.create(Proto), {
  * handler. By default, `in` is `"header"`.
  *
  * @see {@link bearer} for a Bearer token security scheme
+ * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link basic} for an HTTP Basic security scheme
  * @category constructors
  * @since 4.0.0
@@ -199,6 +237,7 @@ export const apiKey = (options: {
  * security scheme.
  *
  * @see {@link bearer} for a Bearer token security scheme
+ * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link apiKey} for an API-key security scheme
  * @category constructors
  * @since 4.0.0

--- a/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
@@ -28,10 +28,11 @@
  * Middleware must reject empty or invalid credentials. Bearer and DPoP tokens
  * and API-key values are delivered as `Redacted` values; Basic credentials
  * expose the username and redact the password. Bearer, DPoP, and Basic schemes
- * read the `Authorization` header, API-key headers use HTTP header name
- * normalization, and API-key query or cookie names are matched exactly. A DPoP
- * scheme does not decode or validate the required `DPoP` proof header. OpenAPI
- * annotations do not change runtime decoding.
+ * read the `Authorization` header and yield empty credentials when its
+ * authentication scheme or token syntax does not match. API-key headers use
+ * HTTP header name normalization, and API-key query or cookie names are
+ * matched exactly. A DPoP scheme does not decode or validate the required
+ * `DPoP` proof header. OpenAPI annotations do not change runtime decoding.
  *
  * **See also**
  *

--- a/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiSecurity.ts
@@ -8,27 +8,28 @@
  *
  * **Mental model**
  *
- * Create a scheme with {@link bearer}, {@link dpop}, {@link apiKey}, or
- * {@link basic}, attach it to middleware, and let the HTTP API builder decode
- * the matching credential shape from each request. OpenAPI generation emits
- * the same declaration as `components.securitySchemes` plus operation security
- * requirements.
+ * Create a scheme with {@link http}, {@link bearer}, {@link dpop},
+ * {@link apiKey}, or {@link basic}, attach it to middleware, and let the HTTP
+ * API builder decode the matching credential shape from each request. OpenAPI
+ * generation emits the same declaration as `components.securitySchemes` plus
+ * operation security requirements.
  *
  * **Common tasks**
  *
- * Use {@link bearer} for `Authorization: Bearer ...` tokens, {@link dpop} for
- * `Authorization: DPoP ...` access tokens, {@link basic} for HTTP Basic
- * username/password credentials, and {@link apiKey} for keys passed through
- * headers, query parameters, or cookies. Use {@link annotate} or
- * {@link annotateMerge} to add documentation metadata for generated OpenAPI
- * descriptions.
+ * Use {@link http} for any HTTP authorization scheme whose parameter should be
+ * exposed as a redacted value, {@link bearer} for `Authorization: Bearer ...`
+ * tokens, {@link dpop} for `Authorization: DPoP ...` access tokens,
+ * {@link basic} for HTTP Basic username/password credentials, and {@link apiKey}
+ * for keys passed through headers, query parameters, or cookies. Use
+ * {@link annotate} or {@link annotateMerge} to add documentation metadata for
+ * generated OpenAPI descriptions.
  *
  * **Gotchas**
  *
- * Middleware must reject empty or invalid credentials. Bearer and DPoP tokens
- * and API-key values are delivered as `Redacted` values; Basic credentials
- * expose the username and redact the password. Bearer, DPoP, and Basic schemes
- * read the `Authorization` header and yield empty credentials when its
+ * Middleware must reject empty or invalid credentials. HTTP authorization
+ * parameters and API-key values are delivered as `Redacted` values; Basic
+ * credentials expose the username and redact the password. HTTP and Basic
+ * schemes read the `Authorization` header and yield empty credentials when its
  * authentication scheme or token syntax does not match. API-key headers use
  * HTTP header name normalization, and API-key query or cookie names are
  * matched exactly. A DPoP scheme does not decode or validate the required
@@ -55,7 +56,7 @@ const TypeId = "~effect/httpapi/HttpApiSecurity"
  * @category models
  * @since 4.0.0
  */
-export type HttpApiSecurity = Bearer | DPoP | ApiKey | Basic
+export type HttpApiSecurity = Http | ApiKey | Basic
 
 /**
  * Helper types for HTTP API security schemes.
@@ -86,13 +87,23 @@ export declare namespace HttpApiSecurity {
 }
 
 /**
+ * HTTP authorization security scheme whose decoded credential is a redacted parameter.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Http<out Scheme extends string = string> extends HttpApiSecurity.Proto<Redacted> {
+  readonly _tag: "Http"
+  readonly scheme: Scheme
+}
+
+/**
  * Bearer token security scheme whose decoded credential is a redacted token.
  *
  * @category models
  * @since 4.0.0
  */
-export interface Bearer extends HttpApiSecurity.Proto<Redacted> {
-  readonly _tag: "Bearer"
+export interface Bearer extends Http<"bearer"> {
 }
 
 /**
@@ -101,8 +112,7 @@ export interface Bearer extends HttpApiSecurity.Proto<Redacted> {
  * @category models
  * @since 4.0.0
  */
-export interface DPoP extends HttpApiSecurity.Proto<Redacted> {
-  readonly _tag: "DPoP"
+export interface DPoP extends Http<"DPoP"> {
 }
 
 /**
@@ -146,6 +156,29 @@ const Proto = {
 }
 
 /**
+ * Creates an HTTP authorization security scheme.
+ *
+ * **When to use**
+ *
+ * Use to require an HTTP authorization parameter for a scheme not otherwise
+ * represented by a convenience declaration.
+ *
+ * @see {@link bearer} for a Bearer token security scheme
+ * @see {@link dpop} for a DPoP-bound access-token security scheme
+ * @see {@link basic} for decoded HTTP Basic username/password credentials
+ * @category constructors
+ * @since 4.0.0
+ */
+export const http = <const Scheme extends string>(options: {
+  readonly scheme: Scheme
+}): Http<Scheme> =>
+  Object.assign(Object.create(Proto), {
+    _tag: "Http",
+    scheme: options.scheme,
+    annotations: Context.empty()
+  })
+
+/**
  * Creates a Bearer token security scheme.
  *
  * **When to use**
@@ -158,16 +191,14 @@ const Proto = {
  * Use `HttpApiBuilder.middlewareSecurity` to implement API middleware for this
  * security scheme.
  *
+ * @see {@link http} for any HTTP authorization security scheme
  * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link apiKey} for an API-key security scheme
  * @see {@link basic} for an HTTP Basic security scheme
  * @category constructors
  * @since 4.0.0
  */
-export const bearer: Bearer = Object.assign(Object.create(Proto), {
-  _tag: "Bearer",
-  annotations: Context.empty()
-})
+export const bearer: Bearer = http({ scheme: "bearer" })
 
 /**
  * Creates a DPoP-bound access-token security scheme.
@@ -182,15 +213,13 @@ export const bearer: Bearer = Object.assign(Object.create(Proto), {
  * This scheme extracts only the access-token parameter. Validate the required
  * `DPoP` proof JWT header in middleware or request schemas.
  *
+ * @see {@link http} for any HTTP authorization security scheme
  * @see {@link bearer} for a Bearer token security scheme
  * @see {@link apiKey} for an API-key security scheme
  * @category constructors
  * @since 4.0.0
  */
-export const dpop: DPoP = Object.assign(Object.create(Proto), {
-  _tag: "DPoP",
-  annotations: Context.empty()
-})
+export const dpop: DPoP = http({ scheme: "DPoP" })
 
 /**
  * Creates an API key security scheme.
@@ -208,6 +237,7 @@ export const dpop: DPoP = Object.assign(Object.create(Proto), {
  * Use `HttpApiBuilder.securitySetCookie` to set the correct cookie in a
  * handler. By default, `in` is `"header"`.
  *
+ * @see {@link http} for an HTTP authorization security scheme
  * @see {@link bearer} for a Bearer token security scheme
  * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link basic} for an HTTP Basic security scheme
@@ -237,6 +267,10 @@ export const apiKey = (options: {
  * Use `HttpApiBuilder.middlewareSecurity` to implement API middleware for this
  * security scheme.
  *
+ * `basic` is specialized rather than an alias for {@link http}, because it
+ * decodes the authorization parameter into `Credentials`.
+ *
+ * @see {@link http} for a redacted HTTP authorization parameter
  * @see {@link bearer} for a Bearer token security scheme
  * @see {@link dpop} for a DPoP-bound access-token security scheme
  * @see {@link apiKey} for an API-key security scheme

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -730,23 +730,18 @@ const makeSecurityScheme = (security: HttpApiSecurity): OpenAPISecurityScheme =>
         scheme: "basic"
       }
     }
-    case "Bearer": {
-      const format = Context.getOption(security.annotations, Format).pipe(
-        Option.map((format) => ({ bearerFormat: format })),
-        Option.getOrUndefined
-      )
+    case "Http": {
+      const format = security.scheme.toLowerCase() === "bearer"
+        ? Context.getOption(security.annotations, Format).pipe(
+          Option.map((format) => ({ bearerFormat: format })),
+          Option.getOrUndefined
+        )
+        : undefined
       return {
         ...meta,
         type: "http",
-        scheme: "bearer",
+        scheme: security.scheme,
         ...format
-      }
-    }
-    case "DPoP": {
-      return {
-        ...meta,
-        type: "http",
-        scheme: "DPoP"
       }
     }
     case "ApiKey": {

--- a/packages/effect/src/unstable/httpapi/OpenApi.ts
+++ b/packages/effect/src/unstable/httpapi/OpenApi.ts
@@ -742,6 +742,13 @@ const makeSecurityScheme = (security: HttpApiSecurity): OpenAPISecurityScheme =>
         ...format
       }
     }
+    case "DPoP": {
+      return {
+        ...meta,
+        type: "http",
+        scheme: "DPoP"
+      }
+    }
     case "ApiKey": {
       return {
         ...meta,
@@ -954,7 +961,7 @@ export interface OpenAPIComponents {
 }
 
 /**
- * Generated OpenAPI HTTP security scheme, such as bearer or basic authentication.
+ * Generated OpenAPI HTTP security scheme, such as bearer, DPoP, or basic authentication.
  *
  * @category models
  * @since 4.0.0

--- a/packages/effect/typetest/unstable/httpapi/HttpApiMiddleware.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiMiddleware.tst.ts
@@ -33,6 +33,17 @@ describe("HttpApiMiddleware", () => {
       expect(M.security).type.toBe<{ readonly cookie: HttpApiSecurity.ApiKey }>()
     })
 
+    it("HTTP security scheme", () => {
+      const signature = HttpApiSecurity.http({ scheme: "Signature" })
+      class M extends HttpApiMiddleware.Service<M>()("M", {
+        security: {
+          signature
+        }
+      }) {}
+      expect(signature).type.toBe<HttpApiSecurity.Http<"Signature">>()
+      expect(M.security).type.toBe<{ readonly signature: HttpApiSecurity.Http<"Signature"> }>()
+    })
+
     it("error + security", () => {
       class M extends HttpApiMiddleware.Service<M>()("Http/Logger", {
         error: Schema.String,

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -1322,7 +1322,7 @@ describe("HttpApi", () => {
               HttpServerRequest.fromWeb(
                 new Request("http://localhost:3000/", {
                   headers: {
-                    authorization: "DPoP foo"
+                    authorization: "dPoP  foo"
                   }
                 })
               )
@@ -1330,6 +1330,72 @@ describe("HttpApi", () => {
             Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
           )
           assert.strictEqual(Redacted.value(redacted), "foo")
+        }).pipe(Effect.provide(HttpLive)))
+
+      it.effect("DPoP authorization security rejects invalid credentials", () =>
+        Effect.gen(function*() {
+          for (const authorization of ["Bearer foo", "", "DPoP", "DPoP ", "DPoP foo bar", "DPoP foo!"]) {
+            const redacted = yield* HttpApiBuilder.securityDecode(securityDPoP).pipe(
+              Effect.provideService(
+                HttpServerRequest.HttpServerRequest,
+                HttpServerRequest.fromWeb(
+                  new Request("http://localhost:3000/", {
+                    headers: {
+                      authorization
+                    }
+                  })
+                )
+              ),
+              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+            )
+            assert.strictEqual(Redacted.value(redacted), "")
+          }
+        }).pipe(Effect.provide(HttpLive)))
+
+      it.effect("Bearer authorization security validates the scheme", () =>
+        Effect.gen(function*() {
+          for (const [authorization, expected] of [["bearer  foo", "foo"], ["DPoP foo", ""]] as const) {
+            const redacted = yield* HttpApiBuilder.securityDecode(securityBearer).pipe(
+              Effect.provideService(
+                HttpServerRequest.HttpServerRequest,
+                HttpServerRequest.fromWeb(
+                  new Request("http://localhost:3000/", {
+                    headers: {
+                      authorization
+                    }
+                  })
+                )
+              ),
+              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+            )
+            assert.strictEqual(Redacted.value(redacted), expected)
+          }
+        }).pipe(Effect.provide(HttpLive)))
+
+      it.effect("Basic authorization security validates the scheme", () =>
+        Effect.gen(function*() {
+          for (
+            const [authorization, username, password] of [
+              ["basic  Zm9vOmJhcg==", "foo", "bar"],
+              ["Bearer Zm9vOmJhcg==", "", ""]
+            ] as const
+          ) {
+            const credentials = yield* HttpApiBuilder.securityDecode(securityBasic).pipe(
+              Effect.provideService(
+                HttpServerRequest.HttpServerRequest,
+                HttpServerRequest.fromWeb(
+                  new Request("http://localhost:3000/", {
+                    headers: {
+                      authorization
+                    }
+                  })
+                )
+              ),
+              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+            )
+            assert.strictEqual(credentials.username, username)
+            assert.strictEqual(Redacted.value(credentials.password), password)
+          }
         }).pipe(Effect.provide(HttpLive)))
     })
 
@@ -1545,6 +1611,8 @@ const securityQuery = HttpApiSecurity.apiKey({
 })
 
 const securityDPoP = HttpApiSecurity.dpop
+const securityBearer = HttpApiSecurity.bearer
+const securityBasic = HttpApiSecurity.basic
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}
 

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -1379,6 +1379,29 @@ describe("HttpApi", () => {
 
       it.effect.each(
         [
+          ["signature  foo", "foo"],
+          ["Bearer foo", ""]
+        ] as const
+      )("HTTP authorization security decodes %s", ([authorization, expected]) =>
+        Effect.gen(function*() {
+          const redacted = yield* HttpApiBuilder.securityDecode(securitySignature).pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromWeb(
+                new Request("http://localhost:3000/", {
+                  headers: {
+                    authorization
+                  }
+                })
+              )
+            ),
+            Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+          )
+          assert.strictEqual(Redacted.value(redacted), expected)
+        }).pipe(Effect.provide(HttpLive)))
+
+      it.effect.each(
+        [
           ["basic  Zm9vOmJhcg==", "foo", "bar"],
           ["Bearer Zm9vOmJhcg==", "", ""]
         ] as const
@@ -1615,6 +1638,7 @@ const securityQuery = HttpApiSecurity.apiKey({
 
 const securityDPoP = HttpApiSecurity.dpop
 const securityBearer = HttpApiSecurity.bearer
+const securitySignature = HttpApiSecurity.http({ scheme: "Signature" })
 const securityBasic = HttpApiSecurity.basic
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -1313,6 +1313,24 @@ describe("HttpApi", () => {
           )
           assert.strictEqual(Redacted.value(redacted), "foo")
         }).pipe(Effect.provide(HttpLive)))
+
+      it.effect("DPoP authorization security", () =>
+        Effect.gen(function*() {
+          const redacted = yield* HttpApiBuilder.securityDecode(securityDPoP).pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromWeb(
+                new Request("http://localhost:3000/", {
+                  headers: {
+                    authorization: "DPoP foo"
+                  }
+                })
+              )
+            ),
+            Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+          )
+          assert.strictEqual(Redacted.value(redacted), "foo")
+        }).pipe(Effect.provide(HttpLive)))
     })
 
     it.effect("client responseMode decoded-and-response", () =>
@@ -1525,6 +1543,8 @@ const securityQuery = HttpApiSecurity.apiKey({
   in: "query",
   key: "api_key"
 })
+
+const securityDPoP = HttpApiSecurity.dpop
 
 class CurrentUser extends Context.Service<CurrentUser, User>()("CurrentUser") {}
 

--- a/packages/platform-node/test/HttpApi.test.ts
+++ b/packages/platform-node/test/HttpApi.test.ts
@@ -1332,70 +1332,73 @@ describe("HttpApi", () => {
           assert.strictEqual(Redacted.value(redacted), "foo")
         }).pipe(Effect.provide(HttpLive)))
 
-      it.effect("DPoP authorization security rejects invalid credentials", () =>
+      it.effect.each(["Bearer foo", "", "DPoP", "DPoP ", "DPoP foo bar", "DPoP foo!"])(
+        "DPoP authorization security rejects %s",
+        (authorization) =>
+          HttpApiBuilder.securityDecode(securityDPoP).pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromWeb(
+                new Request("http://localhost:3000/", {
+                  headers: {
+                    authorization
+                  }
+                })
+              )
+            ),
+            Effect.provideService(HttpServerRequest.ParsedSearchParams, {}),
+            Effect.map((redacted) => {
+              assert.strictEqual(Redacted.value(redacted), "")
+            }),
+            Effect.provide(HttpLive)
+          )
+      )
+
+      it.effect.each(
+        [
+          ["bearer  foo", "foo"],
+          ["DPoP foo", ""]
+        ] as const
+      )("Bearer authorization security decodes %s", ([authorization, expected]) =>
         Effect.gen(function*() {
-          for (const authorization of ["Bearer foo", "", "DPoP", "DPoP ", "DPoP foo bar", "DPoP foo!"]) {
-            const redacted = yield* HttpApiBuilder.securityDecode(securityDPoP).pipe(
-              Effect.provideService(
-                HttpServerRequest.HttpServerRequest,
-                HttpServerRequest.fromWeb(
-                  new Request("http://localhost:3000/", {
-                    headers: {
-                      authorization
-                    }
-                  })
-                )
-              ),
-              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
-            )
-            assert.strictEqual(Redacted.value(redacted), "")
-          }
+          const redacted = yield* HttpApiBuilder.securityDecode(securityBearer).pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromWeb(
+                new Request("http://localhost:3000/", {
+                  headers: {
+                    authorization
+                  }
+                })
+              )
+            ),
+            Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+          )
+          assert.strictEqual(Redacted.value(redacted), expected)
         }).pipe(Effect.provide(HttpLive)))
 
-      it.effect("Bearer authorization security validates the scheme", () =>
+      it.effect.each(
+        [
+          ["basic  Zm9vOmJhcg==", "foo", "bar"],
+          ["Bearer Zm9vOmJhcg==", "", ""]
+        ] as const
+      )("Basic authorization security decodes %s", ([authorization, username, password]) =>
         Effect.gen(function*() {
-          for (const [authorization, expected] of [["bearer  foo", "foo"], ["DPoP foo", ""]] as const) {
-            const redacted = yield* HttpApiBuilder.securityDecode(securityBearer).pipe(
-              Effect.provideService(
-                HttpServerRequest.HttpServerRequest,
-                HttpServerRequest.fromWeb(
-                  new Request("http://localhost:3000/", {
-                    headers: {
-                      authorization
-                    }
-                  })
-                )
-              ),
-              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
-            )
-            assert.strictEqual(Redacted.value(redacted), expected)
-          }
-        }).pipe(Effect.provide(HttpLive)))
-
-      it.effect("Basic authorization security validates the scheme", () =>
-        Effect.gen(function*() {
-          for (
-            const [authorization, username, password] of [
-              ["basic  Zm9vOmJhcg==", "foo", "bar"],
-              ["Bearer Zm9vOmJhcg==", "", ""]
-            ] as const
-          ) {
-            const credentials = yield* HttpApiBuilder.securityDecode(securityBasic).pipe(
-              Effect.provideService(
-                HttpServerRequest.HttpServerRequest,
-                HttpServerRequest.fromWeb(
-                  new Request("http://localhost:3000/", {
-                    headers: {
-                      authorization
-                    }
-                  })
-                )
-              ),
-              Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
-            )
-            assert.strictEqual(credentials.username, username)
-            assert.strictEqual(Redacted.value(credentials.password), password)
-          }
+          const credentials = yield* HttpApiBuilder.securityDecode(securityBasic).pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromWeb(
+                new Request("http://localhost:3000/", {
+                  headers: {
+                    authorization
+                  }
+                })
+              )
+            ),
+            Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+          )
+          assert.strictEqual(credentials.username, username)
+          assert.strictEqual(Redacted.value(credentials.password), password)
         }).pipe(Effect.provide(HttpLive)))
     })
 

--- a/packages/platform-node/test/OpenApi.test.ts
+++ b/packages/platform-node/test/OpenApi.test.ts
@@ -8,6 +8,7 @@ import {
   HttpApiGroup,
   HttpApiMiddleware,
   HttpApiSchema,
+  HttpApiSecurity,
   OpenApi
 } from "effect/unstable/httpapi"
 
@@ -76,6 +77,31 @@ describe("OpenAPI spec", () => {
         }))
       const spec = OpenApi.fromApi(Api)
       assert.deepStrictEqual(spec.tags, [{ name: "A" }])
+    })
+  })
+
+  describe("security", () => {
+    it("DPoP", () => {
+      class Authorization extends HttpApiMiddleware.Service<Authorization>()("Authorization", {
+        security: {
+          dpop: HttpApiSecurity.dpop
+        }
+      }) {}
+
+      const Api = HttpApi.make("api").add(
+        HttpApiGroup.make("group")
+          .add(HttpApiEndpoint.get("a", "/a"))
+          .middleware(Authorization)
+      )
+      const spec = OpenApi.fromApi(Api)
+
+      assert.deepStrictEqual(spec.components.securitySchemes, {
+        dpop: {
+          type: "http",
+          scheme: "DPoP"
+        }
+      })
+      assert.deepStrictEqual(spec.paths["/a"].get?.security, [{ dpop: [] }])
     })
   })
 

--- a/packages/platform-node/test/OpenApi.test.ts
+++ b/packages/platform-node/test/OpenApi.test.ts
@@ -103,6 +103,29 @@ describe("OpenAPI spec", () => {
       })
       assert.deepStrictEqual(spec.paths["/a"].get?.security, [{ dpop: [] }])
     })
+
+    it("custom HTTP authentication scheme", () => {
+      class Authorization extends HttpApiMiddleware.Service<Authorization>()("Authorization", {
+        security: {
+          signature: HttpApiSecurity.http({ scheme: "Signature" })
+        }
+      }) {}
+
+      const Api = HttpApi.make("api").add(
+        HttpApiGroup.make("group")
+          .add(HttpApiEndpoint.get("a", "/a"))
+          .middleware(Authorization)
+      )
+      const spec = OpenApi.fromApi(Api)
+
+      assert.deepStrictEqual(spec.components.securitySchemes, {
+        signature: {
+          type: "http",
+          scheme: "Signature"
+        }
+      })
+      assert.deepStrictEqual(spec.paths["/a"].get?.security, [{ signature: [] }])
+    })
   })
 
   describe("group", () => {

--- a/packages/tools/openapi-generator/src/HttpApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/HttpApiTransformer.ts
@@ -477,6 +477,10 @@ const renderSecurityScheme = (securityScheme: ParsedOpenApiSecurityScheme): stri
       source = "HttpApiSecurity.dpop"
       break
     }
+    case "http": {
+      source = `HttpApiSecurity.http({ scheme: ${JSON.stringify(securityScheme.scheme!)} })`
+      break
+    }
     case "apiKey": {
       source = `HttpApiSecurity.apiKey({ key: ${JSON.stringify(securityScheme.key!)}, in: ${
         JSON.stringify(securityScheme.in!)

--- a/packages/tools/openapi-generator/src/HttpApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/HttpApiTransformer.ts
@@ -473,6 +473,10 @@ const renderSecurityScheme = (securityScheme: ParsedOpenApiSecurityScheme): stri
       source = "HttpApiSecurity.bearer"
       break
     }
+    case "dpop": {
+      source = "HttpApiSecurity.dpop"
+      break
+    }
     case "apiKey": {
       source = `HttpApiSecurity.apiKey({ key: ${JSON.stringify(securityScheme.key!)}, in: ${
         JSON.stringify(securityScheme.in!)

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -974,6 +974,15 @@ const parseSecuritySchemes = (
           key: undefined,
           in: undefined
         })
+      } else if (normalizedScheme === "dpop") {
+        parsed.push({
+          name,
+          type: "dpop",
+          description: Utils.nonEmptyString(scheme.description),
+          bearerFormat: undefined,
+          key: undefined,
+          in: undefined
+        })
       }
       continue
     }

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -960,6 +960,7 @@ const parseSecuritySchemes = (
         parsed.push({
           name,
           type: "basic",
+          scheme: undefined,
           description: Utils.nonEmptyString(scheme.description),
           bearerFormat: undefined,
           key: undefined,
@@ -969,6 +970,7 @@ const parseSecuritySchemes = (
         parsed.push({
           name,
           type: "bearer",
+          scheme: undefined,
           description: Utils.nonEmptyString(scheme.description),
           bearerFormat: Utils.nonEmptyString(scheme.bearerFormat),
           key: undefined,
@@ -978,6 +980,17 @@ const parseSecuritySchemes = (
         parsed.push({
           name,
           type: "dpop",
+          scheme: undefined,
+          description: Utils.nonEmptyString(scheme.description),
+          bearerFormat: undefined,
+          key: undefined,
+          in: undefined
+        })
+      } else {
+        parsed.push({
+          name,
+          type: "http",
+          scheme: scheme.scheme,
           description: Utils.nonEmptyString(scheme.description),
           bearerFormat: undefined,
           key: undefined,
@@ -995,6 +1008,7 @@ const parseSecuritySchemes = (
       parsed.push({
         name,
         type: "apiKey",
+        scheme: undefined,
         description: Utils.nonEmptyString(scheme.description),
         bearerFormat: undefined,
         key: scheme.name,

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -54,7 +54,8 @@ export interface ParsedOpenApiTag {
  */
 export interface ParsedOpenApiSecurityScheme {
   readonly name: string
-  readonly type: "basic" | "bearer" | "dpop" | "apiKey"
+  readonly type: "basic" | "bearer" | "dpop" | "http" | "apiKey"
+  readonly scheme: string | undefined
   readonly description: string | undefined
   readonly bearerFormat: string | undefined
   readonly key: string | undefined

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -54,7 +54,7 @@ export interface ParsedOpenApiTag {
  */
 export interface ParsedOpenApiSecurityScheme {
   readonly name: string
-  readonly type: "basic" | "bearer" | "apiKey"
+  readonly type: "basic" | "bearer" | "dpop" | "apiKey"
   readonly description: string | undefined
   readonly bearerFormat: string | undefined
   readonly key: string | undefined

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -1313,6 +1313,7 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
                   { apiKeyAuth: [] },
                   { bearerAuth: [] },
                   { dpopAuth: [] },
+                  { signatureAuth: [] },
                   { apiKeyAuth: [], basicAuth: [] }
                 ]
               }
@@ -1354,6 +1355,11 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
                 type: "http",
                 scheme: "DPoP",
                 description: "DPoP-bound token"
+              },
+              signatureAuth: {
+                type: "http",
+                scheme: "Signature",
+                description: "Signed request"
               }
             }
           },
@@ -1366,9 +1372,10 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
             `const BearerAuthSecurity = HttpApiSecurity.bearer.pipe(HttpApiSecurity.annotate(OpenApi.Description, "Bearer token")).pipe(HttpApiSecurity.annotate(OpenApi.Format, "JWT"))`,
             `const BasicAuthSecurity = HttpApiSecurity.basic`,
             `const DpopAuthSecurity = HttpApiSecurity.dpop.pipe(HttpApiSecurity.annotate(OpenApi.Description, "DPoP-bound token"))`,
-            `class ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware>()("apiKeyAuth | bearerAuth | dpopAuth security", { security: { "apiKeyAuth": ApiKeyAuthSecurity, "bearerAuth": BearerAuthSecurity, "dpopAuth": DpopAuthSecurity } }) {}`,
+            `const SignatureAuthSecurity = HttpApiSecurity.http({ scheme: "Signature" }).pipe(HttpApiSecurity.annotate(OpenApi.Description, "Signed request"))`,
+            `class ApiKeyAuthOrBearerAuthOrDpopAuthOrSignatureAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthOrBearerAuthOrDpopAuthOrSignatureAuthSecurityMiddleware>()("apiKeyAuth | bearerAuth | dpopAuth | signatureAuth security", { security: { "apiKeyAuth": ApiKeyAuthSecurity, "bearerAuth": BearerAuthSecurity, "dpopAuth": DpopAuthSecurity, "signatureAuth": SignatureAuthSecurity } }) {}`,
             `class ApiKeyAuthAndBasicAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthAndBasicAuthSecurityMiddleware>()("apiKeyAuth & basicAuth security") {}`,
-            `HttpApiEndpoint.get("getSecure", "/secure", { success: HttpApiSchema.Empty(200) })\n      .middleware(ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware)\n      .middleware(ApiKeyAuthAndBasicAuthSecurityMiddleware)`,
+            `HttpApiEndpoint.get("getSecure", "/secure", { success: HttpApiSchema.Empty(200) })\n      .middleware(ApiKeyAuthOrBearerAuthOrDpopAuthOrSignatureAuthSecurityMiddleware)\n      .middleware(ApiKeyAuthAndBasicAuthSecurityMiddleware)`,
             `HttpApiEndpoint.get("getPublic", "/public", { success: HttpApiSchema.Empty(200) })`
           ],
           excludes: [

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -1312,6 +1312,7 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
                 security: [
                   { apiKeyAuth: [] },
                   { bearerAuth: [] },
+                  { dpopAuth: [] },
                   { apiKeyAuth: [], basicAuth: [] }
                 ]
               }
@@ -1348,6 +1349,11 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
               basicAuth: {
                 type: "http",
                 scheme: "basic"
+              },
+              dpopAuth: {
+                type: "http",
+                scheme: "DPoP",
+                description: "DPoP-bound token"
               }
             }
           },
@@ -1359,9 +1365,10 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
             `const ApiKeyAuthSecurity = HttpApiSecurity.apiKey({ key: "x-api-key", in: "header" }).pipe(HttpApiSecurity.annotate(OpenApi.Description, "API key"))`,
             `const BearerAuthSecurity = HttpApiSecurity.bearer.pipe(HttpApiSecurity.annotate(OpenApi.Description, "Bearer token")).pipe(HttpApiSecurity.annotate(OpenApi.Format, "JWT"))`,
             `const BasicAuthSecurity = HttpApiSecurity.basic`,
-            `class ApiKeyAuthOrBearerAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthOrBearerAuthSecurityMiddleware>()("apiKeyAuth | bearerAuth security", { security: { "apiKeyAuth": ApiKeyAuthSecurity, "bearerAuth": BearerAuthSecurity } }) {}`,
+            `const DpopAuthSecurity = HttpApiSecurity.dpop.pipe(HttpApiSecurity.annotate(OpenApi.Description, "DPoP-bound token"))`,
+            `class ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware>()("apiKeyAuth | bearerAuth | dpopAuth security", { security: { "apiKeyAuth": ApiKeyAuthSecurity, "bearerAuth": BearerAuthSecurity, "dpopAuth": DpopAuthSecurity } }) {}`,
             `class ApiKeyAuthAndBasicAuthSecurityMiddleware extends HttpApiMiddleware.Service<ApiKeyAuthAndBasicAuthSecurityMiddleware>()("apiKeyAuth & basicAuth security") {}`,
-            `HttpApiEndpoint.get("getSecure", "/secure", { success: HttpApiSchema.Empty(200) })\n      .middleware(ApiKeyAuthOrBearerAuthSecurityMiddleware)\n      .middleware(ApiKeyAuthAndBasicAuthSecurityMiddleware)`,
+            `HttpApiEndpoint.get("getSecure", "/secure", { success: HttpApiSchema.Empty(200) })\n      .middleware(ApiKeyAuthOrBearerAuthOrDpopAuthSecurityMiddleware)\n      .middleware(ApiKeyAuthAndBasicAuthSecurityMiddleware)`,
             `HttpApiEndpoint.get("getPublic", "/public", { success: HttpApiSchema.Empty(200) })`
           ],
           excludes: [


### PR DESCRIPTION
## Summary

- add `HttpApiSecurity.http({ scheme })` for arbitrary HTTP authorization schemes
- express `HttpApiSecurity.bearer` and `HttpApiSecurity.dpop` as convenience declarations on the generic HTTP scheme
- validate and decode token68 credentials for HTTP authorization schemes and specialized `Basic` authentication
- emit and preserve arbitrary OpenAPI `{ type: "http", scheme }` security schemes in generated `HttpApi` modules
- cover generic runtime extraction, DPoP extraction, invalid/wrong-scheme credentials, OpenAPI output, generator output, and public API typing

## Why

`HttpApi` can currently extract DPoP authorization values only by declaring an API key in the `authorization` header. That exposes the raw header and documents the security scheme incorrectly in OpenAPI. DPoP is not the only HTTP authorization scheme that needs this capability, so the API now models HTTP authentication directly:

```ts
HttpApiSecurity.http({ scheme: "Signature" })
HttpApiSecurity.dpop // equivalent convenience declaration for scheme "DPoP"
HttpApiSecurity.bearer // equivalent convenience declaration for scheme "bearer"
```

HTTP authentication declarations must also enforce their declared scheme. Without validation, a `Bearer` authorization value can be sliced into an apparent DPoP credential because the prefixes have the same length. The decoder now validates the authentication scheme case-insensitively and requires token68 credential syntax before passing a value to middleware; invalid inputs yield the existing empty-credential result for middleware rejection.

`HttpApiSecurity.basic` remains specialized rather than being an alias for `http({ scheme: "basic" })`, because it decodes the authorization parameter into `{ username, password }`. Generic HTTP schemes expose their authorization parameter as a redacted value.

## Usage

A protected DPoP resource declares `HttpApiSecurity.dpop` once, then uses the same middleware to require the companion `DPoP` proof header and delegate RFC 9449 validation to an application service. The verification service implementation is intentionally omitted here: token validation, JWS verification, replay storage, nonce policy, and request URI policy belong to the application.

```ts
import { Context, Effect, Layer, Redacted, Schema } from "effect"
import { HttpServerRequest } from "effect/unstable/http"
import {
  HttpApi,
  HttpApiBuilder,
  HttpApiEndpoint,
  HttpApiError,
  HttpApiGroup,
  HttpApiMiddleware,
  HttpApiSecurity
} from "effect/unstable/httpapi"

interface RelayClient {
  readonly subject: string
}

class CurrentRelayClient extends Context.Service<CurrentRelayClient, RelayClient>()("CurrentRelayClient") {}

class VerifyDPoPProtectedResource extends Context.Service<VerifyDPoPProtectedResource, {
  readonly verify: (input: {
    readonly accessToken: Redacted.Redacted
    readonly proofJwt: Redacted.Redacted
    readonly request: HttpServerRequest.HttpServerRequest
  }) => Effect.Effect<RelayClient, HttpApiError.Unauthorized>
}>()("VerifyDPoPProtectedResource") {}

class RelayDPoPAuth extends HttpApiMiddleware.Service<RelayDPoPAuth, {
  provides: CurrentRelayClient
  requires: VerifyDPoPProtectedResource
}>()("RelayDPoPAuth", {
  error: HttpApiError.UnauthorizedNoContent,
  security: {
    dpop: HttpApiSecurity.dpop
  }
}) {}

const RelayDPoPAuthLive = Layer.succeed(RelayDPoPAuth)({
  dpop: Effect.fnUntraced(function*(handler, { credential }) {
    const request = yield* HttpServerRequest.HttpServerRequest
    const proofJwt = request.headers.dpop
    if (proofJwt.length === 0) {
      return yield* Effect.fail(new HttpApiError.Unauthorized({}))
    }

    const verifier = yield* VerifyDPoPProtectedResource
    const client = yield* verifier.verify({
      accessToken: credential,
      proofJwt: Redacted.make(proofJwt),
      request
    })

    return yield* Effect.provideService(handler, CurrentRelayClient, client)
  })
})

class RelayApi extends HttpApiGroup.make("relay")
  .add(HttpApiEndpoint.get("status", "/status", {
    success: Schema.Struct({ subject: Schema.String })
  }))
  .middleware(RelayDPoPAuth)
{}

class Api extends HttpApi.make("api").add(RelayApi) {}

const RelayApiLive = HttpApiBuilder.group(Api, "relay", (handlers) =>
  handlers.handle("status", Effect.fnUntraced(function*() {
    const client = yield* CurrentRelayClient
    return { subject: client.subject }
  }))
)

const ApiLive = HttpApiBuilder.layer(Api).pipe(
  Layer.provide(RelayApiLive),
  Layer.provide(RelayDPoPAuthLive)
)
```

`credential` is the access token extracted from `Authorization: DPoP <access-token>`. `ApiLive` requires an application layer for `VerifyDPoPProtectedResource`, which verifies the presented access token together with the proof JWT.

The proof header should not be declared as another security entry alongside `dpop`, because security entries are alternatives; checking it in the same middleware expresses that both token and proof are required.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/platform-node/test/HttpApi.test.ts packages/platform-node/test/OpenApi.test.ts packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`
- `pnpm test-types packages/effect/typetest/unstable/httpapi/HttpApiMiddleware.tst.ts`
- `pnpm docgen` from `packages/effect`
- `pnpm docgen` from `packages/tools/openapi-generator` (no docgen modules configured)
- `pnpm exec tsgo -p packages/effect/tsconfig.json --noEmit`
- `pnpm exec tsgo -p packages/tools/openapi-generator/tsconfig.json --noEmit`
- `pnpm check:tsgo` (exited successfully while reporting existing diagnostics in `packages/effect/typetest/Effect.tst.ts`)
