### PR TITLE
docs: correct JSDoc on Workflow.poll and WorkflowEngine.poll

### DIFF
--- a/packages/effect/src/unstable/workflow/Workflow.ts
+++ b/packages/effect/src/unstable/workflow/Workflow.ts
@@ -92,7 +92,7 @@ export interface Workflow<
   >
 
   /**
-   * Execute the workflow with the given payload.
+   * Poll the current status of a workflow execution.
    */
   readonly poll: (
     executionId: string

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -99,7 +99,7 @@ export class WorkflowEngine extends Context.Service<
     >
 
     /**
-     * Execute a registered workflow.
+     * Poll the current status of a registered workflow execution.
      */
     readonly poll: <
       Name extends string,


### PR DESCRIPTION
Fixes #2336.

The `poll` method only polls the current status of a workflow execution; it does not execute the workflow. The JSDoc summary lines were copy-pasted from the neighbouring `execute` blocks and therefore described execution behaviour incorrectly.

This corrects the two summary lines:

- `packages/effect/src/unstable/workflow/Workflow.ts`: the block above `readonly poll:` now reads "Poll the current status of a workflow execution." instead of "Execute the workflow with the given payload."
- `packages/effect/src/unstable/workflow/WorkflowEngine.ts`: the block above `readonly poll:` now reads "Poll the current status of a registered workflow execution." instead of "Execute a registered workflow."

The correct `execute` JSDoc blocks in both files are left untouched.