### PR TITLE
fix(vitest): preserve subproperties on chained access through it proxy

### DIFF
--- a/.changeset/fix-vitest-it-proxy-subproperties.md
+++ b/.changeset/fix-vitest-it-proxy-subproperties.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Fix `it.describe.each`, `it.skip.each`, `it.only.each` (and similar chained access on the `it` proxy) by removing an unnecessary `value.bind(target)` from `makeItProxy`'s `get` trap. The bind stripped each function's own properties (`.each`, `.skip`, `.only`, ...), so `it.describe.each` resolved to `undefined` and threw `TypeError: it.describe.each is not a function`.

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -64,8 +64,7 @@ const makeItProxy = <Methods extends object>(
       if (property in overrides) {
         return Reflect.get(overrides, property)
       }
-      const value = Reflect.get(target, property, receiver)
-      return typeof value === "function" ? value.bind(target) : value
+      return Reflect.get(target, property, receiver)
     }
   })
 

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -33,6 +33,25 @@ it.effect.skip(
   () => Effect.die("skipped anyway")
 )
 
+// chained access through proxy preserves subproperties (regression for
+// https://github.com/Effect-TS/effect-smol/issues/2301)
+
+it.describe("it.describe.each", () => {
+  it.describe.each(["a", "b"] as const)("%s", (text) => {
+    it("matches the case label", () => {
+      assert.include(["a", "b"], text)
+    })
+  })
+})
+
+it.skip.each([1, 2])("it.skip.each is skipped (%s)", (n) => {
+  assert.fail(`should never run for ${n}`)
+})
+
+it.only.each([] as Array<number>)("it.only.each has no cases", () => {
+  assert.fail("no cases registered")
+})
+
 // skipIf
 
 it.effect.skipIf(true)("effect skipIf (true)", () => Effect.die("skipped anyway"))


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Closes Effect-TS/effect#6348.

`makeItProxy` in `packages/vitest/src/internal/internal.ts` returned `value.bind(target)` whenever a non-override property access produced a function. Binding strips the function's own properties, so chained access like `it.describe.each(...)`, `it.skip.each(...)`, or `it.only.each(...)` resolved the chained step to `undefined` and threw `TypeError: it.describe.each is not a function`.

`Reflect.get(target, property, receiver)` already returns the underlying vitest functions correctly; vitest's chainable APIs do not depend on `this === V.it`. Removing the bind restores chained access without changing direct-call behavior.

Adds a regression case in `packages/vitest/test/index.test.ts` covering `it.describe.each`, `it.skip.each`, and `it.only.each`. With the bind removed the suite reports `26 passed | 1 expected fail | 6 skipped`; reverting only the source change (test in place) reproduces the reporter's error against `it.skip.each`.