### PR TITLE
Fix ConfigProvider.orElse ignoring mapInput and nested transformations applied to its operands

### DIFF
--- a/.changeset/config-provider-orelse-transformations.md
+++ b/.changeset/config-provider-orelse-transformations.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix ConfigProvider.orElse ignoring `mapInput` and `nested` transformations applied to its operands.

--- a/packages/effect/src/ConfigProvider.ts
+++ b/packages/effect/src/ConfigProvider.ts
@@ -413,6 +413,11 @@ export function make(
  * The fallback only runs when the path is not found (`undefined`). A
  * `SourceError` from `self` is not caught; it propagates immediately.
  *
+ * Lookups go through each operand's `load`, so a prefix added on top of the
+ * combined provider via {@link nested} passes through each operand's own
+ * `mapInput`. This differs from applying {@link nested} directly to an
+ * operand, where the prefix is prepended after that operand's `mapInput` runs.
+ *
  * **Example** (Falling back to a default provider)
  *
  * ```ts
@@ -437,7 +442,7 @@ export const orElse: {
 } = dual(
   2,
   (self: ConfigProvider, that: ConfigProvider): ConfigProvider =>
-    make((path) => Effect.flatMap(self.get(path), (node) => node ? Effect.succeed(node) : that.get(path)))
+    make((path) => Effect.flatMap(self.load(path), (node) => node ? Effect.succeed(node) : that.load(path)))
 )
 
 /**

--- a/packages/effect/test/ConfigProvider.test.ts
+++ b/packages/effect/test/ConfigProvider.test.ts
@@ -37,6 +37,22 @@ describe("ConfigProvider", () => {
     await assertSuccess(provider, ["B"], ConfigProvider.makeValue("value2"))
   })
 
+  it("orElse applies each operand's transformations", async () => {
+    const primary = ConfigProvider.fromEnv({
+      env: {
+        "DATABASE_HOST": "from-env"
+      }
+    }).pipe(ConfigProvider.constantCase)
+    const fallback = ConfigProvider.fromEnv({
+      env: {
+        "APP_PORT": "3000"
+      }
+    }).pipe(ConfigProvider.nested("APP"))
+    const provider = primary.pipe(ConfigProvider.orElse(fallback))
+    await assertSuccess(provider, ["databaseHost"], ConfigProvider.makeValue("from-env"))
+    await assertSuccess(provider, ["PORT"], ConfigProvider.makeValue("3000"))
+  })
+
   it("constantCase", async () => {
     const provider = ConfigProvider.constantCase(ConfigProvider.fromEnv({
       env: {


### PR DESCRIPTION
## What changed

- `ConfigProvider.orElse` now resolves lookups through each operand's `load` instead of the raw `get`, so the `mapInput` and `prefix` transformations set by combinators like `constantCase`, `mapInput`, and `nested` are applied during both primary and fallback lookups.
- Added a regression test covering `orElse` with a `constantCase` primary and a `nested` fallback (verified to fail against the previous implementation).
- Added a **Gotchas** note to the `orElse` JSDoc documenting the path semantics (see below), plus a patch changeset.

## Why

`load` is the public lookup contract (`Config` only ever calls `load`), and it is where a provider's `mapInput`/`prefix` are applied. Because `orElse` consulted the raw `get`, operand transformations were silently dropped:

```ts
const env = ConfigProvider.fromEnv({ env: { DATABASE_HOST: "from-env" } })
  .pipe(ConfigProvider.constantCase)
const defaults = ConfigProvider.fromUnknown({ databaseHost: "from-defaults" })

ConfigProvider.orElse(env, defaults).load(["databaseHost"])
// before: "from-defaults" (constantCase ignored, env lookup misses)
// after:  "from-env"
```

## Notes for reviewers

One observable consequence worth calling out: lookups now flow through each operand's `load`, so a prefix added on top of the combined provider (e.g. `nested(orElse(p, q), "app")`) passes through each operand's own `mapInput` — unlike `nested` applied to an operand directly, where the prefix is prepended after that operand's `mapInput` runs. This follows from treating operands as black boxes behind `load` (the only composition possible for a binary combinator, since two operands' transforms cannot be hoisted into the combined provider's single `mapInput`/`prefix` slot). It is documented in the new JSDoc gotcha.

Validation: `pnpm vitest run packages/effect/test/ConfigProvider.test.ts` (55/55), `pnpm lint`, `pnpm check:tsgo` all pass; the new test fails when the `orElse` line is reverted to `get`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)