### PR TITLE
Fix searchParam history state handling

### DIFF
--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -2206,10 +2206,10 @@ export const searchParam = <S extends Schema.Codec<any, string> = never>(name: s
 
       if (encode) {
         const encoded = Option.flatMap(value, (v) => Exit.getSuccess(encode(v as S["Type"])))
-        searchParamState.updates.set(name, Option.getOrElse(encoded, () => ""))
+        queueSearchParamUpdate(name, Option.getOrElse(encoded, () => ""))
         value = Option.zipRight(encoded, value)
       } else {
-        searchParamState.updates.set(name, value)
+        queueSearchParamUpdate(name, value)
       }
       ctx.setSelf(value)
       if (searchParamState.timeout) {
@@ -2220,27 +2220,77 @@ export const searchParam = <S extends Schema.Codec<any, string> = never>(name: s
   )
 }
 
+interface SearchParamUpdate {
+  readonly value: string
+  readonly pathname: string
+}
+
 const searchParamState = {
   timeout: undefined as number | undefined,
-  updates: new Map<string, string>(),
-  updating: false
+  updates: new Map<string, SearchParamUpdate>(),
+  updating: false,
+  popstateHookWindow: undefined as typeof window | undefined
+}
+
+function queueSearchParamUpdate(name: string, value: string) {
+  installSearchParamPopstateHook()
+  searchParamState.updates.set(name, { value, pathname: window.location.pathname })
+}
+
+function installSearchParamPopstateHook() {
+  if (searchParamState.popstateHookWindow === window) return
+  searchParamState.popstateHookWindow = window
+  window.addEventListener("popstate", clearPendingSearchParamUpdates)
+}
+
+function clearPendingSearchParamUpdates() {
+  searchParamState.updates.clear()
+  if (searchParamState.timeout !== undefined) {
+    clearTimeout(searchParamState.timeout)
+    searchParamState.timeout = undefined
+  }
+}
+
+function nextSearchParamHistoryState() {
+  const current: unknown = window.history.state
+  if (typeof current !== "object" || current === null) return {}
+  const next: Record<string, unknown> = { ...current }
+  const index = next["__TSR_index"]
+  if (typeof index === "number") {
+    const key = Math.random().toString(36).slice(2, 10)
+    next["__TSR_index"] = index + 1
+    next["__TSR_key"] = key
+    next["key"] = key
+  }
+  return next
 }
 
 function updateSearchParams() {
   searchParamState.timeout = undefined
   searchParamState.updating = true
-  const searchParams = new URLSearchParams(window.location.search)
-  for (const [key, value] of searchParamState.updates.entries()) {
-    if (value.length > 0) {
-      searchParams.set(key, value)
-    } else {
-      searchParams.delete(key)
+  try {
+    const pathname = window.location.pathname
+    const searchParams = new URLSearchParams(window.location.search)
+    let changed = false
+    for (const [key, update] of searchParamState.updates.entries()) {
+      if (update.pathname !== pathname) continue
+      const current = searchParams.get(key) ?? ""
+      if (update.value === current) continue
+      if (update.value.length > 0) {
+        searchParams.set(key, update.value)
+      } else {
+        searchParams.delete(key)
+      }
+      changed = true
     }
+    searchParamState.updates.clear()
+    if (!changed) return
+    const query = searchParams.toString()
+    const newUrl = query.length > 0 ? `${pathname}?${query}` : pathname
+    window.history.pushState(nextSearchParamHistoryState(), "", newUrl)
+  } finally {
+    searchParamState.updating = false
   }
-  searchParamState.updates.clear()
-  const newUrl = `${window.location.pathname}?${searchParams.toString()}`
-  window.history.pushState({}, "", newUrl)
-  searchParamState.updating = false
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -147,6 +147,77 @@ describe.sequential("Atom", () => {
     }
   })
 
+  it("searchParam preserves TanStack history state on push", () => {
+    const previousWindow = (globalThis as any).window
+    const r = AtomRegistry.make()
+    let pushed: any
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: { pathname: "/accounts", search: "" },
+        history: {
+          state: { __TSR_index: 3, __TSR_key: "old", key: "old", keep: true },
+          pushState: (state: any, _title: string, url: string) => {
+            pushed = { state, url }
+          }
+        },
+        addEventListener: () => {},
+        removeEventListener: () => {}
+      },
+      configurable: true,
+      writable: true
+    })
+
+    try {
+      const q = Atom.searchParam("q")
+      r.set(q, "acme")
+      vitest.advanceTimersByTime(500)
+      expect(pushed.url).toEqual("/accounts?q=acme")
+      expect(pushed.state.keep).toEqual(true)
+      expect(pushed.state.__TSR_index).toEqual(4)
+      expect(pushed.state.__TSR_key).not.toEqual("old")
+      expect(pushed.state.key).toEqual(pushed.state.__TSR_key)
+    } finally {
+      r.dispose()
+      if (typeof previousWindow === "undefined") delete (globalThis as any).window
+      else Object.defineProperty(globalThis, "window", { value: previousWindow, configurable: true, writable: true })
+    }
+  })
+
+  it("searchParam discards pending writes across route and history navigation", () => {
+    const previousWindow = (globalThis as any).window
+    const r = AtomRegistry.make()
+    const listeners = new Map<string, Array<() => void>>()
+    const pushes: Array<string> = []
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: { pathname: "/accounts", search: "" },
+        history: { state: {}, pushState: (_state: any, _title: string, url: string) => pushes.push(url) },
+        addEventListener: (name: string, cb: () => void) => listeners.set(name, [...(listeners.get(name) ?? []), cb]),
+        removeEventListener: () => {}
+      },
+      configurable: true,
+      writable: true
+    })
+
+    try {
+      const q = Atom.searchParam("q")
+      r.set(q, "acme")
+      ;(globalThis as any).window.location.pathname = "/people"
+      vitest.advanceTimersByTime(500)
+      expect(pushes).toEqual([])
+
+      ;(globalThis as any).window.location.pathname = "/accounts"
+      r.set(q, "workos")
+      for (const cb of listeners.get("popstate") ?? []) cb()
+      vitest.advanceTimersByTime(500)
+      expect(pushes).toEqual([])
+    } finally {
+      r.dispose()
+      if (typeof previousWindow === "undefined") delete (globalThis as any).window
+      else Object.defineProperty(globalThis, "window", { value: previousWindow, configurable: true, writable: true })
+    }
+  })
+
   it("runtime", async () => {
     const count = counterRuntime.atom(Counter.use((_) => _.get)).pipe(
       Atom.withLabel("count")


### PR DESCRIPTION
## Summary
- Preserve existing `history.state` metadata when `Atom.searchParam` pushes a debounced URL update, including TanStack Router `__TSR_index` / key fields.
- Discard pending writes when the route changes before the debounce flush or when the user navigates via `popstate`.
- Avoid pushing no-op updates.

## Verification
- `pnpm vitest run packages/effect/test/reactivity/Atom.test.ts`
