### PR TITLE
Fix HttpApiEndpoint error inference

### DIFF
--- a/.changeset/fix-httpapi-endpoint-error-inference.md
+++ b/.changeset/fix-httpapi-endpoint-error-inference.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix HttpApiEndpoint endpoint error inference when success schemas include streams.

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -314,7 +314,20 @@ export type Success<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
  * @category models
  * @since 4.0.0
  */
-export type Error<Endpoint extends Any> = Endpoint["~Error"]
+export type Error<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
+  infer _Name,
+  infer _Method,
+  infer _Path,
+  infer _Params,
+  infer _Query,
+  infer _Payload,
+  infer _Headers,
+  infer _Success,
+  infer _Error,
+  infer _M,
+  infer _MR
+> ? _Error
+  : never
 
 /**
  * Extracts the schema used for an endpoint's path parameters.
@@ -453,7 +466,20 @@ export type MiddlewareError<Endpoint extends Any> = HttpApiMiddleware.Error<Midd
  * @category models
  * @since 4.0.0
  */
-export type Errors<Endpoint extends Any> = Endpoint["~Error"]["Type"] | HttpApiMiddleware.Error<Middleware<Endpoint>>
+export type Errors<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
+  infer _Name,
+  infer _Method,
+  infer _Path,
+  infer _Params,
+  infer _Query,
+  infer _Payload,
+  infer _Headers,
+  infer _Success,
+  infer _Error,
+  infer _M,
+  infer _MR
+> ? _Error["Type"] | HttpApiMiddleware.Error<Middleware<Endpoint>>
+  : never
 
 /**
  * Computes the services required to encode an endpoint's error responses,
@@ -462,9 +488,20 @@ export type Errors<Endpoint extends Any> = Endpoint["~Error"]["Type"] | HttpApiM
  * @category models
  * @since 4.0.0
  */
-export type ErrorServicesEncode<Endpoint extends Any> =
-  | Endpoint["~Error"]["EncodingServices"]
-  | HttpApiMiddleware.ErrorServicesEncode<Middleware<Endpoint>>
+export type ErrorServicesEncode<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
+  infer _Name,
+  infer _Method,
+  infer _Path,
+  infer _Params,
+  infer _Query,
+  infer _Payload,
+  infer _Headers,
+  infer _Success,
+  infer _Error,
+  infer _M,
+  infer _MR
+> ? _Error["EncodingServices"] | HttpApiMiddleware.ErrorServicesEncode<Middleware<Endpoint>>
+  : never
 
 /**
  * Builds the decoded request shape passed to a normal endpoint handler, including
@@ -654,9 +691,19 @@ export type MiddlewareServices<Endpoint> = Endpoint extends HttpApiEndpoint<
  * @category models
  * @since 4.0.0
  */
-export type ErrorServicesDecode<Endpoint> = Endpoint extends Any ?
-    | Endpoint["~Error"]["DecodingServices"]
-    | HttpApiMiddleware.ErrorServicesDecode<Middleware<Endpoint>>
+export type ErrorServicesDecode<Endpoint> = Endpoint extends HttpApiEndpoint<
+  infer _Name,
+  infer _Method,
+  infer _Path,
+  infer _Params,
+  infer _Query,
+  infer _Payload,
+  infer _Headers,
+  infer _Success,
+  infer _Error,
+  infer _M,
+  infer _MR
+> ? _Error["DecodingServices"] | HttpApiMiddleware.ErrorServicesDecode<Middleware<Endpoint>>
   : never
 
 /**

--- a/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiEndpoint.ts
@@ -314,20 +314,7 @@ export type Success<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
  * @category models
  * @since 4.0.0
  */
-export type Error<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
-  infer _Name,
-  infer _Method,
-  infer _Path,
-  infer _Params,
-  infer _Query,
-  infer _Payload,
-  infer _Headers,
-  infer _Success,
-  infer _Error,
-  infer _M,
-  infer _MR
-> ? _Error
-  : never
+export type Error<Endpoint extends Any> = Endpoint["~Error"]
 
 /**
  * Extracts the schema used for an endpoint's path parameters.
@@ -466,20 +453,7 @@ export type MiddlewareError<Endpoint extends Any> = HttpApiMiddleware.Error<Midd
  * @category models
  * @since 4.0.0
  */
-export type Errors<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
-  infer _Name,
-  infer _Method,
-  infer _Path,
-  infer _Params,
-  infer _Query,
-  infer _Payload,
-  infer _Headers,
-  infer _Success,
-  infer _Error,
-  infer _M,
-  infer _MR
-> ? _Error["Type"] | HttpApiMiddleware.Error<Middleware<Endpoint>>
-  : never
+export type Errors<Endpoint extends Any> = Endpoint["~Error"]["Type"] | HttpApiMiddleware.Error<Middleware<Endpoint>>
 
 /**
  * Computes the services required to encode an endpoint's error responses,
@@ -488,20 +462,9 @@ export type Errors<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
  * @category models
  * @since 4.0.0
  */
