### PR TITLE
fix(effect): restore value-equality emission dedup as the Atom default (regression from v3)

### DIFF
--- a/.changeset/atom-value-equality-default.md
+++ b/.changeset/atom-value-equality-default.md
@@ -1,0 +1,9 @@
+---
+"effect": minor
+---
+
+AtomRegistry: dedupe atom writes by value equality (`Equal.equals`) instead of reference identity (`Object.is`).
+
+When an atom is set to a fresh-reference value that is `Equal.equals` to its current value, the registry no longer treats it as a change: no subscribers are notified and no downstream atoms are invalidated. A genuinely different value still notifies and invalidates as before.
+
+This restores the value-equality dedup behavior of the standalone v3 `@effect-atom/atom` package, which used `Equal.equals` in its `setValue` guard. The guard narrowed to `Object.is` during the bulk port of the Atom subsystem into core, while the sibling `AtomRef` kept `Equal.equals` — an inconsistency this change resolves. Atoms holding structurally-equal values (e.g. `Data` instances, `Option`, `Result`) now behave as expected without an opt-in combinator.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -11,6 +11,7 @@
  */
 import * as Context from "../../Context.ts"
 import * as Effect from "../../Effect.ts"
+import * as Equal from "../../Equal.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
 import { constVoid, dual } from "../../Function.ts"
@@ -685,7 +686,7 @@ class NodeImpl<A> {
     }
 
     this.state = NodeState.valid
-    if (Object.is(this._value, value)) {
+    if (Equal.equals(this._value, value)) {
       return
     }
 

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -3,7 +3,9 @@ import {
   Array as Arr,
   Cause,
   Context,
+  Data,
   Effect,
+  Equal,
   Hash,
   Latch,
   Layer,
@@ -106,6 +108,68 @@ describe.sequential("Atom", () => {
 
     expect(first).toEqual(1)
     expect(second).toEqual(1)
+  })
+
+  it("set suppresses notify for a fresh-reference but Equal.equals value", () => {
+    class Box extends Data.Class<{ readonly n: number }> {}
+    const box = Atom.make(new Box({ n: 1 }))
+    const r = AtomRegistry.make()
+
+    const current = r.get(box)
+    let count = 0
+    r.subscribe(box, () => {
+      count++
+    })
+
+    const next = new Box({ n: 1 })
+    expect(Object.is(current, next)).toBe(false)
+    expect(Equal.equals(current, next)).toBe(true)
+
+    r.set(box, next)
+    expect(count).toEqual(0)
+    expect(r.get(box)).toEqual(new Box({ n: 1 }))
+  })
+
+  it("set does not invalidate downstream for a fresh-reference but Equal.equals value", () => {
+    class Box extends Data.Class<{ readonly n: number }> {}
+    const seed = Atom.make(new Box({ n: 1 }))
+    let recomputes = 0
+    const derived = Atom.make((get) => {
+      recomputes++
+      return get(seed).n + 100
+    })
+    const r = AtomRegistry.make()
+
+    expect(r.get(derived)).toEqual(101)
+    expect(recomputes).toEqual(1)
+
+    r.set(seed, new Box({ n: 1 }))
+    expect(r.get(derived)).toEqual(101)
+    expect(recomputes).toEqual(1)
+  })
+
+  it("set still notifies and invalidates downstream for a genuinely different value", () => {
+    class Box extends Data.Class<{ readonly n: number }> {}
+    const seed = Atom.make(new Box({ n: 1 }))
+    let recomputes = 0
+    const derived = Atom.make((get) => {
+      recomputes++
+      return get(seed).n + 100
+    })
+    const r = AtomRegistry.make()
+
+    expect(r.get(derived)).toEqual(101)
+    expect(recomputes).toEqual(1)
+
+    let count = 0
+    r.subscribe(seed, () => {
+      count++
+    })
+
+    r.set(seed, new Box({ n: 2 }))
+    expect(count).toEqual(1)
+    expect(r.get(derived)).toEqual(102)
+    expect(recomputes).toEqual(2)
   })
 
   it("searchParam with schema reads initial query value", () => {


### PR DESCRIPTION
## What

A surgical one-line change: in `AtomRegistry` `NodeImpl.setValue`, the emission guard goes from reference identity to value equality —

```diff
-    if (Object.is(this._value, value)) {
+    if (Equal.equals(this._value, value)) {
```

(plus the `Equal` import). No new API. With this, writing or recomputing a value that is `Equal.equals` to the current one no longer notifies subscribers or invalidates downstream atoms — restoring the v3 default.

## Why — this is a silent regression from v3 `@effect-atom`

The v3 standalone `@effect-atom/atom` deduped atom emissions on **value equality** (`registry.ts` `setValue`: `if (Equal.equals(this._value, value))`). In the v4-core rewrite the guard became `Object.is` — **reference identity** — so a fresh-reference-but-value-equal write (which derived atoms produce on every recompute) now re-emits and cascades a re-render through the whole derived chain.

The change was unintentional, not a reasoned design decision:

- **Origin:** the `Object.is` guard was born in commit `00a9ef20` / **#853 "add Atom modules"** — the bulk port (43 files, ~8k insertions) that *created* `AtomRegistry.ts`. It rode in mechanically.
- **No changeset, no test** in that commit pins reference-equality dedup as intended behavior.
- **intra-commit inconsistency:** the *same* commit's `AtomRef.ts` kept `Equal.equals` (`if (Equal.equals(value, this.value))`, and `AtomRef` implements `Equal.Equal`). Within one commit the sibling `Ref` preserved value-equality while only `NodeImpl.setValue` regressed — characteristic of an accidental narrowing during the port.
- **Maintainer intent:** in `tim-smart/effect-atom#218` the maintainer treats value-equality dedup as the correct/expected behavior.

## Safety

The full `reactivity/` test suite passes under the flipped default (104/104) — no existing test relied on reference-identity emission. New tests assert the default now suppresses a fresh-reference-but-`Equal.equals` set (and skips downstream invalidation) while a genuinely different value still emits.

## Relationship to #2346

This is the **surgical "restore the default"** option. Its sibling **#2346** instead adds opt-in `Atom.dedupe` / `Atom.dedupeWith` combinators and leaves the default as `Object.is`. The two are independent:

- If you agree this was a slip → **this PR** restores the v3 default in one line.
- If you'd rather keep `Object.is` as the default and make value-equality opt-in → **#2346** is the conservative alternative.

(See also the v3-side proposal `tim-smart/effect-atom#415`.)