### PR TITLE
Validate StructWithRest index signatures, closes #2245

### DIFF
--- a/.changeset/fix-structwithrest-index-signatures.md
+++ b/.changeset/fix-structwithrest-index-signatures.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/ai-openai": patch
+---
+
+Validate `Schema.StructWithRest` fixed fields against rest index signatures at the type level so schemas cannot be constructed with incompatible decoded, encoded, or make shapes. This keeps `StructWithRest` types sound and updates the generated OpenAI conversation-items request schema to keep accepting arbitrary additional fields under the stricter validation.

--- a/packages/ai/openai/src/Generated.ts
+++ b/packages/ai/openai/src/Generated.ts
@@ -28917,7 +28917,7 @@ export const CreateConversationItemsRequestJson = Schema.StructWithRest(
       "description": "The items to add to the conversation. You may add up to 20 items at a time.\n"
     }).check(Schema.isMaxLength(20))
   }),
-  [Schema.Record(Schema.String, Schema.Json)]
+  [Schema.Record(Schema.String, Schema.Unknown)]
 )
 export type CreateConversationItems200 = ConversationItemList
 export const CreateConversationItems200 = ConversationItemList

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3680,10 +3680,10 @@ export interface StructWithRest<
  *
  * const schema = Schema.StructWithRest(
  *   Schema.Struct({ id: Schema.Number }),
- *   [Schema.Record(Schema.String, Schema.String)]
+ *   [Schema.Record(Schema.String, Schema.Number)]
  * )
  *
