### PR TITLE
fix(RateLimiter): add TTL and nil-guard to Redis token-bucket

### DIFF
--- a/.changeset/fix-ratelimiter-tokenbucket-redis-ttl.md
+++ b/.changeset/fix-ratelimiter-tokenbucket-redis-ttl.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the Redis `RateLimiterStore` token-bucket failing with opaque errors under memory pressure: it now writes its keys with a TTL and guards against a missing refill timestamp.

--- a/packages/effect/src/unstable/persistence/RateLimiter.ts
+++ b/packages/effect/src/unstable/persistence/RateLimiter.ts
@@ -693,28 +693,26 @@ local overflow = ARGV[5] == "1"
 local current = tonumber(redis.call("GET", key))
 local last_refill = tonumber(redis.call("GET", last_refill_key))
 
-if not current then
-  current = limit
-  last_refill = now
-  redis.call("SET", key, current)
-  redis.call("SET", last_refill_key, last_refill)
-end
+if not current then current = limit end
+if not last_refill then last_refill = now end
 
 local elapsed = now - last_refill
 local refill_amount = math.floor(elapsed / refill_ms)
 if refill_amount > 0 then
   current = math.min(current + refill_amount, limit)
   last_refill = last_refill + (refill_amount * refill_ms)
-  redis.call("SET", last_refill_key, last_refill)
 end
 
 local next = current - tokens
-if next < 0 and not overflow then
-  redis.call("SET", key, current)
-  return next
+local stored = current
+if next >= 0 or overflow then
+  stored = next
 end
 
-redis.call("SET", key, next)
+local ttl = math.floor((limit - stored) * refill_ms)
+if ttl < 1 then ttl = 1 end
+redis.call("SET", key, stored, "PX", ttl)
+redis.call("SET", last_refill_key, last_refill, "PX", ttl)
 return next
 `
   }


### PR DESCRIPTION
The Redis token-bucket store wrote its two keys (`<key>`, `<key>:refill`) with no expiry, so they grow unbounded. The script also assumed both keys were always present together, so a missing refill timestamp (e.g. independent eviction under an `allkeys-*` policy) caused a Lua `attempt to perform arithmetic on a nil value`.

This guards each value independently and writes both keys with a `PX` TTL refreshed on every operation (TTL = time for the bucket to fully refill, so an expired-and-reconstructed bucket is indistinguishable from a retained one). This bounds memory and removes the nil-arithmetic failure mode.