### PR TITLE
[metavar][log-level]: Add meta support to show values for log level a…

### DIFF
--- a/.changeset/warm-dolls-brake.md
+++ b/.changeset/warm-dolls-brake.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add meta-var that shows log level and bash options in command line.

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -244,7 +244,7 @@ export const LogLevel: Setting<"log-level", Option.Option<LogLevelType>> = setti
   ).pipe(
     Flag.optional,
     Flag.withDescription("Sets the minimum log level"),
-    Flag.withMetavar("<all|trace|debug|info|warn|warning|error|fatal|none>"),
+    Flag.withMetavar("<all|trace|debug|info|warn|warning|error|fatal|none>")
   )
 })
 

--- a/packages/effect/src/unstable/cli/GlobalFlag.ts
+++ b/packages/effect/src/unstable/cli/GlobalFlag.ts
@@ -203,6 +203,7 @@ export const Completions: Action<Option.Option<"bash" | "zsh" | "fish">> = actio
     .pipe(
       Flag.optional,
       Flag.map((v) => Option.map(v, (s) => s === "sh" ? "bash" : s)),
+      Flag.withMetavar("<bash|zsh|fish|sh>"),
       Flag.withDescription("Print shell completion script")
     ),
   run: (shell, { command }) =>
@@ -242,7 +243,8 @@ export const LogLevel: Setting<"log-level", Option.Option<LogLevelType>> = setti
     ] as const
   ).pipe(
     Flag.optional,
-    Flag.withDescription("Sets the minimum log level")
+    Flag.withDescription("Sets the minimum log level"),
+    Flag.withMetavar("<all|trace|debug|info|warn|warning|error|fatal|none>"),
   )
 })
 

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -57,8 +57,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           admin            Administrative commands
@@ -249,8 +249,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         EXAMPLES
           # Log in with browser OAuth
@@ -293,8 +293,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -323,8 +323,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -351,8 +351,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -382,8 +382,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -408,8 +408,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           set    Set configuration values
@@ -442,8 +442,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level   <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -520,8 +520,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level   <all|trace|debug|info|warn|warning|error|fatal|none>      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           ungrouped    This command is not in a group
@@ -562,8 +562,8 @@ describe("Command help output", () => {
         GLOBAL FLAGS
           --help, -h              Show help information
           --version, -v           Show version information
-          --completions choice    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level choice      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --completions <bash|zsh|fish|sh>      Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           plan, p    Draft a plan in your editor"

--- a/packages/effect/test/unstable/cli/Help.test.ts
+++ b/packages/effect/test/unstable/cli/Help.test.ts
@@ -55,10 +55,10 @@ describe("Command help output", () => {
           --quiet, -q          Suppress non-error output
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           admin            Administrative commands
@@ -247,10 +247,10 @@ describe("Command help output", () => {
           login [flags]
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         EXAMPLES
           # Log in with browser OAuth
@@ -291,10 +291,10 @@ describe("Command help output", () => {
           --buffer-size integer    Buffer size in KB
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -321,10 +321,10 @@ describe("Command help output", () => {
           --verbose, -v        Explain what is being done
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -349,10 +349,10 @@ describe("Command help output", () => {
           --verbose, -v        Show detailed information
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -380,10 +380,10 @@ describe("Command help output", () => {
           --notify, -n         Send notification email
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -406,10 +406,10 @@ describe("Command help output", () => {
           --profile, -p string    Configuration profile to use
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           set    Set configuration values
@@ -440,10 +440,10 @@ describe("Command help output", () => {
           --config-file, -f file    Write to specific config file
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level   <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)"
       `)
     }).pipe(Effect.provide(TestLayer)))
 
@@ -518,10 +518,10 @@ describe("Command help output", () => {
           tool <subcommand> [flags]
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>    Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level   <all|trace|debug|info|warn|warning|error|fatal|none>      Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           ungrouped    This command is not in a group
@@ -560,10 +560,10 @@ describe("Command help output", () => {
           tool <subcommand> [flags]
 
         GLOBAL FLAGS
-          --help, -h              Show help information
-          --version, -v           Show version information
-          --completions <bash|zsh|fish|sh>      Print shell completion script (choices: bash, zsh, fish, sh)
-          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>       Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
+          --help, -h                                                          Show help information
+          --version, -v                                                       Show version information
+          --completions <bash|zsh|fish|sh>                                    Print shell completion script (choices: bash, zsh, fish, sh)
+          --log-level <all|trace|debug|info|warn|warning|error|fatal|none>    Sets the minimum log level (choices: all, trace, debug, info, warn, warning, error, fatal, none)
 
         SUBCOMMANDS
           plan, p    Draft a plan in your editor"


### PR DESCRIPTION
## Type


- Refactor

## Description

Add meta-var that shows log level and bash options in command line. 


## Related

Solve part related to Problem 2 

## 2. Built-in global flags render opaque choice help instead of explicit values

https://github.com/Effect-TS/effect/issues/6376

- Related Issue #
- https://github.com/Effect-TS/effect/issues/6376

