### PR TITLE
Fix HTTP API security credential decoding

### DIFF
--- a/.changeset/fix-http-security-credential-decoding.md
+++ b/.changeset/fix-http-security-credential-decoding.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix HTTP API security credential decoding to strip the authorization scheme separator and reject tokens supplied with a different scheme.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -446,7 +446,7 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
     case "Http": {
       return Effect.map(
         HttpServerRequest,
-        (request) => Redacted.make((request.headers.authorization ?? "").slice(self.schemeLength)) as any
+        (request) => Redacted.make(decodeAuthorizationToken(request.headers.authorization, self.scheme)) as any
       )
     }
     case "ApiKey": {
@@ -475,7 +475,9 @@ export const securityDecode = <Security extends HttpApiSecurity.HttpApiSecurity>
       } as any
       return HttpServerRequest.pipe(
         Effect.flatMap((request) =>
-          Effect.fromResult(Encoding.decodeBase64String((request.headers.authorization ?? "").slice(basicLen)))
+          Effect.fromResult(
+            Encoding.decodeBase64String(decodeAuthorizationToken(request.headers.authorization, "Basic"))
+          )
         ),
         Effect.match({
           onFailure: () => empty,
@@ -521,7 +523,12 @@ export const securitySetCookie = (
 // Internal
 // -----------------------------------------------------------------------------
 
-const basicLen = `Basic `.length
+const authorizationToken = /^([^ ]+) +([-A-Za-z0-9._~+/]+=*)$/
+
+const decodeAuthorizationToken = (authorization: string | undefined, scheme: string): string => {
+  const match = authorizationToken.exec(authorization ?? "")
+  return match !== null && match[1].toLowerCase() === scheme.toLowerCase() ? match[2] : ""
+}
 
 const HandlersProto = {
   [HandlersTypeId]: {

--- a/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts
@@ -1,0 +1,42 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Redacted } from "effect"
+import { HttpServerRequest } from "effect/unstable/http"
+import { HttpApiBuilder, HttpApiSecurity } from "effect/unstable/httpapi"
+
+const decode = (authorization: string, security: HttpApiSecurity.Http = HttpApiSecurity.bearer) =>
+  HttpApiBuilder.securityDecode(security).pipe(
+    Effect.provideService(
+      HttpServerRequest.HttpServerRequest,
+      HttpServerRequest.fromWeb(
+        new Request("http://localhost", {
+          headers: { authorization }
+        })
+      )
+    ),
+    Effect.provideService(HttpServerRequest.ParsedSearchParams, {})
+  )
+
+describe("HttpApiBuilder", () => {
+  describe("securityDecode", () => {
+    it.effect("decodes bearer credentials without the authorization scheme separator", () =>
+      Effect.gen(function*() {
+        const credential = yield* decode("Bearer token")
+
+        assert.strictEqual(Redacted.value(credential), "token")
+      }))
+
+    it.effect("rejects credentials from a different authorization scheme", () =>
+      Effect.gen(function*() {
+        const credential = yield* decode("Basic token")
+
+        assert.strictEqual(Redacted.value(credential), "")
+      }))
+
+    it.effect("decodes custom HTTP authorization schemes", () =>
+      Effect.gen(function*() {
+        const credential = yield* decode("DPoP proof", HttpApiSecurity.http({ scheme: "DPoP" }))
+
+        assert.strictEqual(Redacted.value(credential), "proof")
+      }))
+  })
+})


### PR DESCRIPTION
## Summary

- restore validated HTTP authorization token decoding for generalized `HttpApiSecurity.http` schemes
- strip the scheme separator before passing credentials to security middleware
- preserve scheme validation for `Basic` decoding and add direct regression tests

## Root Cause

When `HttpApiSecurity.http` generalized bearer-style authorization schemes, `securityDecode` changed from parsing the authorization token to slicing at `scheme.length`. For a standard header such as `Authorization: Bearer token`, the middleware therefore received `" token"` rather than `"token"`. It also no longer rejected a token supplied with a different authorization scheme.

## Validation

- `DPRINT_MAX_THREADS=1 pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/httpapi/HttpApiBuilder.test.ts`
- `pnpm check:tsgo`

`DPRINT_MAX_THREADS=1` was used because the unrestricted full-tree `dprint fmt` subprocess was killed by the local OS while formatting this checkout.