### PR TITLE
Swallow reader.cancel rejection in Stream.fromReadableStream finalizer

### DIFF
--- a/.changeset/fix-from-readable-stream-cancel-defect.md
+++ b/.changeset/fix-from-readable-stream-cancel-defect.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Stream.fromReadableStream: swallow the `reader.cancel()` rejection in the finalizer. Cancelling the reader of an already-errored ReadableStream rejects with the stored error, which turned the typed `onError` failure into a defect.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1416,7 +1416,10 @@ export const fromReadableStream = <A, E>(
       scope,
       options.releaseLockOnEnd
         ? Effect.sync(() => reader.releaseLock())
-        : Effect.promise(() => reader.cancel())
+        // Cancelling the reader of an already-errored stream rejects with the
+        // stored error - swallow it so the finalizer does not die with a
+        // defect after the error was already surfaced through `onError`.
+        : Effect.promise(() => reader.cancel().catch(constVoid))
     )
     return Effect.flatMap(
       Effect.tryPromise({

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1416,9 +1416,6 @@ export const fromReadableStream = <A, E>(
       scope,
       options.releaseLockOnEnd
         ? Effect.sync(() => reader.releaseLock())
-        // Cancelling the reader of an already-errored stream rejects with the
-        // stored error - swallow it so the finalizer does not die with a
-        // defect after the error was already surfaced through `onError`.
         : Effect.promise(() => reader.cancel().catch(constVoid))
     )
     return Effect.flatMap(

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -238,6 +238,28 @@ describe("Stream", () => {
         assert.deepStrictEqual(result, [2, 4])
         assert.strictEqual(yield* Ref.get(releases), 2)
       }))
+
+    it.effect("fromReadableStream - errored streams fail with the mapped error, not a finalizer defect", () =>
+      Effect.gen(function*() {
+        // Cancelling the reader of an already-errored ReadableStream rejects
+        // with the stored error. The cancel in the finalizer must swallow that
+        // rejection so the typed `onError` failure is the only cause.
+        const exit = yield* Stream.fromReadableStream({
+          evaluate: () =>
+            new ReadableStream<number>({
+              start(controller) {
+                controller.error(new Error("boom"))
+              }
+            }),
+          onError: (error) => new Error(`mapped: ${(error as Error).message}`)
+        }).pipe(Stream.runDrain, Effect.exit)
+
+        assertTrue(Exit.isFailure(exit))
+        if (Exit.isFailure(exit)) {
+          assertTrue(exit.cause.reasons.every(Cause.isFailReason))
+          deepStrictEqual(Cause.squash(exit.cause), new Error("mapped: boom"))
+        }
+      }))
   })
 
   describe("encoding", () => {

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -241,9 +241,6 @@ describe("Stream", () => {
 
     it.effect("fromReadableStream - errored streams fail with the mapped error, not a finalizer defect", () =>
       Effect.gen(function*() {
-        // Cancelling the reader of an already-errored ReadableStream rejects
-        // with the stored error. The cancel in the finalizer must swallow that
-        // rejection so the typed `onError` failure is the only cause.
         const exit = yield* Stream.fromReadableStream({
           evaluate: () =>
             new ReadableStream<number>({


### PR DESCRIPTION
Fixes #2372

`reader.cancel()` rejects with the stored error when the `ReadableStream` has already errored. The finalizer runs it through `Effect.promise`, so the rejection came back as a defect and clobbered the typed failure that `onError` had already produced — `Stream.runDrain` on an errored source ended with `["Die"]` instead of `["Fail"]`.

The finalizer now swallows the cancel rejection. The error has already been surfaced through `onError` at that point, so there's nothing to lose.

Added a regression test asserting an errored source fails with only the mapped error, plus a changeset.
