### PR TITLE
Encode HTTP API path params

### DIFF
--- a/.changeset/tidy-stacks-encode.md
+++ b/.changeset/tidy-stacks-encode.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Encode HTTP API client path parameters when building request URLs.

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -620,28 +620,25 @@ export const urlBuilder = <Api extends HttpApi.Any>(api: Api, options?: {
 
 // ----------------------------------------------------------------------------
 
-const paramsRegExp = /:(\w+)\??/g
+const paramsRegExp = /(\/?):(\w+)(\?)?/g
 
 const compilePath = (path: string) => {
-  const segments = path.split(paramsRegExp)
-  const len = segments.length
-  if (len === 1) {
+  if (!paramsRegExp.test(path)) {
     return (_: any) => path
   }
+  paramsRegExp.lastIndex = 0
   return (params: Record<string, string | undefined>) => {
-    let url = segments[0]
-    for (let i = 1; i < len; i++) {
-      if (i % 2 === 0) {
-        url += segments[i]
-      } else {
-        const value = params[segments[i]]
-        if (value === undefined) {
-          throw new Error(`Missing path parameter: ${segments[i]}`)
+    paramsRegExp.lastIndex = 0
+    return path.replace(paramsRegExp, (_, slash: string, key: string, optional: string | undefined) => {
+      const value = params[key]
+      if (value === undefined) {
+        if (optional !== undefined) {
+          return ""
         }
-        url += encodeURIComponent(value)
+        throw new Error(`Missing path parameter: ${key}`)
       }
-    }
-    return url
+      return `${slash}${encodeURIComponent(value)}`
+    })
   }
 }
 

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -635,7 +635,10 @@ const compilePath = (path: string) => {
         url += segments[i]
       } else {
         const value = params[segments[i]]
-        url += value === undefined ? value : encodeURIComponent(value)
+        if (value === undefined) {
+          throw new Error(`Missing path parameter: ${segments[i]}`)
+        }
+        url += encodeURIComponent(value)
       }
     }
     return url

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -634,7 +634,8 @@ const compilePath = (path: string) => {
       if (i % 2 === 0) {
         url += segments[i]
       } else {
-        url += params[segments[i]]
+        const value = params[segments[i]]
+        url += value === undefined ? value : encodeURIComponent(value)
       }
     }
     return url

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@effect/vitest"
 import { strictEqual } from "@effect/vitest/utils"
-import { Schema } from "effect"
+import { Effect, Schema } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { HttpApi, HttpApiClient, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 
 describe("HttpApiClient", () => {
@@ -41,6 +42,34 @@ describe("HttpApiClient", () => {
       )
     })
 
+    it("encodes path parameters", () => {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("stacks")
+            .add(
+              HttpApiEndpoint.get("listResources", "/state/stacks/:stack/stages/:stage/resources", {
+                params: {
+                  stack: Schema.String,
+                  stage: Schema.String
+                }
+              })
+            )
+        )
+      const builder = HttpApiClient.urlBuilder(Api, {
+        baseUrl: "https://api.example.com"
+      })
+
+      strictEqual(
+        builder.stacks.listResources({
+          params: {
+            stack: "a/b",
+            stage: "prod/blue"
+          }
+        }),
+        "https://api.example.com/state/stacks/a%2Fb/stages/prod%2Fblue/resources"
+      )
+    })
+
     it("returns relative urls when baseUrl is omitted", () => {
       const builder = HttpApiClient.urlBuilder(Api)
 
@@ -64,4 +93,38 @@ describe("HttpApiClient", () => {
       strictEqual(builder.health(), "https://api.example.com/v1/health")
     })
   })
+
+  it.effect("encodes path parameters when executing requests", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("stacks")
+            .add(
+              HttpApiEndpoint.get("listResources", "/state/stacks/:stack/stages/:stage/resources", {
+                params: {
+                  stack: Schema.String,
+                  stage: Schema.String
+                }
+              })
+            )
+        )
+      const httpClient = HttpClient.make((request, url) =>
+        Effect.sync(() => {
+          strictEqual(url.toString(), "https://api.example.com/state/stacks/a%2Fb/stages/prod%2Fblue/resources")
+          return HttpClientResponse.fromWeb(request, new Response(null, { status: 204 }))
+        })
+      )
+      const client = yield* HttpApiClient.makeWith(Api, {
+        httpClient,
+        baseUrl: "https://api.example.com"
+      })
+
+      yield* client.stacks.listResources({
+        params: {
+          stack: "a/b",
+          stage: "prod/blue"
+        },
+        responseMode: "response-only"
+      })
+    }))
 })

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -70,6 +70,32 @@ describe("HttpApiClient", () => {
       )
     })
 
+    it("omits missing optional path parameters", () => {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("files")
+            .add(
+              HttpApiEndpoint.get("download", "/files/:path?", {
+                params: {
+                  path: Schema.optional(Schema.String)
+                }
+              })
+            )
+        )
+      const builder = HttpApiClient.urlBuilder(Api, {
+        baseUrl: "https://api.example.com"
+      })
+
+      strictEqual(
+        builder.files.download({ params: {} }),
+        "https://api.example.com/files"
+      )
+      strictEqual(
+        builder.files.download({ params: { path: "a/b" } }),
+        "https://api.example.com/files/a%2Fb"
+      )
+    })
+
     it("returns relative urls when baseUrl is omitted", () => {
       const builder = HttpApiClient.urlBuilder(Api)
 

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -153,4 +153,42 @@ describe("HttpApiClient", () => {
         responseMode: "response-only"
       })
     }))
+
+  it.effect("omits optional path parameters when executing requests", () =>
+    Effect.gen(function*() {
+      const Api = HttpApi.make("Api")
+        .add(
+          HttpApiGroup.make("files")
+            .add(
+              HttpApiEndpoint.get("download", "/files/:path?", {
+                params: {
+                  path: Schema.optional(Schema.String)
+                }
+              })
+            )
+        )
+      const urls: Array<string> = []
+      const httpClient = HttpClient.make((request, url) =>
+        Effect.sync(() => {
+          urls.push(url.toString())
+          return HttpClientResponse.fromWeb(request, new Response(null, { status: 204 }))
+        })
+      )
+      const client = yield* HttpApiClient.makeWith(Api, {
+        httpClient,
+        baseUrl: "https://api.example.com"
+      })
+
+      yield* client.files.download({
+        params: {},
+        responseMode: "response-only"
+      })
+      yield* client.files.download({
+        params: { path: "a/b" },
+        responseMode: "response-only"
+      })
+
+      strictEqual(urls[0], "https://api.example.com/files")
+      strictEqual(urls[1], "https://api.example.com/files/a%2Fb")
+    }))
 })


### PR DESCRIPTION
## Summary
- encode generated HTTP API client path parameters with encodeURIComponent
- add urlBuilder and generated client regression coverage for slash-containing params
- add a patch changeset

## Validation
- pnpm test packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
- pnpm lint-fix
- pnpm check:tsgo