### PR TITLE
fix(vitest): preserve chained helpers like it.describe.each

### DIFF
--- a/.changeset/vitest-describe-each.md
+++ b/.changeset/vitest-describe-each.md
@@ -1,0 +1,5 @@
+---
+"@effect/vitest": patch
+---
+
+Preserve the chained helpers Vitest attaches to its test and suite functions when accessed through `it`, so `it.describe.each` (and similar) no longer throw `it.describe.each is not a function`.

--- a/packages/vitest/src/internal/internal.ts
+++ b/packages/vitest/src/internal/internal.ts
@@ -65,7 +65,23 @@ const makeItProxy = <Methods extends object>(
         return Reflect.get(overrides, property)
       }
       const value = Reflect.get(target, property, receiver)
-      return typeof value === "function" ? value.bind(target) : value
+      if (typeof value !== "function") {
+        return value
+      }
+      // `value.bind(target)` would drop the static properties Vitest attaches to
+      // its test/suite functions (e.g. `describe.each`, `test.skip`). Wrap in a
+      // proxy that calls through with the original `this` while keeping access to
+      // those chained helpers, with `this` bound to the original function.
+      const fn = value as (...args: Array<unknown>) => unknown
+      return new Proxy(fn, {
+        apply(fn, _thisArg, argArray) {
+          return Reflect.apply(fn, value, argArray)
+        },
+        get(fn, prop, receiver) {
+          const inner = Reflect.get(fn, prop, receiver)
+          return typeof inner === "function" ? inner.bind(fn) : inner
+        }
+      })
     }
   })
 

--- a/packages/vitest/test/index.test.ts
+++ b/packages/vitest/test/index.test.ts
@@ -22,6 +22,10 @@ it.live.each([1, 2, 3])(
   (n) => Effect.acquireRelease(Effect.sync(() => expect(n).toEqual(n)), () => Effect.void)
 )
 
+it.describe.each(["foo", "bar"] as const)("describe each %s", (text) => {
+  it.effect("runs", () => Effect.sync(() => assert.include(["foo", "bar"], text)))
+})
+
 // skip
 
 it.live.skip(


### PR DESCRIPTION
The proxy in `makeItProxy` returns `value.bind(target)` for any function pulled off the underlying Vitest API. Binding produces a fresh function without the helpers Vitest hangs off `describe`/`test` (`each`, `skip`, `only`, etc.), so `it.describe.each(...)` throws `it.describe.each is not a function`.

This wraps such functions in a small proxy that calls through with the original `this` while still exposing the chained helpers, bound to the original function so they keep working. Added a `describe.each` case to the existing test.

Closes Effect-TS/effect#6348.