### PR TITLE
Fix Redis script handling for rate limiter

### DIFF
--- a/.changeset/quiet-redis-scripts.md
+++ b/.changeset/quiet-redis-scripts.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Retry Redis scripts after `NOSCRIPT` and declare the token bucket refill key

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -630,11 +630,13 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
     },
     tokenBucket(options) {
       const key = `${prefix}${options.key}`
+      const lastRefillKey = `${key}:refill`
       const refillMillis = Duration.toMillis(options.refillRate)
       return Effect.clockWith((clock) =>
         Effect.mapError(
           tokenBucket(
             key,
+            lastRefillKey,
             options.tokens,
             refillMillis,
             options.limit,
@@ -687,17 +689,18 @@ return { next, nextpttl }
 const tokenBucketScript = Redis.script(
   (
     key: string,
+    lastRefillKey: string,
     tokens: number,
     refillMillis: number,
     limit: number,
     now: number,
     overflow: 0 | 1
-  ) => [key, tokens, refillMillis, limit, now, overflow],
+  ) => [key, lastRefillKey, tokens, refillMillis, limit, now, overflow],
   {
-    numberOfKeys: 1,
+    numberOfKeys: 2,
     lua: `
 local key = KEYS[1]
-local last_refill_key = key .. ":refill"
+local last_refill_key = KEYS[2]
 local tokens = tonumber(ARGV[1])
 local refill_ms = tonumber(ARGV[2])
 local limit = tonumber(ARGV[3])

--- a/packages/effect/src/unstable/persistence/Redis.ts
+++ b/packages/effect/src/unstable/persistence/Redis.ts
@@ -89,14 +89,22 @@ export const make = Effect.fnUntraced(function*(
   >(
     script: Script<Config>
   ) =>
-  (...params: Config["params"]): Effect.Effect<Config["result"], RedisError> =>
-    Effect.flatMap(Cache.get(scriptCache, script), (sha) =>
+  (...params: Config["params"]): Effect.Effect<Config["result"], RedisError> => {
+    const evalSha = (sha: string) =>
       options.send<Config["result"]>(
         "EVALSHA",
         sha,
         script.numberOfKeys(...params).toString(),
         ...script.params(...params).map((param) => String(param))
-      ))
+      )
+    return Cache.get(scriptCache, script).pipe(
+      Effect.flatMap(evalSha),
+      Effect.catchIf(
+        (error) => String(error.cause).includes("NOSCRIPT"),
+        () => Cache.refresh(scriptCache, script).pipe(Effect.flatMap(evalSha))
+      )
+    )
+  }
 
   return identity<Redis["Service"]>({
     send: options.send,

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -1,0 +1,44 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { Redis } from "effect/unstable/persistence"
+
+describe("Redis", () => {
+  it.effect("reloads and retries scripts when EVALSHA returns NOSCRIPT", () =>
+    Effect.gen(function*() {
+      const commands: Array<readonly [command: string, args: ReadonlyArray<string>]> = []
+      let evalShaAttempts = 0
+      const redis = yield* Redis.make({
+        send: (command, ...args) =>
+          Effect.sync(() => {
+            commands.push([command, args])
+            if (command === "EVALSHA") {
+              evalShaAttempts += 1
+            }
+          }).pipe(Effect.flatMap(() => {
+            if (command === "SCRIPT") {
+              return Effect.succeed("sha")
+            }
+            if (command === "EVALSHA" && evalShaAttempts === 1) {
+              return Effect.fail(new Redis.RedisError({ cause: new Error("NOSCRIPT No matching script") }))
+            }
+            return Effect.succeed("ok")
+          }))
+      })
+      const evalScript = redis.eval(
+        Redis.script((key: string) => [key], {
+          lua: "return KEYS[1]",
+          numberOfKeys: 1
+        }).withReturnType<string>()
+      )
+
+      const result = yield* evalScript("key")
+
+      assert.strictEqual(result, "ok")
+      assert.deepStrictEqual(commands.map(([command]) => command), [
+        "SCRIPT",
+        "EVALSHA",
+        "SCRIPT",
+        "EVALSHA"
+      ])
+    }))
+})

--- a/packages/effect/test/unstable/persistence/Redis.test.ts
+++ b/packages/effect/test/unstable/persistence/Redis.test.ts
@@ -9,20 +9,19 @@ describe("Redis", () => {
       let evalShaAttempts = 0
       const redis = yield* Redis.make({
         send: (command, ...args) =>
-          Effect.sync(() => {
+          Effect.suspend(() => {
             commands.push([command, args])
             if (command === "EVALSHA") {
               evalShaAttempts += 1
             }
-          }).pipe(Effect.flatMap(() => {
             if (command === "SCRIPT") {
-              return Effect.succeed("sha")
+              return Effect.succeed("sha" as any)
             }
             if (command === "EVALSHA" && evalShaAttempts === 1) {
               return Effect.fail(new Redis.RedisError({ cause: new Error("NOSCRIPT No matching script") }))
             }
             return Effect.succeed("ok")
-          }))
+          })
       })
       const evalScript = redis.eval(
         Redis.script((key: string) => [key], {


### PR DESCRIPTION
Fixes Redis script handling issues discussed in #2328.

- retry cached script execution after NOSCRIPT by refreshing the script cache
- declare the token bucket refill key as a Redis script key