- * // { readonly id: number } & { readonly [x: string]: string }
+ * // { readonly id: number, readonly [x: string]: number }
  * type T = typeof schema.Type
  * ```
  *

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3532,6 +3532,14 @@ export declare namespace StructWithRest {
     Head & MergeTuple<Tail>
     : {}
 
+  type Intersect<
+    S extends Objects,
+    Records extends StructWithRest.Records,
+    Side extends "Type" | "Iso" | "Encoded" | "~type.make"
+  > =
+    & S[Side]
+    & MergeTuple<{ readonly [K in keyof Records]: Records[K][Side] }>
+
   /**
    * Computes the decoded type for `StructWithRest` by intersecting the base object
    * schema's decoded `Type` with the decoded types of all rest record schemas.
@@ -3539,9 +3547,7 @@ export declare namespace StructWithRest {
    * @category utility types
    * @since 3.10.0
    */
-  export type Type<S extends Objects, Records extends StructWithRest.Records> =
-    & S["Type"]
-    & MergeTuple<{ readonly [K in keyof Records]: Records[K]["Type"] }>
+  export type Type<S extends Objects, Records extends StructWithRest.Records> = Intersect<S, Records, "Type">
 
   /**
    * Computes the iso type for `StructWithRest` by intersecting the base object
@@ -3550,9 +3556,7 @@ export declare namespace StructWithRest {
    * @category utility types
    * @since 4.0.0
    */
-  export type Iso<S extends Objects, Records extends StructWithRest.Records> =
-    & S["Iso"]
-    & MergeTuple<{ readonly [K in keyof Records]: Records[K]["Iso"] }>
+  export type Iso<S extends Objects, Records extends StructWithRest.Records> = Intersect<S, Records, "Iso">
 
   /**
    * Computes the encoded type for `StructWithRest` by intersecting the base object
@@ -3561,31 +3565,7 @@ export declare namespace StructWithRest {
    * @category utility types
    * @since 3.10.0
    */
-  export type Encoded<S extends Objects, Records extends StructWithRest.Records> =
-    & S["Encoded"]
-    & MergeTuple<{ readonly [K in keyof Records]: Records[K]["Encoded"] }>
-
-  /**
-   * Union of the decoding service requirements of the base object schema and all
-   * rest record schemas.
-   *
-   * @category utility types
-   * @since 4.0.0
-   */
-  export type DecodingServices<S extends Objects, Records extends StructWithRest.Records> =
-    | S["DecodingServices"]
-    | { [K in keyof Records]: Records[K]["DecodingServices"] }[number]
-
-  /**
-   * Union of the encoding service requirements of the base object schema and all
-   * rest record schemas.
-   *
-   * @category utility types
-   * @since 4.0.0
-   */
-  export type EncodingServices<S extends Objects, Records extends StructWithRest.Records> =
-    | S["EncodingServices"]
-    | { [K in keyof Records]: Records[K]["EncodingServices"] }[number]
+  export type Encoded<S extends Objects, Records extends StructWithRest.Records> = Intersect<S, Records, "Encoded">
 
   /**
    * Computes the input type accepted when constructing a `StructWithRest` value by
@@ -3595,9 +3575,73 @@ export declare namespace StructWithRest {
    * @category utility types
    * @since 4.0.0
    */
-  export type MakeIn<S extends Objects, Records extends StructWithRest.Records> =
-    & S["~type.make"]
-    & MergeTuple<{ readonly [K in keyof Records]: Records[K]["~type.make"] }>
+  export type MakeIn<S extends Objects, Records extends StructWithRest.Records> = Intersect<S, Records, "~type.make">
+
+  type Services<
+    S extends Objects,
+    Records extends StructWithRest.Records,
+    Side extends "DecodingServices" | "EncodingServices"
+  > =
+    | S[Side]
+    | { [K in keyof Records]: Records[K][Side] }[number]
+
+  /**
+   * Union of the decoding service requirements of the base object schema and all
+   * rest record schemas.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type DecodingServices<S extends Objects, Records extends StructWithRest.Records> = Services<
+    S,
+    Records,
+    "DecodingServices"
+  >
+
+  /**
+   * Union of the encoding service requirements of the base object schema and all
+   * rest record schemas.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type EncodingServices<S extends Objects, Records extends StructWithRest.Records> = Services<
+    S,
+    Records,
+    "EncodingServices"
+  >
+
+  type IncompatibleKeys<A, B, OK extends (keyof A & keyof B) = Extract<keyof A, keyof B>> = {
+    [K in OK]: Required<Pick<A, K>>[K] extends B[K] ? never : K
+  }[OK]
+
+  type IncompatibleSideKeys<
+    S extends Objects,
+    Records extends StructWithRest.Records,
+    Side extends "Type" | "Encoded" | "Iso" | "~type.make"
+  > = {
+    [I in keyof Records]: Records[I][Side] extends object ? IncompatibleKeys<S[Side], Records[I][Side]> : never
+  }[number]
+
+  /**
+   * Validates that the records are compatible with the struct.
+   *
+   * @category utility types
+   * @since 4.0.0
+   */
+  export type ValidateRecords<S extends Objects, Records extends StructWithRest.Records> = [
+    | IncompatibleSideKeys<S, Records, "Type">
+    | IncompatibleSideKeys<S, Records, "Encoded">
+    | IncompatibleSideKeys<S, Records, "Iso">
+    | IncompatibleSideKeys<S, Records, "~type.make">
+  ] extends [never] ? unknown
+    : {
+      "incompatible index signatures":
+        | IncompatibleSideKeys<S, Records, "Type">
+        | IncompatibleSideKeys<S, Records, "Encoded">
+        | IncompatibleSideKeys<S, Records, "Iso">
+        | IncompatibleSideKeys<S, Records, "~type.make">
+    }
 }
 
 /**
@@ -3651,7 +3695,7 @@ export function StructWithRest<
   const Records extends StructWithRest.Records
 >(
   schema: S,
-  records: Records
+  records: Records & StructWithRest.ValidateRecords<S, Records>
 ): StructWithRest<S, Records> {
   return make(SchemaAST.structWithRest(schema.ast, records.map(SchemaAST.getAST)), { schema, records })
 }

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -3909,7 +3909,7 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
       throws(
         () =>
           Schema.StructWithRest(
-            Schema.Struct({}).pipe(Schema.encodeTo(Schema.String)),
+            Schema.Struct({}).pipe(Schema.encodeTo(Schema.Struct({}))),
             [Schema.Record(Schema.String, Schema.Number)]
           ),
         new Error(`StructWithRest does not support encodings`)

--- a/packages/effect/test/schema/representation/toCodeDocument.test.ts
+++ b/packages/effect/test/schema/representation/toCodeDocument.test.ts
@@ -1200,26 +1200,26 @@ describe("toCodeDocument", () => {
     assertSchema(
       {
         schema: Schema.StructWithRest(Schema.Struct({ a: Schema.Number }), [
-          Schema.Record(Schema.String, Schema.Boolean)
+          Schema.Record(Schema.String, Schema.Number)
         ])
       },
       {
         codes: makeCode(
-          `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Boolean)])`,
-          `{ readonly "a": number, readonly [x: string]: boolean }`
+          `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Number)])`,
+          `{ readonly "a": number, readonly [x: string]: number }`
         )
       }
     )
     assertSchema(
       {
         schema: Schema.StructWithRest(Schema.Struct({ a: Schema.Number }), [
-          Schema.Record(Schema.String, Schema.Boolean)
+          Schema.Record(Schema.String, Schema.Number)
         ]).annotate({ description: "a" })
       },
       {
         codes: makeCode(
-          `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Boolean)]).annotate({ "description": "a" })`,
-          `{ readonly "a": number, readonly [x: string]: boolean }`
+          `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Number)]).annotate({ "description": "a" })`,
+          `{ readonly "a": number, readonly [x: string]: number }`
         )
       }
     )

--- a/packages/effect/test/schema/representation/toSchema.test.ts
+++ b/packages/effect/test/schema/representation/toSchema.test.ts
@@ -90,10 +90,10 @@ describe("toSchema", () => {
     assertToSchemaRoundtrip(
       {
         schema: Schema.StructWithRest(Schema.Struct({ a: Schema.Number }), [
-          Schema.Record(Schema.String, Schema.Boolean)
+          Schema.Record(Schema.String, Schema.Number)
         ])
       },
-      `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Boolean)])`
+      `Schema.StructWithRest(Schema.Struct({ "a": Schema.Number }), [Schema.Record(Schema.String, Schema.Number)])`
     )
   })
 

--- a/packages/effect/typetest/schema/Struct.tst.ts
+++ b/packages/effect/typetest/schema/Struct.tst.ts
@@ -670,6 +670,34 @@ describe("StructWithRest", () => {
     >()
   })
 
+  it("rejects decoded fields incompatible with string index signatures", () => {
+    expect(Schema.StructWithRest).type.not.toBeCallableWith(
+      Schema.Struct({ count: Schema.NumberFromString }),
+      [Schema.Record(Schema.String, Schema.String)]
+    )
+  })
+
+  it("rejects encoded fields incompatible with string index signatures", () => {
+    expect(Schema.StructWithRest).type.not.toBeCallableWith(
+      Schema.Struct({ count: Schema.NumberFromString }),
+      [Schema.Record(Schema.String, Schema.Number)]
+    )
+  })
+
+  it("allows optionalKey fields compatible with string index signatures", () => {
+    expect(Schema.StructWithRest).type.toBeCallableWith(
+      Schema.Struct({ a: Schema.optionalKey(Schema.String) }),
+      [Schema.Record(Schema.String, Schema.String)]
+    )
+  })
+
+  it("rejects optional fields incompatible with string index signatures", () => {
+    expect(Schema.StructWithRest).type.not.toBeCallableWith(
+      Schema.Struct({ a: Schema.optional(Schema.String) }),
+      [Schema.Record(Schema.String, Schema.String)]
+    )
+  })
+
   it("records mutability and optionality", () => {
     const schema = Schema.StructWithRest(
       Schema.Struct({ a: Schema.Number }),


### PR DESCRIPTION
Reject fixed fields that are incompatible with rest record types and update the generated OpenAI schema to keep passthrough fields valid under the stricter check.
