### PR TITLE
feat: preserve reasoning deltas for chat completions compat

### DIFF
--- a/.changeset/openai-compat-reasoning.md
+++ b/.changeset/openai-compat-reasoning.md
@@ -1,0 +1,9 @@
+---
+"@effect/ai-openai-compat": patch
+---
+
+Surface reasoning tokens from OpenAI-compatible chat completion responses.
+
+Previously, reasoning tokens streamed by OpenAI-compatible providers were silently discarded because the chat completion message and delta schemas only parsed `role` / `content` / `tool_calls`.
+
+The schemas now accept the optional `reasoning` field (e.g. Baseten, OpenRouter-style APIs) as well as the DeepSeek-style `reasoning_content` field. Streamed reasoning tokens are emitted as `reasoning-start` / `reasoning-delta` / `reasoning-end` stream parts, with an open reasoning part closed when text content begins or the stream ends. Non-streaming responses surface reasoning as a `reasoning` response part.

--- a/.changeset/openai-compat-reasoning.md
+++ b/.changeset/openai-compat-reasoning.md
@@ -3,7 +3,3 @@
 ---
 
 Surface reasoning tokens from OpenAI-compatible chat completion responses.
-
-Previously, reasoning tokens streamed by OpenAI-compatible providers were silently discarded because the chat completion message and delta schemas only parsed `role` / `content` / `tool_calls`.
-
-The schemas now accept the optional `reasoning` field (e.g. Baseten, OpenRouter-style APIs) as well as the DeepSeek-style `reasoning_content` field. Streamed reasoning tokens are emitted as `reasoning-start` / `reasoning-delta` / `reasoning-end` stream parts, with an open reasoning part closed when text content begins or the stream ends. Non-streaming responses surface reasoning as a `reasoning` response part.

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1101,12 +1101,19 @@ const ChatCompletionToolCallDelta = Schema.Struct({
 const ChatCompletionMessage = Schema.Struct({
   role: Schema.optionalKey(Schema.String),
   content: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  // Reasoning tokens emitted by OpenAI-compatible providers. Most providers
+  // (e.g. Baseten, OpenRouter) use `reasoning`, while DeepSeek and several
+  // vLLM deployments use `reasoning_content`.
+  reasoning: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  reasoning_content: Schema.optionalKey(Schema.NullOr(Schema.String)),
   tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
 })
 
 const ChatCompletionDelta = Schema.Struct({
   role: Schema.optionalKey(Schema.String),
   content: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  reasoning: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  reasoning_content: Schema.optionalKey(Schema.NullOr(Schema.String)),
   tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCallDelta))
 })
 

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1100,13 +1100,10 @@ const ChatCompletionToolCallDelta = Schema.Struct({
 
 const ChatCompletionMessage = Schema.Struct({
   role: Schema.optionalKey(Schema.String),
-  content: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  // Reasoning tokens emitted by OpenAI-compatible providers. Most providers
-  // (e.g. Baseten, OpenRouter) use `reasoning`, while DeepSeek and several
-  // vLLM deployments use `reasoning_content`.
+content: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning_content: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
+tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
 })
 
 const ChatCompletionDelta = Schema.Struct({

--- a/packages/ai/openai-compat/src/OpenAiClient.ts
+++ b/packages/ai/openai-compat/src/OpenAiClient.ts
@@ -1100,10 +1100,10 @@ const ChatCompletionToolCallDelta = Schema.Struct({
 
 const ChatCompletionMessage = Schema.Struct({
   role: Schema.optionalKey(Schema.String),
-content: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  content: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning: Schema.optionalKey(Schema.NullOr(Schema.String)),
   reasoning_content: Schema.optionalKey(Schema.NullOr(Schema.String)),
-tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
+  tool_calls: Schema.optionalKey(Schema.Array(ChatCompletionToolCall))
 })
 
 const ChatCompletionDelta = Schema.Struct({

--- a/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
+++ b/packages/ai/openai-compat/src/OpenAiLanguageModel.ts
@@ -1064,6 +1064,11 @@ const makeResponse = Effect.fnUntraced(
     const message = choice?.message
 
     if (message !== undefined) {
+      const reasoning = message.reasoning ?? message.reasoning_content
+      if (Predicate.isNotNullish(reasoning) && reasoning.length > 0) {
+        parts.push({ type: "reasoning", text: reasoning })
+      }
+
       if (
         message.content !== undefined && Predicate.isNotNull(message.content) && message.content.length > 0
       ) {
@@ -1137,6 +1142,8 @@ const makeStreamResponse = Effect.fnUntraced(
     let metadataEmitted = false
     let textStarted = false
     let textId = ""
+    let reasoningStarted = false
+    let reasoningId = ""
     let hasToolCalls = false
     const activeToolCalls: Record<number, ActiveToolCall> = {}
 
@@ -1145,6 +1152,14 @@ const makeStreamResponse = Effect.fnUntraced(
         const parts: Array<Response.StreamPartEncoded> = []
 
         if (event === "[DONE]") {
+          if (reasoningStarted) {
+            parts.push({
+              type: "reasoning-end",
+              id: reasoningId,
+              metadata: { openai: { ...makeItemIdMetadata(reasoningId) } }
+            })
+          }
+
           if (textStarted) {
             parts.push({
               type: "text-end",
@@ -1202,6 +1217,7 @@ const makeStreamResponse = Effect.fnUntraced(
         if (!metadataEmitted) {
           metadataEmitted = true
           textId = `${event.id}_message`
+          reasoningId = `${event.id}_reasoning`
           parts.push({
             type: "response-metadata",
             id: event.id,
@@ -1216,7 +1232,29 @@ const makeStreamResponse = Effect.fnUntraced(
           return parts
         }
 
+        const reasoningDelta = choice.delta?.reasoning ?? choice.delta?.reasoning_content
+        if (Predicate.isNotNullish(reasoningDelta) && reasoningDelta.length > 0) {
+          if (!reasoningStarted) {
+            reasoningStarted = true
+            parts.push({
+              type: "reasoning-start",
+              id: reasoningId,
+              metadata: { openai: { ...makeItemIdMetadata(reasoningId) } }
+            })
+          }
+          parts.push({ type: "reasoning-delta", id: reasoningId, delta: reasoningDelta })
+        }
+
         if (choice.delta?.content !== undefined && Predicate.isNotNull(choice.delta.content)) {
+          if (reasoningStarted) {
+            reasoningStarted = false
+            parts.push({
+              type: "reasoning-end",
+              id: reasoningId,
+              metadata: { openai: { ...makeItemIdMetadata(reasoningId) } }
+            })
+          }
+
           if (!textStarted) {
             textStarted = true
             parts.push({

--- a/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
+++ b/packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts
@@ -486,6 +486,82 @@ describe("OpenAiLanguageModel", () => {
           reasoning: 0
         })
       }))
+
+    it.effect("surfaces reasoning from non-streaming responses", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "stop",
+                    message: {
+                      role: "assistant",
+                      reasoning: "I should greet the user.",
+                      content: "Hello!"
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const result = yield* LanguageModel.generateText({ prompt: "hello" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        const reasoning = result.content.find((part) => part.type === "reasoning")
+        assert.isDefined(reasoning)
+        if (reasoning?.type !== "reasoning") {
+          return
+        }
+        assert.strictEqual(reasoning.text, "I should greet the user.")
+        assert.strictEqual(result.text, "Hello!")
+      }))
+
+    it.effect("surfaces reasoning_content from non-streaming responses", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(jsonResponse(
+                request,
+                makeChatCompletion({
+                  choices: [{
+                    index: 0,
+                    finish_reason: "stop",
+                    message: {
+                      role: "assistant",
+                      reasoning_content: "I should greet the user.",
+                      content: "Hello!"
+                    }
+                  }]
+                })
+              ))
+            )
+          ))
+        )
+
+        const result = yield* LanguageModel.generateText({ prompt: "hello" }).pipe(
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        const reasoning = result.content.find((part) => part.type === "reasoning")
+        assert.isDefined(reasoning)
+        if (reasoning?.type !== "reasoning") {
+          return
+        }
+        assert.strictEqual(reasoning.text, "I should greet the user.")
+        assert.strictEqual(result.text, "Hello!")
+      }))
   })
 
   describe("generateObject", () => {
@@ -1088,6 +1164,150 @@ describe("OpenAiLanguageModel", () => {
         }
         assert.strictEqual(toolCall.name, "TestTool")
         assert.deepStrictEqual(toolCall.params, { input: "hello" })
+      }))
+
+    it.effect("emits reasoning lifecycle parts for delta.reasoning", () =>
+      Effect.gen(function*() {
+        const chunk = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
+          id: "chatcmpl_reasoning_1",
+          object: "chat.completion.chunk",
+          model: "gpt-4o-mini",
+          created: 1,
+          choices: [{ index: 0, delta, finish_reason: finishReason }]
+        })
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                chunk({ reasoning: "Let me think" }),
+                chunk({ reasoning: " about this." }),
+                chunk({ content: "Hello" }),
+                chunk({ content: " there" }, "stop"),
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({ prompt: "test" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        assert.deepStrictEqual(parts.map((part) => part.type), [
+          "response-metadata",
+          "reasoning-start",
+          "reasoning-delta",
+          "reasoning-delta",
+          "reasoning-end",
+          "text-start",
+          "text-delta",
+          "text-delta",
+          "text-end",
+          "finish"
+        ])
+
+        const reasoningText = parts
+          .flatMap((part) => part.type === "reasoning-delta" ? [part.delta] : [])
+          .join("")
+        assert.strictEqual(reasoningText, "Let me think about this.")
+
+        const reasoningIds = parts.flatMap((part) =>
+          part.type === "reasoning-start" || part.type === "reasoning-delta" || part.type === "reasoning-end"
+            ? [part.id]
+            : []
+        )
+        assert.strictEqual(new Set(reasoningIds).size, 1)
+
+        const textIds = parts.flatMap((part) => part.type === "text-start" ? [part.id] : [])
+        assert.notStrictEqual(reasoningIds[0], textIds[0])
+      }))
+
+    it.effect("emits reasoning lifecycle parts for delta.reasoning_content", () =>
+      Effect.gen(function*() {
+        const chunk = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
+          id: "chatcmpl_reasoning_2",
+          object: "chat.completion.chunk",
+          model: "gpt-4o-mini",
+          created: 1,
+          choices: [{ index: 0, delta, finish_reason: finishReason }]
+        })
+
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                chunk({ reasoning_content: "Thinking..." }),
+                chunk({ content: "Answer." }, "stop"),
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({ prompt: "test" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        assert.deepStrictEqual(parts.map((part) => part.type), [
+          "response-metadata",
+          "reasoning-start",
+          "reasoning-delta",
+          "reasoning-end",
+          "text-start",
+          "text-delta",
+          "text-end",
+          "finish"
+        ])
+
+        const reasoningText = parts
+          .flatMap((part) => part.type === "reasoning-delta" ? [part.delta] : [])
+          .join("")
+        assert.strictEqual(reasoningText, "Thinking...")
+      }))
+
+    it.effect("closes an open reasoning part at stream end", () =>
+      Effect.gen(function*() {
+        const layer = OpenAiClient.layer({ apiKey: Redacted.make("sk-test-key") }).pipe(
+          Layer.provide(Layer.succeed(
+            HttpClient.HttpClient,
+            makeHttpClient((request) =>
+              Effect.succeed(sseResponse(request, [
+                {
+                  id: "chatcmpl_reasoning_3",
+                  object: "chat.completion.chunk",
+                  model: "gpt-4o-mini",
+                  created: 1,
+                  choices: [{ index: 0, delta: { reasoning: "Only thoughts." }, finish_reason: "stop" }]
+                },
+                "[DONE]"
+              ]))
+            )
+          ))
+        )
+
+        const partsChunk = yield* LanguageModel.streamText({ prompt: "test" }).pipe(
+          Stream.runCollect,
+          Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+          Effect.provide(layer)
+        )
+
+        const parts = globalThis.Array.from(partsChunk)
+        assert.deepStrictEqual(parts.map((part) => part.type), [
+          "response-metadata",
+          "reasoning-start",
+          "reasoning-delta",
+          "reasoning-end",
+          "finish"
+        ])
       }))
   })
 


### PR DESCRIPTION
## Summary

OpenAI-compatible providers stream reasoning tokens on chat-completion chunks — most (Baseten, OpenRouter-style gateways) as `delta.reasoning`, DeepSeek and several vLLM deployments as `delta.reasoning_content`. `@effect/ai-openai-compat` currently drops these silently: the chat completion message/delta schemas only parse `role` / `content` / `tool_calls`, so no reasoning parts are ever emitted.

This PR:

- Adds optional, nullable `reasoning` and `reasoning_content` fields to the `ChatCompletionMessage` and `ChatCompletionDelta` schemas.
- Emits streamed reasoning with the same `reasoning-start` / `reasoning-delta` / `reasoning-end` lifecycle used for text parts, following the `@effect/ai-openrouter` precedent: an open reasoning part is closed when text content begins, and any still-open reasoning part is closed at `[DONE]` (reasoning-only responses). Reasoning parts use a `${id}_reasoning` id alongside the existing `${id}_message` text id, with matching `itemId` metadata.
- Surfaces reasoning on non-streaming responses as a `reasoning` response part, ordered before the text part.
- Only non-empty deltas open/emit reasoning parts, so providers that send `reasoning: ""` or `reasoning: null` markers on content chunks don't produce spurious parts.

## Test plan

Added to `packages/ai/openai-compat/test/OpenAiLanguageModel.test.ts` using the existing SSE fixture helpers:

- interleaved `reasoning` + `content` stream → exact part sequence (`reasoning-start` → 2× `reasoning-delta` → `reasoning-end` → `text-start` → …), accumulated reasoning text, stable reasoning ids distinct from the text id
- `reasoning_content` (DeepSeek-style) stream → same lifecycle
- reasoning-only stream → reasoning part closed at `[DONE]` before `finish`
- non-streaming `reasoning` and `reasoning_content` → `reasoning` response part plus intact text

Ran `pnpm lint-fix`, `pnpm check:tsgo`, and the full `packages/ai/openai-compat` suite (35 passing).