### PR TITLE
fix(HttpApi): strip space delimiter when decoding bearer/http credentials

### DIFF
--- a/.changeset/wild-suns-bearer-space.md
+++ b/.changeset/wild-suns-bearer-space.md
@@ -2,6 +2,4 @@
 "effect": patch
 ---
 
-Fix `HttpApiSecurity` bearer/http credential gaining a leading space
-
-`securityDecode` sliced `schemeLength` off the `Authorization` header, but the header is `"<scheme> <credential>"`, so it left the delimiter space attached to the credential (e.g. `Bearer abc123` decoded to `" abc123"`). It now slices `schemeLength + 1` to skip the space.
+Fix `HttpApiSecurity` bearer/http credential decoding

--- a/.changeset/wild-suns-bearer-space.md
+++ b/.changeset/wild-suns-bearer-space.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Fix `HttpApiSecurity` bearer/http credential gaining a leading space
+
+`securityDecode` sliced `schemeLength` off the `Authorization` header, but the header is `"<scheme> <credential>"`, so it left the delimiter space attached to the credential (e.g. `Bearer abc123` decoded to `" abc123"`). It now slices `schemeLength + 1` to skip the space.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -446,9 +446,7 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
     case "Http": {
       return Effect.map(
         HttpServerRequest,
-        // The `Authorization` header is `"<scheme> <credential>"`, so skip the
-        // scheme name plus the single space delimiter that separates it from
-        // the credential. Slicing only `schemeLength` leaves a leading space.
+        // schemeLength + space
         (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength + 1)) as any
       )
     }

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -446,7 +446,10 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
     case "Http": {
       return Effect.map(
         HttpServerRequest,
-        (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength)) as any
+        // The `Authorization` header is `"<scheme> <credential>"`, so skip the
+        // scheme name plus the single space delimiter that separates it from
+        // the credential. Slicing only `schemeLength` leaves a leading space.
+        (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength + 1)) as any
       )
     }
     case "ApiKey": {

--- a/packages/effect/test/unstable/httpapi/HttpApiSecurity.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSecurity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "@effect/vitest"
+import { strictEqual } from "@effect/vitest/utils"
+import { Effect, Redacted } from "effect"
+import { HttpClientRequest, HttpServerRequest } from "effect/unstable/http"
+import { HttpApiBuilder, HttpApiSecurity } from "effect/unstable/httpapi"
+
+const decode = (security: HttpApiSecurity.HttpApiSecurity, authorization: string) =>
+  HttpApiBuilder.securityDecode(security).pipe(
+    Effect.provideService(
+      HttpServerRequest.HttpServerRequest,
+      HttpServerRequest.fromWeb(new Request("http://localhost/", { headers: { authorization } }))
+    ),
+    Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+  )
+
+describe("HttpApiSecurity", () => {
+  describe("securityDecode", () => {
+    it.effect("decodes a bearer token without a leading space", () =>
+      Effect.gen(function*() {
+        const token = "abc123"
+        // build the header exactly as a client does
+        const { headers } = HttpClientRequest.get("http://localhost/").pipe(
+          HttpClientRequest.bearerToken(token)
+        )
+        const credential = yield* decode(HttpApiSecurity.bearer, headers.authorization!)
+        strictEqual(Redacted.value(credential), token)
+      }))
+
+    it.effect("decodes a custom http scheme without a leading space", () =>
+      Effect.gen(function*() {
+        const credential = yield* decode(HttpApiSecurity.http({ scheme: "Token" }), "Token abc123")
+        strictEqual(Redacted.value(credential), "abc123")
+      }))
+  })
+})

--- a/packages/effect/test/unstable/httpapi/HttpApiSecurity.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiSecurity.test.ts
@@ -4,31 +4,34 @@ import { Effect, Redacted } from "effect"
 import { HttpClientRequest, HttpServerRequest } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiSecurity } from "effect/unstable/httpapi"
 
-const decode = (security: HttpApiSecurity.HttpApiSecurity, authorization: string) =>
-  HttpApiBuilder.securityDecode(security).pipe(
-    Effect.provideService(
-      HttpServerRequest.HttpServerRequest,
-      HttpServerRequest.fromWeb(new Request("http://localhost/", { headers: { authorization } }))
-    ),
-    Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
-  )
-
 describe("HttpApiSecurity", () => {
   describe("securityDecode", () => {
     it.effect("decodes a bearer token without a leading space", () =>
       Effect.gen(function*() {
         const token = "abc123"
-        // build the header exactly as a client does
         const { headers } = HttpClientRequest.get("http://localhost/").pipe(
           HttpClientRequest.bearerToken(token)
         )
-        const credential = yield* decode(HttpApiSecurity.bearer, headers.authorization!)
+        const credential = yield* HttpApiBuilder.securityDecode(HttpApiSecurity.bearer).pipe(
+          Effect.provideService(
+            HttpServerRequest.HttpServerRequest,
+            HttpServerRequest.fromWeb(new Request("http://localhost/", { headers }))
+          ),
+          Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+        )
+
         strictEqual(Redacted.value(credential), token)
       }))
 
     it.effect("decodes a custom http scheme without a leading space", () =>
       Effect.gen(function*() {
-        const credential = yield* decode(HttpApiSecurity.http({ scheme: "Token" }), "Token abc123")
+        const credential = yield* HttpApiBuilder.securityDecode(HttpApiSecurity.http({ scheme: "Token" })).pipe(
+          Effect.provideService(
+            HttpServerRequest.HttpServerRequest,
+            HttpServerRequest.fromWeb(new Request("http://localhost/", { headers: { authorization: "Token abc123" } }))
+          ),
+          Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+        )
         strictEqual(Redacted.value(credential), "abc123")
       }))
   })


### PR DESCRIPTION
Closes #2305

`securityDecode` slices `schemeLength` off the `Authorization` header, but the header is `"<scheme> <credential>"` — so the single space separating the scheme from the credential stays attached to the decoded value. Every `bearer`/`http` credential decodes with a leading space (`basic` is unaffected — it still uses the `basicLen = "Basic ".length` constant).

```diff
- (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength)) as any
+ (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength + 1)) as any
```

```ts
// before:  "Bearer abc123".slice("Bearer".length /* 6 */) === " abc123"
// after:   "Bearer abc123".slice("Bearer".length + 1 /* 7 */) === "abc123"
```

### Regression

Introduced in 361ca30eb6e134feece547d6e00f82be4cb23f75 (#2291, "Add HttpApiSecurity.http for passing custom schemes"), first released in `effect@4.0.0-beta.73`. That change replaced the hard-coded ``const bearerLen = `Bearer `.length`` (7, which included the delimiter space) with `schemeLength: options.scheme.length` (6) and `slice(self.schemeLength)`, dropping the `+ 1`. Bisection: `beta.72` good, `beta.73` bad.

### Impact

Any HTTP API guarded by `HttpApiSecurity.bearer` (or a custom `HttpApiSecurity.http({ scheme })`) rejects valid credentials, because the server-side decoded token is one byte longer than what the client sent.

### Test

Added `HttpApiSecurity.test.ts` exercising `securityDecode` for both `bearer` and a custom `http` scheme. Verified it fails on `main` (`Received: " abc123"`) and passes with the fix.