-export type ErrorServicesEncode<Endpoint extends Any> = Endpoint extends HttpApiEndpoint<
-  infer _Name,
-  infer _Method,
-  infer _Path,
-  infer _Params,
-  infer _Query,
-  infer _Payload,
-  infer _Headers,
-  infer _Success,
-  infer _Error,
-  infer _M,
-  infer _MR
-> ? _Error["EncodingServices"] | HttpApiMiddleware.ErrorServicesEncode<Middleware<Endpoint>>
-  : never
+export type ErrorServicesEncode<Endpoint extends Any> =
+  | Endpoint["~Error"]["EncodingServices"]
+  | HttpApiMiddleware.ErrorServicesEncode<Middleware<Endpoint>>
 
 /**
  * Builds the decoded request shape passed to a normal endpoint handler, including
@@ -691,19 +654,9 @@ export type MiddlewareServices<Endpoint> = Endpoint extends HttpApiEndpoint<
  * @category models
  * @since 4.0.0
  */
-export type ErrorServicesDecode<Endpoint> = Endpoint extends HttpApiEndpoint<
-  infer _Name,
-  infer _Method,
-  infer _Path,
-  infer _Params,
-  infer _Query,
-  infer _Payload,
-  infer _Headers,
-  infer _Success,
-  infer _Error,
-  infer _M,
-  infer _MR
-> ? _Error["DecodingServices"] | HttpApiMiddleware.ErrorServicesDecode<Middleware<Endpoint>>
+export type ErrorServicesDecode<Endpoint> = Endpoint extends Any ?
+    | Endpoint["~Error"]["DecodingServices"]
+    | HttpApiMiddleware.ErrorServicesDecode<Middleware<Endpoint>>
   : never
 
 /**
@@ -1099,7 +1052,7 @@ export type SuccessConstraint = Schema.Top | ReadonlyArray<Schema.Top>
  */
 export type ErrorConstraint = Schema.Top | ReadonlyArray<Schema.Top>
 
-type ErrorWithoutStream<S extends ErrorConstraint> = [
+type ErrorNoStream<S extends ErrorConstraint> = [
   Extract<
     S extends ReadonlyArray<Schema.Top> ? S[number] : S,
     HttpApiSchema.StreamSchema
@@ -1135,7 +1088,7 @@ export const make = <Method extends HttpMethod>(method: Method): {
       readonly headers?: Headers | undefined
       readonly payload?: Payload | undefined
       readonly success?: Success | undefined
-      readonly error?: ErrorWithoutStream<Error> | undefined
+      readonly error?: (Error & ErrorNoStream<Types.NoInfer<Error>>) | undefined
     }
   ): HttpApiEndpoint<
     Name,
@@ -1168,7 +1121,7 @@ export const make = <Method extends HttpMethod>(method: Method): {
       readonly headers?: Headers | undefined
       readonly payload?: Payload | undefined
       readonly success?: Success | undefined
-      readonly error?: ErrorWithoutStream<Error> | undefined
+      readonly error?: (Error & ErrorNoStream<Types.NoInfer<Error>>) | undefined
     }
   ): HttpApiEndpoint<
     Name,
@@ -1201,7 +1154,7 @@ export const make = <Method extends HttpMethod>(method: Method): {
     readonly headers?: Headers | undefined
     readonly payload?: Payload | undefined
     readonly success?: Success | undefined
-    readonly error?: ErrorWithoutStream<Error> | undefined
+    readonly error?: (Error & ErrorNoStream<Types.NoInfer<Error>>) | undefined
   }
 ): HttpApiEndpoint<
   Name,

--- a/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
@@ -436,10 +436,7 @@ describe("HttpApiEndpoint", () => {
       })
 
       expect(endpoint["~Error"]).type.toBe<typeof HttpApiError.BadRequest | typeof HttpApiError.Conflict>()
-      expect<HttpApiEndpoint.Error<typeof endpoint>>().type.toBe<
-        typeof HttpApiError.BadRequest | typeof HttpApiError.Conflict
-      >()
-      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<
+      expect<(typeof endpoint)["~Error"]["Type"]>().type.toBe<
         HttpApiError.BadRequest | HttpApiError.Conflict
       >()
     })

--- a/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
+++ b/packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
@@ -1,6 +1,6 @@
 import { type Effect, hole, Schema, type Stream, Struct } from "effect"
 import type { HttpServerResponse } from "effect/unstable/http/HttpServerResponse"
