### PR TITLE
fix(openapi-generator): declare swagger2openapi runtime dependency

### DIFF
--- a/.changeset/fix-openapi-generator-swagger2openapi.md
+++ b/.changeset/fix-openapi-generator-swagger2openapi.md
@@ -1,0 +1,5 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Declare `swagger2openapi` as a runtime dependency so published `openapigen` installs can resolve the converter imported by `OpenApiGenerator`.

--- a/packages/tools/openapi-generator/package.json
+++ b/packages/tools/openapi-generator/package.json
@@ -65,12 +65,14 @@
     "@effect/platform-node": "workspace:^",
     "effect": "workspace:^"
   },
+  "dependencies": {
+    "swagger2openapi": "^7.0.8"
+  },
   "devDependencies": {
     "@types/swagger2openapi": "^7.0.4",
     "effect": "workspace:^",
     "json-schema-typed": "^8.0.2",
     "openapi-typescript": "^7.13.0",
-    "swagger2openapi": "^7.0.8",
     "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -782,6 +782,9 @@ importers:
       '@effect/platform-node':
         specifier: workspace:^
         version: link:../../platform-node
+      swagger2openapi:
+        specifier: ^7.0.8
+        version: 7.0.8
     devDependencies:
       '@types/swagger2openapi':
         specifier: ^7.0.4
@@ -795,9 +798,6 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@6.0.3)
-      swagger2openapi:
-        specifier: ^7.0.8
-        version: 7.0.8
       yaml:
         specifier: ^2.9.0
         version: 2.9.0


### PR DESCRIPTION
## Summary

- Moves `swagger2openapi` from `devDependencies` to `dependencies` for `@effect/openapi-generator`.
- Updates the lockfile importer entry to match.
- Adds a patch changeset.

This fixes the published package case where `OpenApiGenerator` imports `swagger2openapi` at runtime, but fresh consumers of `openapigen` do not get that package installed.

Closes #2155.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `pnpm --filter @effect/openapi-generator check`
- `pnpm --filter @effect/openapi-generator build`
- `pnpm --filter @effect/openapi-generator test -- --run` -> 5 files / 64 tests passed
- `git diff --check`