### PR TITLE
fix(effect): make module-level side effects tree-shakable

### DIFF
--- a/.changeset/clean-needles-shake.md
+++ b/.changeset/clean-needles-shake.md
@@ -1,0 +1,23 @@
+---
+"effect": patch
+---
+
+Fix module-level side effects that defeated bundler tree-shaking.
+
+Bare top-level statements cannot be `#__PURE__`-annotated by the build, so
+bundlers must retain them and everything they reference, even in bundles that
+never use the code:
+
+- `Option`: the standalone `Object.defineProperty(SomeProto, "valueOrUndefined", ...)`
+  statement anchored the whole `Option` proto chain into every bundle. It is
+  now folded into the `SomeProto` initializer.
+- `Headers`: same pattern with `Object.defineProperties(Proto, ...)`, folded
+  into the initializer.
+- `Logger`: module-level `process.stdout.isTTY` property reads (potential
+  getters, never droppable) moved inside `consolePretty`.
+- `Utils`: when `internalCall` was unused, its dropped binding left behind a
+  retained initializer tail (`standard`/`forced` probe with computed property
+  reads). The selection is now wrapped in a single pure-annotated call.
+
+A minimal `Effect.succeed(123).pipe(Effect.runFork)` bundle shrinks by ~1.3%
+gzipped; bundles that don't use `Option` or `Headers` no longer pay for them.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "codemod": "node scripts/codemod.mjs",
     "build": "tspc -b tsconfig.packages.json && pnpm --recursive --parallel --filter \"./packages/**/*\" run build",
     "build:tsgo": "tsgo -b tsconfig.packages.json && pnpm --recursive --parallel --filter \"./packages/**/*\" run build:tsgo",
+    "bundle-compare": "bash scripts/bundle-compare.sh",
     "circular": "node scripts/circular.mjs",
     "test": "vitest",
     "coverage": "vitest --coverage",

--- a/packages/effect/src/Utils.ts
+++ b/packages/effect/src/Utils.ts
@@ -190,25 +190,32 @@ export type Gen<F extends TypeLambda> = <
   A
 >
 
