### PR TITLE
[codex] Add YAML and TOML modules

### DIFF
--- a/.changeset/add-yaml-toml-modules.md
+++ b/.changeset/add-yaml-toml-modules.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Yaml` and `Toml` modules for safe document parsing, plus `Schema.fromYamlString`.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10424,6 +10424,57 @@ export function fromJsonString<S extends Top>(schema: S): fromJsonString<S> {
 }
 
 /**
+ * Type-level representation returned by {@link fromYamlString}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface fromYamlString<S extends Top> extends decodeTo<S, String> {
+  readonly "Rebuild": fromYamlString<S>
+}
+
+/**
+ * Returns a schema that decodes a YAML string and then decodes the parsed value
+ * using the given schema.
+ *
+ * **When to use**
+ *
+ * Use when you need to validate YAML-encoded configuration or document text
+ * with an existing schema.
+ *
+ * **Details**
+ *
+ * The resulting schema parses the input string as YAML before running the
+ * provided schema. Encoding runs the provided schema and then serializes the
+ * encoded value as YAML text.
+ *
+ * **Example** (Decoding YAML strings with a schema)
+ *
+ * ```ts
+ * import { Schema } from "effect"
+ *
+ * const schema = Schema.fromYamlString(
+ *   Schema.Struct({ name: Schema.String })
+ * )
+ *
+ * Schema.decodeUnknownSync(schema)("name: example")
+ * // => { name: "example" }
+ * ```
+ *
+ * @see {@link fromJsonString} for JSON text
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export function fromYamlString<S extends Top>(schema: S): fromYamlString<S> {
+  return String.annotate({
+    expected: "a string that will be decoded as YAML",
+    contentMediaType: "application/yaml",
+    contentSchema: SchemaAST.toEncoded(schema.ast)
+  }).pipe(decodeTo(schema, SchemaTransformation.fromYamlString))
+}
+
+/**
  * Type-level representation of {@link File}.
  *
  * @category file

--- a/packages/effect/src/SchemaGetter.ts
+++ b/packages/effect/src/SchemaGetter.ts
@@ -36,6 +36,7 @@
  * - Coerce to a primitive type → {@link String}, {@link Number}, {@link Boolean}, {@link BigInt}, {@link Date}
  * - Transform strings → {@link trim}, {@link capitalize}, {@link toLowerCase}, {@link toUpperCase}, {@link split}, {@link splitKeyValue}, {@link joinKeyValue}
  * - Parse/stringify JSON → {@link parseJson}, {@link stringifyJson}
+ * - Parse/stringify YAML → {@link parseYaml}, {@link stringifyYaml}
  * - Encode/decode Base64 → {@link encodeBase64}, {@link decodeBase64}, {@link decodeBase64String}
  * - Encode/decode Hex → {@link encodeHex}, {@link decodeHex}, {@link decodeHexString}
  * - Encode/decode URI components → {@link encodeUriComponent}, {@link decodeUriComponent}
@@ -96,6 +97,7 @@ import type * as Schema from "./Schema.ts"
 import type * as SchemaAST from "./SchemaAST.ts"
 import * as SchemaIssue from "./SchemaIssue.ts"
 import * as Str from "./String.ts"
+import * as Yaml from "./Yaml.ts"
 
 /**
  * Represents a composable transformation from an encoded type `E` to a decoded type `T`.
@@ -1115,6 +1117,76 @@ export function stringifyJson(options?: StringifyJsonOptions): Getter<string, un
     Effect.try({
       try: () => Option.some(JSON.stringify(input, options?.replacer, options?.space)),
       catch: (e) => new SchemaIssue.InvalidValue(Option.some(input), { message: globalThis.String(e) })
+    })
+  )
+}
+
+/**
+ * Parses a YAML string into a value.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema getter to parse a present encoded YAML string
+ * during decoding.
+ *
+ * **Details**
+ *
+ * Parse failures become `SchemaIssue.InvalidValue` values.
+ *
+ * **Example** (Parse YAML)
+ *
+ * ```ts
+ * import { SchemaGetter } from "effect"
+ *
+ * const parse = SchemaGetter.parseYaml<string>()
+ * // Getter<unknown, string>
+ * ```
+ *
+ * @see {@link stringifyYaml} for the inverse operation
+ *
+ * @category YAML getters
+ * @since 4.0.0
+ */
+export function parseYaml<E extends string>(options?: Yaml.ParseOptions): Getter<unknown, E> {
+  return transformOrFail((input) =>
+    Result.match(Yaml.parse(input, options), {
+      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onSuccess: Effect.succeed
+    })
+  )
+}
+
+/**
+ * Stringifies a present value as YAML.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema getter to serialize a present decoded value to
+ * YAML text during encoding.
+ *
+ * **Details**
+ *
+ * Stringify failures become `SchemaIssue.InvalidValue` values.
+ *
+ * **Example** (Stringify YAML)
+ *
+ * ```ts
+ * import { SchemaGetter } from "effect"
+ *
+ * const stringify = SchemaGetter.stringifyYaml()
+ * // Getter<string, unknown>
+ * ```
+ *
+ * @see {@link parseYaml} for the inverse operation
+ *
+ * @category YAML getters
+ * @since 4.0.0
+ */
+export function stringifyYaml(options?: Yaml.StringifyOptions): Getter<string, unknown> {
+  return transformOrFail((input) =>
+    Result.match(Yaml.stringify(input, options), {
+      onFailure: (e) => Effect.fail(new SchemaIssue.InvalidValue(Option.some(input), { message: e.message })),
+      onSuccess: Effect.succeed
     })
   )
 }

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -43,6 +43,7 @@
  * - Base64 ↔ string → {@link stringFromBase64String}
  * - URI component ↔ string → {@link stringFromUriComponent}
  * - JSON string ↔ unknown → {@link fromJsonString}
+ * - YAML string ↔ unknown → {@link fromYamlString}
  * - FormData/URLSearchParams ↔ unknown → {@link fromFormData}, {@link fromURLSearchParams}
  * - Check if a value is a Transformation → {@link isTransformation}
  *
@@ -1602,6 +1603,38 @@ export const stringFromUriComponent: Transformation<string, string> = new Transf
 export const fromJsonString = new Transformation<unknown, string>(
   SchemaGetter.parseJson(),
   SchemaGetter.stringifyJson()
+)
+
+/**
+ * Decodes a YAML string and encodes a value as YAML text.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema transformation to decode YAML stored or
+ * transmitted as a string before validating the parsed structure.
+ *
+ * **Details**
+ *
+ * Decode and encode failures become `InvalidValue` schema issues.
+ *
+ * **Example** (Parsing YAML)
+ *
+ * ```ts
+ * import { Schema, SchemaTransformation } from "effect"
+ *
+ * const schema = Schema.String.pipe(
+ *   Schema.decodeTo(Schema.Unknown, SchemaTransformation.fromYamlString)
+ * )
+ * ```
+ *
+ * @see {@link fromJsonString} for JSON text
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const fromYamlString = new Transformation<unknown, string>(
+  SchemaGetter.parseYaml(),
+  SchemaGetter.stringifyYaml()
 )
 
 /**

--- a/packages/effect/src/Toml.ts
+++ b/packages/effect/src/Toml.ts
@@ -1,0 +1,103 @@
+/**
+ * Parse TOML documents without throwing exceptions.
+ *
+ * TOML is useful for configuration files and other human-edited documents.
+ * This module exposes parsing as a synchronous `Result` value so callers can
+ * handle invalid input explicitly.
+ *
+ * **Common tasks**
+ *
+ * - Parse TOML text into a JavaScript value with {@link parse}
+ * - Detect TOML failures with {@link isTomlError}
+ *
+ * **Gotchas**
+ *
+ * - The underlying TOML package supports parsing only, so this module does not
+ *   expose a stringify operation.
+ * - TOML values are returned as `unknown`; validate parsed values before using
+ *   them in application code.
+ *
+ * @since 4.0.0
+ */
+import * as toml from "toml"
+import * as Data from "./Data.ts"
+import { hasProperty } from "./Predicate.ts"
+import * as Result from "./Result.ts"
+
+const TomlErrorTypeId = "~effect/Toml/TomlError"
+
+/**
+ * Represents an error raised while parsing TOML.
+ *
+ * **When to use**
+ *
+ * Use when you need to inspect a failed TOML parse returned by `parse`.
+ *
+ * @see {@link isTomlError} for narrowing unknown values to this error type
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export class TomlError extends Data.TaggedError("TomlError")<{
+  readonly input: string
+  readonly message: string
+  readonly cause: unknown
+}> {
+  readonly [TomlErrorTypeId]: typeof TomlErrorTypeId = TomlErrorTypeId
+}
+
+/**
+ * Checks whether a value is a `TomlError`.
+ *
+ * **When to use**
+ *
+ * Use when you need to narrow an unknown failure before handling it as a TOML
+ * parse error.
+ *
+ * @see {@link TomlError} for the error returned by {@link parse}
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export const isTomlError = (u: unknown): u is TomlError => hasProperty(u, TomlErrorTypeId)
+
+/**
+ * Parses a TOML document into a JavaScript value.
+ *
+ * **When to use**
+ *
+ * Use when you need to read TOML text while handling invalid input as a
+ * `Result`.
+ *
+ * **Gotchas**
+ *
+ * The returned value is `unknown`. Validate it before relying on its shape.
+ *
+ * **Example** (Parsing TOML)
+ *
+ * ```ts
+ * import { Result, Toml } from "effect"
+ *
+ * const result = Toml.parse('name = "example"')
+ *
+ * if (Result.isSuccess(result)) {
+ *   console.log(result.success) // { name: "example" }
+ * }
+ * ```
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const parse = (input: string): Result.Result<unknown, TomlError> =>
+  Result.try({
+    try: () => toml.parse(input),
+    catch: (cause) =>
+      new TomlError({
+        input,
+        message: getErrorMessage(cause),
+        cause
+      })
+  })
+
+const getErrorMessage = (cause: unknown): string =>
+  hasProperty(cause, "message") && typeof cause.message === "string" ? cause.message : globalThis.String(cause)

--- a/packages/effect/src/Yaml.ts
+++ b/packages/effect/src/Yaml.ts
@@ -1,0 +1,191 @@
+/**
+ * Parse and stringify YAML documents without throwing exceptions.
+ *
+ * YAML is useful for configuration files and other human-edited documents.
+ * This module exposes the common single-document operations as synchronous
+ * `Result` values so callers can handle invalid input explicitly.
+ *
+ * **Common tasks**
+ *
+ * - Parse YAML text into a JavaScript value with {@link parse}
+ * - Stringify a JavaScript value as YAML text with {@link stringify}
+ * - Detect YAML failures with {@link isYamlError}
+ *
+ * **Gotchas**
+ *
+ * - `parse` handles one YAML document. Multi-document streams are not exposed
+ *   by this module.
+ * - YAML values are returned as `unknown`; validate parsed values before using
+ *   them in application code.
+ *
+ * @since 4.0.0
+ */
+import * as yaml from "yaml"
+import * as Data from "./Data.ts"
+import { hasProperty } from "./Predicate.ts"
+import * as Result from "./Result.ts"
+
+const YamlErrorTypeId = "~effect/Yaml/YamlError"
+
+/**
+ * Options used when parsing a YAML document.
+ *
+ * **When to use**
+ *
+ * Use when you need to customize YAML parsing, such as enabling bigint values
+ * or selecting a YAML schema.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ParseOptions = yaml.ParseOptions & yaml.DocumentOptions & yaml.SchemaOptions & yaml.ToJSOptions
+
+/**
+ * Options used when stringifying a YAML document.
+ *
+ * **When to use**
+ *
+ * Use when you need to customize YAML output, such as sorting map entries or
+ * selecting a collection style.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type StringifyOptions =
+  & yaml.DocumentOptions
+  & yaml.SchemaOptions
+  & yaml.ParseOptions
+  & yaml.CreateNodeOptions
+  & yaml.ToStringOptions
+
+/**
+ * Represents an error raised while parsing or stringifying YAML.
+ *
+ * **When to use**
+ *
+ * Use when you need to inspect a failed YAML conversion returned by `parse` or
+ * `stringify`.
+ *
+ * @see {@link isYamlError} for narrowing unknown values to this error type
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export class YamlError extends Data.TaggedError("YamlError")<{
+  readonly kind: "Parse" | "Stringify"
+  readonly input: unknown
+  readonly message: string
+  readonly cause: unknown
+}> {
+  readonly [YamlErrorTypeId]: typeof YamlErrorTypeId = YamlErrorTypeId
+}
+
+/**
+ * Checks whether a value is a `YamlError`.
+ *
+ * **When to use**
+ *
+ * Use when you need to narrow an unknown failure before handling it as a YAML
+ * conversion error.
+ *
+ * @see {@link YamlError} for the error returned by YAML conversions
+ *
+ * @category guards
+ * @since 4.0.0
+ */
+export const isYamlError = (u: unknown): u is YamlError => hasProperty(u, YamlErrorTypeId)
+
+/**
+ * Parses a YAML document into a JavaScript value.
+ *
+ * **When to use**
+ *
+ * Use when you need to read YAML text while handling invalid input as a
+ * `Result`.
+ *
+ * **Gotchas**
+ *
+ * The returned value is `unknown`. Validate it before relying on its shape.
+ *
+ * **Example** (Parsing YAML)
+ *
+ * ```ts
+ * import { Result, Yaml } from "effect"
+ *
+ * const result = Yaml.parse("name: example")
+ *
+ * if (Result.isSuccess(result)) {
+ *   console.log(result.success) // { name: "example" }
+ * }
+ * ```
+ *
+ * @see {@link stringify} for converting a JavaScript value to YAML text
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const parse = (input: string, options?: ParseOptions): Result.Result<unknown, YamlError> =>
+  Result.try({
+    try: () => yaml.parse(input, options),
+    catch: (cause) =>
+      new YamlError({
+        kind: "Parse",
+        input,
+        message: getErrorMessage(cause),
+        cause
+      })
+  })
+
+/**
+ * Stringifies a JavaScript value as a YAML document.
+ *
+ * **When to use**
+ *
+ * Use when you need to serialize a JavaScript value as YAML text while handling
+ * conversion failures as a `Result`.
+ *
+ * **Details**
+ *
+ * The returned document ends with a newline.
+ *
+ * **Example** (Stringifying YAML)
+ *
+ * ```ts
+ * import { Yaml } from "effect"
+ *
+ * const result = Yaml.stringify({ name: "example" })
+ * // Result<string, YamlError>
+ * ```
+ *
+ * @see {@link parse} for converting YAML text to a JavaScript value
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const stringify = (input: unknown, options?: StringifyOptions): Result.Result<string, YamlError> =>
+  Result.try({
+    try: () => yaml.stringify(input, options),
+    catch: (cause) =>
+      new YamlError({
+        kind: "Stringify",
+        input,
+        message: getErrorMessage(cause),
+        cause
+      })
+  }).pipe(
+    Result.flatMap((output) =>
+      typeof output === "string" ?
+        Result.succeed(output) :
+        Result.fail(
+          new YamlError({
+            kind: "Stringify",
+            input,
+            message: "Unable to stringify input",
+            cause: output
+          })
+        )
+    )
+  )
+
+const getErrorMessage = (cause: unknown): string =>
+  hasProperty(cause, "message") && typeof cause.message === "string" ? cause.message : globalThis.String(cause)

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -622,6 +622,11 @@ export * as Take from "./Take.ts"
 export * as Terminal from "./Terminal.ts"
 
 /**
+ * @since 4.0.0
+ */
+export * as Toml from "./Toml.ts"
+
+/**
  * @since 2.0.0
  */
 export * as Tracer from "./Tracer.ts"
@@ -710,3 +715,8 @@ export * as Unify from "./Unify.ts"
  * @since 2.0.0
  */
 export * as Utils from "./Utils.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as Yaml from "./Yaml.ts"

--- a/packages/effect/src/unstable/cli/Primitive.ts
+++ b/packages/effect/src/unstable/cli/Primitive.ts
@@ -61,8 +61,6 @@
  * @since 4.0.0
  */
 import * as Ini from "ini"
-import * as Toml from "toml"
-import * as Yaml from "yaml"
 import * as Config from "../../Config.ts"
 import * as Effect from "../../Effect.ts"
 import * as FileSystem from "../../FileSystem.ts"
@@ -70,10 +68,13 @@ import { format } from "../../Formatter.ts"
 import { identity } from "../../Function.ts"
 import * as Path from "../../Path.ts"
 import * as Redacted from "../../Redacted.ts"
+import * as Result from "../../Result.ts"
 import * as Schema from "../../Schema.ts"
 import type { Formatter } from "../../SchemaIssue.ts"
 import type * as Struct from "../../Struct.ts"
+import * as Toml from "../../Toml.ts"
 import type { Covariant } from "../../Types.ts"
+import * as Yaml from "../../Yaml.ts"
 
 const TypeId = "~effect/cli/Primitive"
 
@@ -571,9 +572,9 @@ export type FileParseOptions = {
 const fileParsers: Record<string, (content: string) => unknown> = {
   ini: (content: string) => Ini.parse(content),
   json: (content: string) => JSON.parse(content),
-  toml: (content: string) => Toml.parse(content),
-  yml: (content: string) => Yaml.parse(content),
-  yaml: (content: string) => Yaml.parse(content)
+  toml: (content: string) => Result.getOrThrow(Toml.parse(content)),
+  yml: (content: string) => Result.getOrThrow(Yaml.parse(content)),
+  yaml: (content: string) => Result.getOrThrow(Yaml.parse(content))
 }
 
 /**

--- a/packages/effect/test/Toml.test.ts
+++ b/packages/effect/test/Toml.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "@effect/vitest"
+import { assertFalse, assertTrue, strictEqual } from "@effect/vitest/utils"
+import { Result, Toml } from "effect"
+
+describe("Toml", () => {
+  it("isTomlError", () => {
+    const result = Toml.parse("name =")
+    assertTrue(Result.isFailure(result))
+    assertTrue(Toml.isTomlError(result.failure))
+    assertFalse(Toml.isTomlError(new Error("regular error")))
+    assertFalse(Toml.isTomlError("not an error"))
+  })
+
+  it("TomlError constructor", () => {
+    const cause = new Error("boom")
+    const error = new Toml.TomlError({
+      input: "name =",
+      message: cause.message,
+      cause
+    })
+    assertTrue(error instanceof Error)
+    assertTrue(Toml.isTomlError(error))
+    strictEqual(error._tag, "TomlError")
+    strictEqual(error.input, "name =")
+    strictEqual(error.message, "boom")
+    strictEqual(error.cause, cause)
+  })
+
+  it("parse", () => {
+    const result = Toml.parse(`
+name = "example"
+ports = [3000, 3001]
+created = 1979-05-27T07:32:00Z
+local = 1979-05-27T07:32:00
+`)
+    assertTrue(Result.isSuccess(result))
+    const parsed = result.success as {
+      readonly name: string
+      readonly ports: ReadonlyArray<number>
+      readonly created: Date
+      readonly local: string
+    }
+    strictEqual(parsed.name, "example")
+    strictEqual(parsed.ports[0], 3000)
+    strictEqual(parsed.ports[1], 3001)
+    strictEqual(parsed.created.toISOString(), "1979-05-27T07:32:00.000Z")
+    strictEqual(parsed.local, "1979-05-27T07:32:00")
+  })
+})

--- a/packages/effect/test/Yaml.test.ts
+++ b/packages/effect/test/Yaml.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "@effect/vitest"
+import { assertFalse, assertTrue, deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Result, Yaml } from "effect"
+
+describe("Yaml", () => {
+  it("isYamlError", () => {
+    const result = Yaml.parse("a: [")
+    assertTrue(Result.isFailure(result))
+    assertTrue(Yaml.isYamlError(result.failure))
+    assertFalse(Yaml.isYamlError(new Error("regular error")))
+    assertFalse(Yaml.isYamlError("not an error"))
+  })
+
+  it("YamlError constructor", () => {
+    const cause = new Error("boom")
+    const error = new Yaml.YamlError({
+      kind: "Parse",
+      input: "a: [",
+      message: cause.message,
+      cause
+    })
+    assertTrue(error instanceof Error)
+    assertTrue(Yaml.isYamlError(error))
+    strictEqual(error._tag, "YamlError")
+    strictEqual(error.kind, "Parse")
+    strictEqual(error.input, "a: [")
+    strictEqual(error.message, "boom")
+    strictEqual(error.cause, cause)
+  })
+
+  it("parse", () => {
+    deepStrictEqual(
+      Yaml.parse(`
+name: example
+ports:
+  - 3000
+  - 3001
+`),
+      Result.succeed({
+        name: "example",
+        ports: [3000, 3001]
+      })
+    )
+    deepStrictEqual(Yaml.parse("value: 1", { intAsBigInt: true }), Result.succeed({ value: 1n }))
+  })
+
+  it("parse fails for multiple documents", () => {
+    const result = Yaml.parse(`
+---
+a: 1
+---
+b: 2
+`)
+    assertTrue(Result.isFailure(result))
+    strictEqual(result.failure.kind, "Parse")
+    assertTrue(result.failure.message.includes("Source contains multiple documents"))
+  })
+
+  it("stringify", () => {
+    deepStrictEqual(
+      Yaml.stringify({ name: "example", ports: [3000, 3001] }),
+      Result.succeed(`name: example
+ports:
+  - 3000
+  - 3001
+`)
+    )
+  })
+
+  it("stringify fails for unsupported values", () => {
+    const result = Yaml.stringify(undefined)
+    assertTrue(Result.isFailure(result))
+    strictEqual(result.failure.kind, "Stringify")
+    strictEqual(result.failure.message, "Unable to stringify input")
+  })
+})

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -4872,6 +4872,44 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
     })
   })
 
+  describe("fromYamlString", () => {
+    it("use case: create a YAML string serializer for an existing schema", async () => {
+      const schema = Schema.fromYamlString(Schema.Struct({
+        name: Schema.String,
+        ports: Schema.Array(Schema.Number)
+      }))
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding()
+      await decoding.succeed(
+        `name: example
+ports:
+  - 3000
+  - 3001
+`,
+        { name: "example", ports: [3000, 3001] }
+      )
+      await decoding.fail(
+        "name: [",
+        `Flow sequence in block collection must be sufficiently indented and end with a ] at line 1, column 8:
+
+name: [
+       ^
+`
+      )
+
+      const encoding = asserts.encoding()
+      await encoding.succeed(
+        { name: "example", ports: [3000, 3001] },
+        `name: example
+ports:
+  - 3000
+  - 3001
+`
+      )
+    })
+  })
+
   it("fromFormData", async () => {
     const schema = Schema.fromFormData(Schema.Struct({
       a: Schema.NonEmptyString,

--- a/packages/effect/test/schema/toJsonSchemaDocument.test.ts
+++ b/packages/effect/test/schema/toJsonSchemaDocument.test.ts
@@ -3561,6 +3561,23 @@ describe("toJsonSchemaDocument", () => {
     })
   })
 
+  describe("fromYamlString", () => {
+    it("top level fromYamlString", () => {
+      assertJsonSchemaDocument(
+        Schema.fromYamlString(Schema.FiniteFromString),
+        {
+          schema: {
+            "type": "string",
+            "contentMediaType": "application/yaml",
+            "contentSchema": {
+              "type": "string"
+            }
+          }
+        }
+      )
+    })
+  })
+
   it("Class", () => {
     class A extends Schema.Class<A>("A")({
       a: Schema.String


### PR DESCRIPTION
`effect` declares `toml` and `yaml` as dependencies (used by the CLI modules). This creates some slim modules for those so users doesn't need to install the packages separately