-import { HttpApiEndpoint, HttpApiSchema } from "effect/unstable/httpapi"
+import { HttpApiEndpoint, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { describe, expect, it } from "tstyche"
 
 describe("HttpApiEndpoint", () => {
@@ -348,6 +348,102 @@ describe("HttpApiEndpoint", () => {
       >()
     })
 
+    it("should infer endpoint errors with mixed buffered and StreamSse success schemas", () => {
+      const endpoint = HttpApiEndpoint.post("completions", "/completions", {
+        payload: Schema.Struct({ prompt: Schema.String }),
+        success: [
+          Schema.Struct({ message: Schema.String }),
+          HttpApiSchema.StreamSse({
+            data: Schema.Struct({ token: Schema.String }),
+            error: HttpApiError.InternalServerError
+          })
+        ],
+        headers: {
+          "x-session-affinity": Schema.optional(Schema.String)
+        },
+        error: [HttpApiError.BadRequest]
+      })
+
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<HttpApiError.BadRequest>()
+    })
+
+    it("should infer a single endpoint error with StreamSse success", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.StreamSse({
+          data: Schema.Struct({ token: Schema.String }),
+          error: HttpApiError.InternalServerError
+        }),
+        error: HttpApiError.BadRequest
+      })
+
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<HttpApiError.BadRequest>()
+    })
+
+    it("should infer endpoint error arrays with StreamSse success", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.StreamSse({
+          data: Schema.Struct({ token: Schema.String }),
+          error: HttpApiError.InternalServerError
+        }),
+        error: [HttpApiError.BadRequest, HttpApiError.Conflict]
+      })
+
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<
+        HttpApiError.BadRequest | HttpApiError.Conflict
+      >()
+    })
+
+    it("should infer endpoint error arrays with StreamSse first in a success array", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: [
+          HttpApiSchema.StreamSse({
+            data: Schema.Struct({ token: Schema.String }),
+            error: HttpApiError.InternalServerError
+          }),
+          Schema.Struct({ message: Schema.String })
+        ],
+        error: [HttpApiError.BadRequest, HttpApiError.Conflict]
+      })
+
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<
+        HttpApiError.BadRequest | HttpApiError.Conflict
+      >()
+    })
+
+    it("should infer endpoint error arrays with StreamUint8Array success", () => {
+      const endpoint = HttpApiEndpoint.get("a", "/a", {
+        success: HttpApiSchema.StreamUint8Array(),
+        error: [HttpApiError.BadRequest, HttpApiError.Conflict]
+      })
+
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<
+        HttpApiError.BadRequest | HttpApiError.Conflict
+      >()
+    })
+
+    it("should infer endpoint errors with disableCodecs enabled", () => {
+      const endpoint = HttpApiEndpoint.post("a", "/a", {
+        disableCodecs: true,
+        payload: Schema.Struct({ prompt: Schema.String }),
+        success: [
+          Schema.Struct({ message: Schema.String }),
+          HttpApiSchema.StreamSse({
+            data: Schema.Struct({ token: Schema.String }),
+            error: HttpApiError.InternalServerError
+          })
+        ],
+        error: [HttpApiError.BadRequest, HttpApiError.Conflict]
+      })
+
+      expect(endpoint["~Error"]).type.toBe<typeof HttpApiError.BadRequest | typeof HttpApiError.Conflict>()
+      expect<HttpApiEndpoint.Error<typeof endpoint>>().type.toBe<
+        typeof HttpApiError.BadRequest | typeof HttpApiError.Conflict
+      >()
+      expect<HttpApiEndpoint.Errors<typeof endpoint>>().type.toBe<
+        HttpApiError.BadRequest | HttpApiError.Conflict
+      >()
+    })
+
     it("should not accept streaming schemas", () => {
       expect(HttpApiEndpoint.get).type.not.toBeCallableWith("a", "/a", {
         error: HttpApiSchema.StreamUint8Array()
@@ -360,6 +456,13 @@ describe("HttpApiEndpoint", () => {
           }),
           error: Schema.Struct({ reason: Schema.String })
         })
+      })
+      expect(HttpApiEndpoint.get).type.not.toBeCallableWith("a", "/a", {
+        error: [Schema.String, HttpApiSchema.StreamUint8Array()]
+      })
+      expect(HttpApiEndpoint.get).type.not.toBeCallableWith("a", "/a", {
+        disableCodecs: true,
+        error: [Schema.String, HttpApiSchema.StreamUint8Array()]
       })
     })
   })


### PR DESCRIPTION
## Summary
- fix endpoint error inference when success schemas include streaming responses
- keep endpoint-level stream schemas rejected for errors
- add type-level regression coverage across mixed stream/buffered success permutations

## Validation
- pnpm test-types packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
- pnpm exec tstyche --target "5.6 || 5.7 || 5.8 || 5.9" packages/effect/typetest/unstable/httpapi/HttpApiEndpoint.tst.ts
- pnpm lint-fix
- pnpm check:tsgo