-const InternalTypeId = "~effect/Utils/internal"
+// the probe is wrapped in a single function call (rather than module-level
+// statements) so the whole selection is pure-annotated by the build and
+// tree-shakable when `internalCall` is unused.
+const pickInternalCall = (): <A>(body: () => A) => A => {
+  const InternalTypeId = "~effect/Utils/internal"
 
-const standard = {
-  [InternalTypeId]: <A>(body: () => A) => {
-    return body()
-  }
-}
-
-const forced = {
-  [InternalTypeId]: <A>(body: () => A) => {
-    try {
+  const standard = {
+    [InternalTypeId]: <A>(body: () => A) => {
       return body()
-    } finally {
-      //
     }
   }
+
+  const forced = {
+    [InternalTypeId]: <A>(body: () => A) => {
+      try {
+        return body()
+      } finally {
+        //
+      }
+    }
+  }
+
+  const isNotOptimizedAway = standard[InternalTypeId](() => new Error().stack)?.includes(InternalTypeId) === true
+
+  return isNotOptimizedAway ? standard[InternalTypeId] : forced[InternalTypeId]
 }
 
-const isNotOptimizedAway = standard[InternalTypeId](() => new Error().stack)?.includes(InternalTypeId) === true
-
 /** @internal */
-export const internalCall = isNotOptimizedAway ? standard[InternalTypeId] : forced[InternalTypeId]
+export const internalCall = pickInternalCall()

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -6168,20 +6168,21 @@ const defaultDateFormat = (date: Date): string =>
     date.getSeconds().toString().padStart(2, "0")
   }.${date.getMilliseconds().toString().padStart(3, "0")}`
 
-const hasProcessStdout = typeof process === "object" &&
-  process !== null &&
-  typeof process.stdout === "object" &&
-  process.stdout !== null
-const processStdoutIsTTY = hasProcessStdout &&
-  process.stdout.isTTY === true
-const hasProcessStdoutOrDeno = hasProcessStdout || "Deno" in globalThis
-
 /** @internal */
 export const consolePretty = (options?: {
   readonly colors?: "auto" | boolean | undefined
   readonly formatDate?: ((date: Date) => string) | undefined
   readonly mode?: "browser" | "tty" | "auto" | undefined
 }) => {
+  // evaluated lazily so the module-level bundle stays free of `process`
+  // property accesses, which bundlers must retain as possible side effects
+  const hasProcessStdout = typeof process === "object" &&
+    process !== null &&
+    typeof process.stdout === "object" &&
+    process.stdout !== null
+  const processStdoutIsTTY = hasProcessStdout &&
+    process.stdout.isTTY === true
+  const hasProcessStdoutOrDeno = hasProcessStdout || "Deno" in globalThis
   const mode_ = options?.mode ?? "auto"
   const mode = mode_ === "auto" ? (hasProcessStdoutOrDeno ? "tty" : "browser") : mode_
   const isBrowser = mode === "browser"

--- a/packages/effect/src/internal/option.ts
+++ b/packages/effect/src/internal/option.ts
@@ -22,34 +22,39 @@ const CommonProto = {
   }
 }
 
-const SomeProto = Object.assign(Object.create(CommonProto), {
-  _tag: "Some",
-  _op: "Some",
-  [Equal.symbol]<A>(this: Option.Some<A>, that: unknown): boolean {
-    return (
-      isOption(that) && isSome(that) && Equal.equals(this.value, that.value)
-    )
-  },
-  [Hash.symbol]<A>(this: Option.Some<A>) {
-    return Hash.combine(Hash.hash(this._tag))(Hash.hash(this.value))
-  },
-  toString<A>(this: Option.Some<A>) {
-    return `some(${format(this.value)})`
-  },
-  toJSON<A>(this: Option.Some<A>) {
-    return {
-      _id: "Option",
-      _tag: this._tag,
-      value: toJson(this.value)
+// `valueOrUndefined` is folded into the initializer (rather than a separate
+// `Object.defineProperty(SomeProto, ...)` statement) so the whole definition
+// is pure-annotated by the build and tree-shakable.
+const SomeProto = Object.defineProperty(
+  Object.assign(Object.create(CommonProto), {
+    _tag: "Some",
+    _op: "Some",
+    [Equal.symbol]<A>(this: Option.Some<A>, that: unknown): boolean {
+      return (
+        isOption(that) && isSome(that) && Equal.equals(this.value, that.value)
+      )
+    },
+    [Hash.symbol]<A>(this: Option.Some<A>) {
+      return Hash.combine(Hash.hash(this._tag))(Hash.hash(this.value))
+    },
+    toString<A>(this: Option.Some<A>) {
+      return `some(${format(this.value)})`
+    },
+    toJSON<A>(this: Option.Some<A>) {
+      return {
+        _id: "Option",
+        _tag: this._tag,
+        value: toJson(this.value)
+      }
+    }
+  }),
+  "valueOrUndefined",
+  {
+    get() {
+      return this.value
     }
   }
-})
-
-Object.defineProperty(SomeProto, "valueOrUndefined", {
-  get() {
-    return this.value
-  }
-})
+)
 
 const NoneHash = Hash.hash("None")
 const NoneProto = Object.assign(Object.create(CommonProto), {

--- a/packages/effect/src/unstable/http/Headers.ts
+++ b/packages/effect/src/unstable/http/Headers.ts
@@ -62,9 +62,10 @@ export interface Headers extends Redactable.Redactable {
   readonly [key: string]: string
 }
 
-const Proto = Object.create(null)
-
-Object.defineProperties(Proto, {
+// the properties are folded into the initializer (rather than a separate
+// `Object.defineProperties(Proto, ...)` statement) so the whole definition
+// is pure-annotated by the build and tree-shakable.
+const Proto = Object.defineProperties(Object.create(null), {
   [TypeId]: {
     value: TypeId
   },

--- a/scripts/bundle-compare.sh
+++ b/scripts/bundle-compare.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the CI bundle-size comparison locally (see the Bundle job in
+# .github/workflows/check.yml): builds the current checkout, builds the base
+# ref in a cached git worktree under tmp/, then compares fixture bundle sizes.
+#
+# Usage: scripts/bundle-compare.sh [base-ref]   (default: main)
+#
+# The base worktree is reused across runs while it points at the same commit.
+# Remove it with: git worktree remove --force tmp/bundle-base
+
+BASE_REF="${1:-main}"
+ROOT="$(git rev-parse --show-toplevel)"
+BASE_DIR="$ROOT/tmp/bundle-base"
+OUTPUT_PATH="$ROOT/tmp/bundle-stats.txt"
+
+cd "$ROOT"
+
+echo "Building current checkout..."
+pnpm build:tsgo
+
+BASE_COMMIT="$(git rev-parse "$BASE_REF")"
+
+if [ -d "$BASE_DIR/packages/effect/dist" ] && [ "$(git -C "$BASE_DIR" rev-parse HEAD)" = "$BASE_COMMIT" ]; then
+  echo "Reusing built base worktree at $BASE_DIR ($BASE_REF @ ${BASE_COMMIT:0:8})"
+else
+  if [ -d "$BASE_DIR" ]; then
+    git worktree remove --force "$BASE_DIR"
+  fi
+  echo "Creating base worktree at $BASE_DIR ($BASE_REF @ ${BASE_COMMIT:0:8})"
+  git worktree add --detach "$BASE_DIR" "$BASE_COMMIT"
+  echo "Building base checkout..."
+  (cd "$BASE_DIR" && pnpm install && pnpm build:tsgo)
+fi
+
+node packages/tools/bundle/src/bin.ts compare \
+  --base-dir "$BASE_DIR/packages/tools/bundle/fixtures" \
+  --output-path "$OUTPUT_PATH"
+
+echo
+cat "$OUTPUT_PATH"


### PR DESCRIPTION
## Summary

Four spots in `packages/effect` defeated bundler tree-shaking because they were module-level statements that cannot be `#__PURE__`-annotated by the `annotate-pure-calls` build step (it can only annotate calls in assignment contexts — a bare statement's result is by definition unused, so annotating it would mean unconditional deletion):

- **`internal/option.ts`** — a bare `Object.defineProperty(SomeProto, "valueOrUndefined", ...)` statement anchored the entire Option proto chain (`SomeProto`, `CommonProto`, `isOption`, `isSome`) into every bundle, even ones that never use `Option`. Folded into the `SomeProto` initializer — identical descriptor semantics, now one pure-annotated expression.
- **`unstable/http/Headers.ts`** — same pattern with `Object.defineProperties(Proto, ...)`, same fix.
- **`internal/effect.ts`** — module-level `process.stdout.isTTY` property reads (potential getters, never droppable under Rollup's default `propertyReadSideEffects`) moved inside `consolePretty`, which runs once per logger construction.
- **`Utils.ts`** — when `internalCall` is unused, Rollup dropped the binding but had to retain the initializer tail (`standard`/`forced` probe with computed property reads). The selection is now wrapped in a single `pickInternalCall()` call that the build pure-annotates.

No observable runtime behavior change: all four are restructurings of module-initialization code (same objects, same property descriptors, same evaluation results).

Also adds `scripts/bundle-compare.sh` (`pnpm bundle-compare [base-ref]`), which reproduces the CI Bundle job locally: builds the current checkout and the base ref in a cached worktree under `tmp/`, then runs the `@effect/bundle` comparison.

## Results

`pnpm bundle-compare` against `main`:

| Fixture | main | this PR | diff |
|---|---|---|---|
| `basic.ts` | 6.72 KB | 6.63 KB | −1.31% |
| `brand.ts` | 6.20 KB | 6.15 KB | −0.82% |
| `batching.ts` | 9.24 KB | 9.17 KB | −0.78% |
| `metric.ts` | 8.56 KB | 8.48 KB | −0.88% |
| `optic.ts` | 7.37 KB | 7.32 KB | −0.71% |
| `queue.ts` | 11.08 KB | 11.03 KB | −0.51% |
| `stm.ts` | 11.96 KB | 11.90 KB | −0.48% |
| `logger.ts` | 10.19 KB | 10.15 KB | −0.38% |

(Fixtures that genuinely use Option/Headers keep their size; nothing regresses.)

After these fixes, bundling every fixture with Rollup's maximally aggressive tree-shake settings produces **0 bytes** of difference vs defaults — there are no remaining statement-level shake failures in the built dist.

## Validation

- `pnpm test` — Option, Logger, Headers, Effect suites (262 tests passed)
- `pnpm check:tsgo` clean
- `pnpm lint-fix` clean
- Dist-wide scans for remaining bare top-level expression statements and conditional-initializer property reads: no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)