### PR TITLE
EFF-823 Add custom HTTP security scheme generation

### DIFF
--- a/.changeset/custom-http-security-openapi-generator.md
+++ b/.changeset/custom-http-security-openapi-generator.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Add HttpApi generation support for custom OpenAPI HTTP security schemes.

--- a/packages/tools/openapi-generator/src/HttpApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/HttpApiTransformer.ts
@@ -473,6 +473,10 @@ const renderSecurityScheme = (securityScheme: ParsedOpenApiSecurityScheme): stri
       source = "HttpApiSecurity.bearer"
       break
     }
+    case "http": {
+      source = `HttpApiSecurity.http({ scheme: ${JSON.stringify(securityScheme.scheme!)} })`
+      break
+    }
     case "apiKey": {
       source = `HttpApiSecurity.apiKey({ key: ${JSON.stringify(securityScheme.key!)}, in: ${
         JSON.stringify(securityScheme.in!)
@@ -484,7 +488,9 @@ const renderSecurityScheme = (securityScheme: ParsedOpenApiSecurityScheme): stri
   if (securityScheme.description !== undefined) {
     source += `.pipe(HttpApiSecurity.annotate(OpenApi.Description, ${JSON.stringify(securityScheme.description)}))`
   }
-  if (securityScheme.type === "bearer" && securityScheme.bearerFormat !== undefined) {
+  if (
+    (securityScheme.type === "bearer" || securityScheme.type === "http") && securityScheme.bearerFormat !== undefined
+  ) {
     source += `.pipe(HttpApiSecurity.annotate(OpenApi.Format, ${JSON.stringify(securityScheme.bearerFormat)}))`
   }
 

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -954,7 +954,7 @@ const parseSecuritySchemes = (
       continue
     }
 
-    if (scheme.type === "http") {
+    if (scheme.type === "http" && typeof scheme.scheme === "string") {
       const normalizedScheme = scheme.scheme.toLowerCase()
       if (normalizedScheme === "basic") {
         parsed.push({
@@ -962,6 +962,7 @@ const parseSecuritySchemes = (
           type: "basic",
           description: Utils.nonEmptyString(scheme.description),
           bearerFormat: undefined,
+          scheme: undefined,
           key: undefined,
           in: undefined
         })
@@ -971,6 +972,17 @@ const parseSecuritySchemes = (
           type: "bearer",
           description: Utils.nonEmptyString(scheme.description),
           bearerFormat: Utils.nonEmptyString(scheme.bearerFormat),
+          scheme: undefined,
+          key: undefined,
+          in: undefined
+        })
+      } else {
+        parsed.push({
+          name,
+          type: "http",
+          description: Utils.nonEmptyString(scheme.description),
+          bearerFormat: Utils.nonEmptyString(scheme.bearerFormat),
+          scheme: scheme.scheme,
           key: undefined,
           in: undefined
         })
@@ -988,6 +1000,7 @@ const parseSecuritySchemes = (
         type: "apiKey",
         description: Utils.nonEmptyString(scheme.description),
         bearerFormat: undefined,
+        scheme: undefined,
         key: scheme.name,
         in: scheme.in
       })

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -54,9 +54,10 @@ export interface ParsedOpenApiTag {
  */
 export interface ParsedOpenApiSecurityScheme {
   readonly name: string
-  readonly type: "basic" | "bearer" | "apiKey"
+  readonly type: "basic" | "bearer" | "apiKey" | "http"
   readonly description: string | undefined
   readonly bearerFormat: string | undefined
+  readonly scheme: string | undefined
   readonly key: string | undefined
   readonly in: "header" | "query" | "cookie" | undefined
 }

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -1378,6 +1378,52 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
         }
       ))
 
+    it.effect("generates custom http security schemes", () =>
+      assertHttpApiWithWarnings(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Custom Security API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/secure": {
+              get: {
+                operationId: "getSecure",
+                parameters: [],
+                responses: {
+                  200: {
+                    description: "Secure"
+                  }
+                },
+                tags: ["Security"],
+                security: [{ digestAuth: [] }]
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            securitySchemes: {
+              digestAuth: {
+                type: "http",
+                scheme: "Digest",
+                bearerFormat: "DigestToken",
+                description: "Digest token"
+              }
+            }
+          },
+          security: [],
+          tags: [{ name: "Security" }]
+        },
+        {
+          includes: [
+            `const DigestAuthSecurity = HttpApiSecurity.http({ scheme: "Digest" }).pipe(HttpApiSecurity.annotate(OpenApi.Description, "Digest token")).pipe(HttpApiSecurity.annotate(OpenApi.Format, "DigestToken"))`,
+            `class DigestAuthSecurityMiddleware extends HttpApiMiddleware.Service<DigestAuthSecurityMiddleware>()("digestAuth security", { security: { "digestAuth": DigestAuthSecurity } }) {}`
+          ],
+          warnings: []
+        }
+      ))
+
     it.effect("inherits global security and respects operation-level clearing", () =>
       assertHttpApiWithWarnings(
         {


### PR DESCRIPTION
## Summary
- Parse custom OpenAPI HTTP security schemes in the openapi-generator HttpApi pipeline.
- Render custom schemes as `HttpApiSecurity.http({ scheme })` while preserving description/format annotations.
- Add a regression test and changeset for @effect/openapi-generator.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/tools/openapi-generator/test/OpenApiGenerator.test.ts`
- `pnpm --filter @effect/openapi-generator check`
- `pnpm check:tsgo` (fails in unrelated `packages/effect/typetest/Effect.tst.ts` missing `OtherError` expected errors)