### PR TITLE
Fail with typed SqlError when sqlite-bun statement preparation throws

### DIFF
--- a/.changeset/sqlite-bun-prepare-error-channel.md
+++ b/.changeset/sqlite-bun-prepare-error-channel.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-bun": patch
+---
+
+Fail with a typed `SqlError` when Bun SQLite statement preparation throws (for example a missing table or a syntax error), instead of letting the driver error escape as a defect, closes #2385.

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -139,14 +139,8 @@ export const make = (
       ) =>
         Effect.withFiber<Array<any>, SqlError>((fiber) => {
           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
-          let statement: ReturnType<typeof db.query>
           try {
-            statement = prepare(sql, useSafeIntegers)
-          } catch (cause) {
-            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") }))
-          }
-          try {
-            return Effect.succeed((statement.all(...(params as any)) ?? []) as Array<any>)
+            return Effect.succeed((prepare(sql, useSafeIntegers).all(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {
             return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
           }
@@ -158,16 +152,12 @@ export const make = (
       ) =>
         Effect.withFiber<Array<any>, SqlError>((fiber) => {
           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
-          let statement: ReturnType<typeof db.query>
           try {
-            statement = prepare(sql, useSafeIntegers)
+            return Effect.succeed((prepare(sql, useSafeIntegers).values(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {
-            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") }))
-          }
-          try {
-            return Effect.succeed((statement.values(...(params as any)) ?? []) as Array<any>)
-          } catch (cause) {
-            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
+            return Effect.fail(
+              new SqlError({ reason: classifyError(cause, "Failed to execute statement", "executeValues") })
+            )
           }
         })
 

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -126,15 +126,25 @@ export const make = (
         db.run("PRAGMA journal_mode = WAL;")
       }
 
+      const prepare = (sql: string, useSafeIntegers: boolean) => {
+        const statement = db.query(sql)
+        // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
+        statement.safeIntegers(useSafeIntegers)
+        return statement
+      }
+
       const run = (
         sql: string,
         params: ReadonlyArray<unknown> = []
       ) =>
         Effect.withFiber<Array<any>, SqlError>((fiber) => {
-          const statement = db.query(sql)
           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
-          // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
-          statement.safeIntegers(useSafeIntegers)
+          let statement: ReturnType<typeof db.query>
+          try {
+            statement = prepare(sql, useSafeIntegers)
+          } catch (cause) {
+            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") }))
+          }
           try {
             return Effect.succeed((statement.all(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {
@@ -147,10 +157,13 @@ export const make = (
         params: ReadonlyArray<unknown> = []
       ) =>
         Effect.withFiber<Array<any>, SqlError>((fiber) => {
-          const statement = db.query(sql)
           const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
-          // @ts-ignore bun-types missing safeIntegers method, fixed in https://github.com/oven-sh/bun/pull/26627
-          statement.safeIntegers(useSafeIntegers)
+          let statement: ReturnType<typeof db.query>
+          try {
+            statement = prepare(sql, useSafeIntegers)
+          } catch (cause) {
+            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") }))
+          }
           try {
             return Effect.succeed((statement.values(...(params as any)) ?? []) as Array<any>)
           } catch (cause) {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Closes #2385.

In `@effect/sql-sqlite-bun`, `run` and `runValues` call `db.query(sql)` before the `try` block. Bun's `db.query` prepares the statement eagerly, so a prepare-time driver error (missing table, syntax error) throws synchronously inside `Effect.withFiber` and escapes as a defect instead of landing in the error channel as a typed `SqlError` — it blows past `Effect.result` and crashes `runPromise`, as the issue repro shows.

The sibling clients already handle this: `sqlite-node` wraps `db.prepare` in `Effect.try` with a `"Failed to prepare statement"` / `"prepare"` classification, and `sqlite-wasm` / `sqlite-do` wrap the whole run. This change closes the asymmetry by moving statement preparation (including the `safeIntegers` call) into a guarded step that fails with `classifySqliteError(cause, { message: "Failed to prepare statement", operation: "prepare" })`, mirroring the node client's semantics. Execute-phase classification is unchanged.

Verified with the issue's repro under `bun` against this branch: before, the raw `SQLiteError: no such table` is thrown at `SqliteClient.ts:134`; after, `Effect.result` captures `SqlError` with `operation: "prepare"`. Also verified the happy path and that an execute-phase unique violation still classifies as `UniqueViolation` / `operation: "execute"`. No CI-runnable regression test added because the test matrix runs Node and Deno only, where `bun:sqlite` cannot load (the package's test file is a stub for the same reason).

`pnpm --filter @effect/sql-sqlite-bun check`, `oxlint`, and `dprint check` are clean; changeset included.