### PR TITLE
fix: Claude 4-6 generation supports native structured output (ai-anthropic)

### DIFF
--- a/.changeset/anthropic-4-6-structured-output.md
+++ b/.changeset/anthropic-4-6-structured-output.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Mark the Claude 4-6 generation as supporting native structured output in `getModelCapabilities`. `claude-opus-4-6` and `claude-sonnet-4-6` support Anthropic's constrained-decoding structured output (verified against the live API), but were classified as `supportsStructuredOutput: false`, so `generateObject` fell back to a forced JSON tool instead of requesting `output_config.format` (`json_schema`). `claude-opus-4-7` / `claude-opus-4-8` are classified the same way for when the generated `Model` enum picks them up.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -2966,7 +2966,11 @@ const getModelCapabilities = (modelId: string): ModelCapabilities => {
   if (
     modelId.includes("claude-sonnet-4-5") ||
     modelId.includes("claude-opus-4-5") ||
-    modelId.includes("claude-haiku-4-5")
+    modelId.includes("claude-haiku-4-5") ||
+    modelId.includes("claude-opus-4-6") ||
+    modelId.includes("claude-sonnet-4-6") ||
+    modelId.includes("claude-opus-4-7") ||
+    modelId.includes("claude-opus-4-8")
   ) {
     return {
       maxOutputTokens: 64000,

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -238,9 +238,11 @@ describe("AnthropicLanguageModel", () => {
         assert.strictEqual(body.output_config?.format?.type, "json_schema")
       })
 
-    it.effect("uses native json_schema output for claude-opus-4-6", () => assertNativeStructuredOutput("claude-opus-4-6"))
+    it.effect("uses native json_schema output for claude-opus-4-6", () =>
+      assertNativeStructuredOutput("claude-opus-4-6"))
 
-    it.effect("uses native json_schema output for claude-sonnet-4-6", () => assertNativeStructuredOutput("claude-sonnet-4-6"))
+    it.effect("uses native json_schema output for claude-sonnet-4-6", () =>
+      assertNativeStructuredOutput("claude-sonnet-4-6"))
   })
 })
 

--- a/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
+++ b/packages/ai/anthropic/test/AnthropicLanguageModel.test.ts
@@ -185,6 +185,63 @@ describe("AnthropicLanguageModel", () => {
         assert.deepStrictEqual(dynamicTool.input_schema, inputSchema)
       }))
   })
+
+  describe("generateObject", () => {
+    // A model that supports native structured output requests it via `output_config.format` (json_schema)
+    // rather than falling back to a forced JSON tool.
+    const assertNativeStructuredOutput = (model: string) =>
+      Effect.gen(function*() {
+        let capturedRequest: HttpClientRequest.HttpClientRequest | undefined = undefined
+        const layer = AnthropicClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) => {
+              capturedRequest = request
+              return Effect.succeed(jsonResponse(request, {
+                id: "msg_test_1",
+                type: "message",
+                role: "assistant",
+                model,
+                content: [{ type: "text", text: JSON.stringify({ name: "John", age: 30 }) }],
+                stop_reason: "end_turn",
+                stop_sequence: null,
+                usage: {
+                  cache_creation: null,
+                  cache_creation_input_tokens: null,
+                  cache_read_input_tokens: null,
+                  inference_geo: null,
+                  input_tokens: 10,
+                  output_tokens: 5,
+                  service_tier: null
+                }
+              }))
+            })
+          ))
+        )
+
+        // Assert the request shape; the response outcome is irrelevant here.
+        yield* LanguageModel.generateObject({
+          prompt: "Give me a person",
+          schema: Schema.Struct({ name: Schema.String, age: Schema.Number })
+        }).pipe(
+          Effect.provide(AnthropicLanguageModel.model(model)),
+          Effect.provide(layer),
+          Effect.ignore
+        )
+
+        assert.isDefined(capturedRequest)
+        if (capturedRequest === undefined) {
+          return
+        }
+
+        const body = yield* getRequestBody(capturedRequest)
+        assert.strictEqual(body.output_config?.format?.type, "json_schema")
+      })
+
+    it.effect("uses native json_schema output for claude-opus-4-6", () => assertNativeStructuredOutput("claude-opus-4-6"))
+
+    it.effect("uses native json_schema output for claude-sonnet-4-6", () => assertNativeStructuredOutput("claude-sonnet-4-6"))
+  })
 })
 
 const makeHttpClient = (


### PR DESCRIPTION
## Problem

`getModelCapabilities` classifies the Claude 4-6 generation (`claude-opus-4-6`, `claude-sonnet-4-6`) as `supportsStructuredOutput: false`. So `generateObject` skips native structured output (`output_config.format` = `json_schema`) and falls back to a forced JSON tool — even though these models do support native structured output (verified against the live API). On the fallback path the model can prepend prose to the tool JSON, which then fails `JSON.parse` in `resolveStructuredOutput`.

## Solution

Add the 4-6 generation to the native-structured-output branch. `claude-opus-4-7` / `claude-opus-4-8` are also classified (likewise live-verified); they aren't in the generated `Model` enum yet, so this is correct the moment the codegen picks them up. Tests assert `output_config.format.type === "json_schema"` on the request (mirroring the OpenAI provider's structured-output test); split red → green.

---

🤖 This change was LLM-assisted.
