### PR TITLE
fix: align ProcessInput.Input runtime field name with type definition

### DIFF
--- a/.changeset/good-trees-pull.md
+++ b/.changeset/good-trees-pull.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+align ProcessInput.Input runtime field name with type definition on Prompt.custom

--- a/packages/effect/src/unstable/cli/Prompt.ts
+++ b/packages/effect/src/unstable/cli/Prompt.ts
@@ -1364,7 +1364,7 @@ const runLoop = Effect.fnUntraced(
       yield* Effect.orDie(terminal.display(msg))
       if (loop.events) {
         const takeInput = Queue.take(input).pipe(
-          Effect.map((event) => ({ _tag: "Input" as const, event }))
+          Effect.map((input) => ({ _tag: "Input" as const, input }))
         )
         const result = yield* Effect.raceFirst(
           takeInput,

--- a/packages/effect/test/unstable/cli/Prompt.test.ts
+++ b/packages/effect/test/unstable/cli/Prompt.test.ts
@@ -594,4 +594,36 @@ describe("Prompt.custom", () => {
       const result = yield* Prompt.run(prompt)
       assert.strictEqual(result, 3)
     }).pipe(Effect.provide(TestLayer)))
+
+  it.effect("Input variant exposes the input field with UserInput", () =>
+    Effect.gen(function*() {
+      const eventQueue = yield* Queue.make<string>()
+
+      const prompt = Prompt.custom(
+        { captured: "" },
+        Queue.asDequeue(eventQueue),
+        {
+          render: (state) => Effect.succeed(`Captured: ${state.captured}`),
+          process: (input, state) =>
+            Match.value(input).pipe(
+              Match.tag("Input", ({ input: userInput }) => {
+                const key = userInput.key.name
+                return key === "enter"
+                  ? Effect.succeed(Action.Submit({ value: state.captured }))
+                  : Effect.succeed(Action.NextFrame({ state: { captured: state.captured + key } }))
+              }),
+              Match.tag("Event", () => Effect.succeed(Action.NextFrame({ state }))),
+              Match.exhaustive
+            ),
+          clear: () => Effect.succeed("")
+        }
+      )
+
+      yield* MockTerminal.inputKey("x")
+      yield* MockTerminal.inputKey("y")
+      yield* MockTerminal.inputKey("enter")
+
+      const result = yield* Prompt.run(prompt)
+      assert.strictEqual(result, "xy")
+    }).pipe(Effect.provide(TestLayer)))
 })


### PR DESCRIPTION

## Type

- [x] Bug Fix

## Description

Found a bug with my last PR (#2205) where at runtime the `TerminalInput` was mapped to `event` instead of `input` like in the `ProcessInput`.  Was surprised the tests didn't catch this so have added a new test specifically for it. 🙏 

## Related

- Related PR #2205
