### PR TITLE
POC: Add experimental schema compiler

### DIFF
--- a/.changeset/schema-compiler.md
+++ b/.changeset/schema-compiler.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add experimental `SchemaCompiler.compileTypeGuard` for cached JIT type-side validation predicates.

--- a/packages/effect/benchmark/schema/compileTypeGuard.ts
+++ b/packages/effect/benchmark/schema/compileTypeGuard.ts
@@ -1,0 +1,327 @@
+import { Type } from "@sinclair/typebox"
+import { TypeCompiler } from "@sinclair/typebox/compiler"
+import { Ajv } from "ajv"
+import { Array as Arr, Option, Schema, SchemaCompiler } from "effect"
+import { Bench } from "tinybench"
+import * as v from "valibot"
+
+const bench = new Bench({ time: 1000 })
+const ajv = new Ajv({ allErrors: false, discriminator: true, strict: false })
+
+// Mirrors the core object shape used by moltar/typescript-runtime-type-benchmarks
+// assertLoose/assertStrict cases.
+const MoltarNestedLoose = Schema.Struct({
+  foo: Schema.String,
+  num: Schema.Number,
+  bool: Schema.Boolean
+})
+const MoltarObjectLoose = Schema.Struct({
+  number: Schema.Number,
+  negNumber: Schema.Number,
+  maxNumber: Schema.Number,
+  string: Schema.String,
+  longString: Schema.String,
+  boolean: Schema.Boolean,
+  deeplyNested: MoltarNestedLoose
+})
+
+const ValibotMoltarNestedLoose = v.object({
+  foo: v.string(),
+  num: v.number(),
+  bool: v.boolean()
+})
+const ValibotMoltarObjectLoose = v.object({
+  number: v.number(),
+  negNumber: v.number(),
+  maxNumber: v.number(),
+  string: v.string(),
+  longString: v.string(),
+  boolean: v.boolean(),
+  deeplyNested: ValibotMoltarNestedLoose
+})
+const ValibotMoltarNestedStrict = v.strictObject({
+  foo: v.string(),
+  num: v.number(),
+  bool: v.boolean()
+})
+const ValibotMoltarObjectStrict = v.strictObject({
+  number: v.number(),
+  negNumber: v.number(),
+  maxNumber: v.number(),
+  string: v.string(),
+  longString: v.string(),
+  boolean: v.boolean(),
+  deeplyNested: ValibotMoltarNestedStrict
+})
+
+const AjvMoltarObjectLoose = ajv.compile({
+  type: "object",
+  properties: {
+    number: { type: "number" },
+    negNumber: { type: "number" },
+    maxNumber: { type: "number" },
+    string: { type: "string" },
+    longString: { type: "string" },
+    boolean: { type: "boolean" },
+    deeplyNested: {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        num: { type: "number" },
+        bool: { type: "boolean" }
+      },
+      required: ["foo", "num", "bool"]
+    }
+  },
+  required: ["number", "negNumber", "maxNumber", "string", "longString", "boolean", "deeplyNested"]
+})
+const AjvMoltarObjectStrict = ajv.compile({
+  type: "object",
+  properties: {
+    number: { type: "number" },
+    negNumber: { type: "number" },
+    maxNumber: { type: "number" },
+    string: { type: "string" },
+    longString: { type: "string" },
+    boolean: { type: "boolean" },
+    deeplyNested: {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        num: { type: "number" },
+        bool: { type: "boolean" }
+      },
+      required: ["foo", "num", "bool"],
+      additionalProperties: false
+    }
+  },
+  required: ["number", "negNumber", "maxNumber", "string", "longString", "boolean", "deeplyNested"],
+  additionalProperties: false
+})
+
+const TypeBoxMoltarNestedLoose = Type.Object({
+  foo: Type.String(),
+  num: Type.Number(),
+  bool: Type.Boolean()
+})
+const TypeBoxMoltarObjectLoose = TypeCompiler.Compile(Type.Object({
+  number: Type.Number(),
+  negNumber: Type.Number(),
+  maxNumber: Type.Number(),
+  string: Type.String(),
+  longString: Type.String(),
+  boolean: Type.Boolean(),
+  deeplyNested: TypeBoxMoltarNestedLoose
+}))
+const TypeBoxMoltarNestedStrict = Type.Object({
+  foo: Type.String(),
+  num: Type.Number(),
+  bool: Type.Boolean()
+}, { additionalProperties: false })
+const TypeBoxMoltarObjectStrict = TypeCompiler.Compile(Type.Object({
+  number: Type.Number(),
+  negNumber: Type.Number(),
+  maxNumber: Type.Number(),
+  string: Type.String(),
+  longString: Type.String(),
+  boolean: Type.Boolean(),
+  deeplyNested: TypeBoxMoltarNestedStrict
+}, { additionalProperties: false }))
+
+const moltarObjects = Arr.makeBy(1_000, (i) => ({
+  number: i,
+  negNumber: -i,
+  maxNumber: Number.MAX_SAFE_INTEGER,
+  string: `string-${i}`,
+  longString: `long-string-${i}-abcdefghijklmnopqrstuvwxyz`,
+  boolean: i % 2 === 0,
+  deeplyNested: {
+    foo: `foo-${i}`,
+    num: i,
+    bool: i % 2 === 1
+  }
+}))
+
+const isMoltarObjectLoose = Schema.is(MoltarObjectLoose)
+const isCompiledTypeGuardMoltarObjectLoose = SchemaCompiler.compileTypeGuard(MoltarObjectLoose)
+const isCompiledTypeGuardMoltarObjectLooseSimple = SchemaCompiler.compileTypeGuard(MoltarObjectLoose, {
+  simpleInputs: true
+})
+const parseMoltarObjectStrict = Schema.decodeUnknownOption(MoltarObjectLoose, { onExcessProperty: "error" })
+const isCompiledTypeGuardMoltarObjectStrict = SchemaCompiler.compileTypeGuard(MoltarObjectLoose, {
+  strict: true
+})
+const isCompiledTypeGuardMoltarObjectStrictSimple = SchemaCompiler.compileTypeGuard(MoltarObjectLoose, {
+  simpleInputs: true,
+  strict: true
+})
+
+const Member = Schema.Union([
+  Schema.Struct({ _tag: Schema.Literal("Admin"), permissions: Schema.Array(Schema.String) }),
+  Schema.Struct({ _tag: Schema.Literal("Editor"), sections: Schema.Array(Schema.String) }),
+  Schema.Struct({ _tag: Schema.Literal("Viewer"), expires: Schema.optional(Schema.Number) })
+])
+const ValibotMember = v.variant("_tag", [
+  v.object({ _tag: v.literal("Admin"), permissions: v.array(v.string()) }),
+  v.object({ _tag: v.literal("Editor"), sections: v.array(v.string()) }),
+  v.object({ _tag: v.literal("Viewer"), expires: v.optional(v.number()) })
+])
+const AjvMember = ajv.compile({
+  oneOf: [
+    {
+      type: "object",
+      properties: {
+        _tag: { const: "Admin" },
+        permissions: {
+          type: "array",
+          items: { type: "string" }
+        }
+      },
+      required: ["_tag", "permissions"]
+    },
+    {
+      type: "object",
+      properties: {
+        _tag: { const: "Editor" },
+        sections: {
+          type: "array",
+          items: { type: "string" }
+        }
+      },
+      required: ["_tag", "sections"]
+    },
+    {
+      type: "object",
+      properties: {
+        _tag: { const: "Viewer" },
+        expires: { type: "number" }
+      },
+      required: ["_tag"]
+    }
+  ],
+  discriminator: { propertyName: "_tag" }
+})
+const TypeBoxMember = TypeCompiler.Compile(Type.Union([
+  Type.Object({ _tag: Type.Literal("Admin"), permissions: Type.Array(Type.String()) }),
+  Type.Object({ _tag: Type.Literal("Editor"), sections: Type.Array(Type.String()) }),
+  Type.Object({ _tag: Type.Literal("Viewer"), expires: Type.Optional(Type.Number()) })
+]))
+
+const members = Arr.makeBy(1_000, (i) =>
+  i % 3 === 0
+    ? { _tag: "Admin", permissions: ["read", "write"] }
+    : i % 3 === 1
+    ? { _tag: "Editor", sections: ["docs"] }
+    : { _tag: "Viewer", expires: i })
+
+const isMember = Schema.is(Member)
+const isCompiledTypeGuardMember = SchemaCompiler.compileTypeGuard(Member)
+
+isMoltarObjectLoose(moltarObjects[0])
+isCompiledTypeGuardMoltarObjectLoose(moltarObjects[0])
+isCompiledTypeGuardMoltarObjectLooseSimple(moltarObjects[0])
+Option.isSome(parseMoltarObjectStrict(moltarObjects[0]))
+isCompiledTypeGuardMoltarObjectStrict(moltarObjects[0])
+isCompiledTypeGuardMoltarObjectStrictSimple(moltarObjects[0])
+v.is(ValibotMoltarObjectLoose, moltarObjects[0])
+v.is(ValibotMoltarObjectStrict, moltarObjects[0])
+AjvMoltarObjectLoose(moltarObjects[0])
+AjvMoltarObjectStrict(moltarObjects[0])
+TypeBoxMoltarObjectLoose.Check(moltarObjects[0])
+TypeBoxMoltarObjectStrict.Check(moltarObjects[0])
+isMember(members[0])
+isCompiledTypeGuardMember(members[0])
+v.is(ValibotMember, members[0])
+AjvMember(members[0])
+TypeBoxMember.Check(members[0])
+
+bench
+  .add("SchemaCompiler.compileTypeGuard moltar loose object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      isCompiledTypeGuardMoltarObjectLoose(moltarObjects[i])
+    }
+  })
+  .add("SchemaCompiler.compileTypeGuard moltar loose simple object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      isCompiledTypeGuardMoltarObjectLooseSimple(moltarObjects[i])
+    }
+  })
+  .add("TypeBox moltar loose object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      TypeBoxMoltarObjectLoose.Check(moltarObjects[i])
+    }
+  })
+  .add("Ajv moltar loose object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      AjvMoltarObjectLoose(moltarObjects[i])
+    }
+  })
+  .add("Valibot moltar loose object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      v.is(ValibotMoltarObjectLoose, moltarObjects[i])
+    }
+  })
+  .add("Schema.is moltar loose object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      isMoltarObjectLoose(moltarObjects[i])
+    }
+  })
+  .add("SchemaCompiler.compileTypeGuard moltar strict object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      isCompiledTypeGuardMoltarObjectStrict(moltarObjects[i])
+    }
+  })
+  .add("SchemaCompiler.compileTypeGuard moltar strict simple object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      isCompiledTypeGuardMoltarObjectStrictSimple(moltarObjects[i])
+    }
+  })
+  .add("TypeBox moltar strict object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      TypeBoxMoltarObjectStrict.Check(moltarObjects[i])
+    }
+  })
+  .add("Ajv moltar strict object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      AjvMoltarObjectStrict(moltarObjects[i])
+    }
+  })
+  .add("Valibot moltar strict object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      v.is(ValibotMoltarObjectStrict, moltarObjects[i])
+    }
+  })
+  .add("Schema.decodeUnknownOption moltar strict object", function() {
+    for (let i = 0; i < moltarObjects.length; i++) {
+      Option.isSome(parseMoltarObjectStrict(moltarObjects[i]))
+    }
+  })
+  .add("SchemaCompiler.compileTypeGuard discriminated union", function() {
+    for (let i = 0; i < members.length; i++) {
+      isCompiledTypeGuardMember(members[i])
+    }
+  })
+  .add("TypeBox discriminated union", function() {
+    for (let i = 0; i < members.length; i++) {
+      TypeBoxMember.Check(members[i])
+    }
+  })
+  .add("Ajv discriminated union", function() {
+    for (let i = 0; i < members.length; i++) {
+      AjvMember(members[i])
+    }
+  })
+  .add("Valibot discriminated union", function() {
+    for (let i = 0; i < members.length; i++) {
+      v.is(ValibotMember, members[i])
+    }
+  })
+  .add("Schema.is discriminated union", function() {
+    for (let i = 0; i < members.length; i++) {
+      isMember(members[i])
+    }
+  })
+
+await bench.run()
+
+console.table(bench.table())

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -103,6 +103,7 @@
     "coverage": "vitest --run --coverage --sequence.concurrent=false"
   },
   "devDependencies": {
+    "@sinclair/typebox": "0.27.10",
     "@types/ini": "^4.1.1",
     "@types/node": "^25.7.0",
     "ajv": "^8.20.0",

--- a/packages/effect/src/SchemaCompiler.ts
+++ b/packages/effect/src/SchemaCompiler.ts
@@ -1,0 +1,994 @@
+/**
+ * Experimental compiler for Schema validators.
+ *
+ * @since 4.0.0
+ */
+
+import * as Number_ from "./Number.ts"
+import * as Schema from "./Schema.ts"
+import * as SchemaAST from "./SchemaAST.ts"
+import * as SchemaParser from "./SchemaParser.ts"
+
+/**
+ * Error thrown when a schema cannot be compiled into a predicate.
+ *
+ * **When to use**
+ *
+ * Use when you need to distinguish an unsupported schema compiler input from
+ * validation failures produced by a compiled predicate.
+ *
+ * **Details**
+ *
+ * `path` identifies the AST location that could not be compiled, `tag`
+ * contains the AST node tag at that location, and `reason` describes the
+ * unsupported construct.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class CompilationError extends Error {
+  readonly _tag = "CompilationError"
+  readonly path: string
+  readonly tag: string
+  readonly reason: string
+
+  constructor(options: {
+    readonly path: string
+    readonly tag: string
+    readonly reason: string
+  }) {
+    super(`Cannot compile schema at ${options.path} (${options.tag}): ${options.reason}`)
+    this.name = "SchemaCompiler.CompilationError"
+    this.path = options.path
+    this.tag = options.tag
+    this.reason = options.reason
+  }
+}
+
+/**
+ * Options for {@link compileTypeGuard}.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface CompileTypeGuardOptions {
+  /**
+   * Rejects object properties not declared by the schema.
+   *
+   * @since 4.0.0
+   */
+  readonly strict?: boolean | undefined
+
+  /**
+   * Assumes inputs are plain data values, such as values produced by
+   * `JSON.parse`.
+   *
+   * **Details**
+   *
+   * When enabled, generated checks may use enumerable string keys and skip
+   * checks for symbols, non-enumerable properties, accessors, and prototype
+   * pollution.
+   *
+   * @since 4.0.0
+   */
+  readonly simpleInputs?: boolean | undefined
+}
+
+/**
+ * Compiles a schema into a cached type guard.
+ *
+ * **When to use**
+ *
+ * Use when you need to validate many values against the same schema and only
+ * need a boolean type-side result.
+ *
+ * **Details**
+ *
+ * The compiler validates `Schema.toType(schema)`, so transformations,
+ * decoding, encoding, parse output, and parse diagnostics are not part of the
+ * generated predicate. Successful compiles are cached by the type-side AST
+ * object and option set. Pass `strict: true` to reject object properties not
+ * declared by the schema. Pass `simpleInputs: true` when all inputs are plain
+ * data values, such as values produced by `JSON.parse`, to enable faster
+ * generated checks. Custom filters and declarations are called through
+ * captured runtime references when they cannot be compiled to direct
+ * JavaScript checks.
+ *
+ * **Gotchas**
+ *
+ * This API uses runtime code generation through `Function`. It can fail in
+ * environments that block eval-like code generation through Content Security
+ * Policy or equivalent runtime restrictions.
+ *
+ * @category compilers
+ * @since 4.0.0
+ */
+export function compileTypeGuard<S extends Schema.Top>(
+  schema: S,
+  options?: CompileTypeGuardOptions
+): (input: unknown) => input is S["Type"] {
+  const ast = Schema.toType(schema).ast
+  const compilerOptions: CompilerOptions = {
+    simpleInputs: options?.simpleInputs === true,
+    strict: options?.strict === true
+  }
+  const selectedCache = cacheForOptions(compilerOptions)
+  const cached = selectedCache.get(ast)
+  if (cached) {
+    return cached as (input: unknown) => input is S["Type"]
+  }
+  const predicate = new Compiler(compilerOptions).compile(ast)
+  selectedCache.set(ast, predicate)
+  return predicate as (input: unknown) => input is S["Type"]
+}
+
+const defaultCache = new WeakMap<SchemaAST.AST, (input: unknown) => boolean>()
+const simpleInputsCache = new WeakMap<SchemaAST.AST, (input: unknown) => boolean>()
+const strictCache = new WeakMap<SchemaAST.AST, (input: unknown) => boolean>()
+const strictSimpleInputsCache = new WeakMap<SchemaAST.AST, (input: unknown) => boolean>()
+
+const numberStringRegExp = new globalThis.RegExp(`(?:${SchemaAST.FINITE_PATTERN}|Infinity|-Infinity|NaN)`)
+
+interface CompilerOptions {
+  readonly simpleInputs: boolean
+  readonly strict: boolean
+}
+
+function cacheForOptions(options: CompilerOptions): WeakMap<SchemaAST.AST, (input: unknown) => boolean> {
+  if (options.strict) {
+    return options.simpleInputs ? strictSimpleInputsCache : strictCache
+  }
+  return options.simpleInputs ? simpleInputsCache : defaultCache
+}
+
+class Compiler {
+  private readonly refs: Array<unknown> = []
+  private readonly names = new WeakMap<SchemaAST.AST, string>()
+  private readonly bodies: Array<string> = []
+  private readonly options: CompilerOptions
+  private nextName = 0
+  private nextVar = 0
+
+  constructor(options: CompilerOptions) {
+    this.options = options
+  }
+
+  compile(ast: SchemaAST.AST): (input: unknown) => boolean {
+    const root = this.ensure(ast, "$")
+    const source = `${this.bodies.join("\n")}\nreturn ${root}`
+    return new globalThis.Function("refs", source)(this.refs) as (input: unknown) => boolean
+  }
+
+  private ensure(ast: SchemaAST.AST, path: string): string {
+    const existing = this.names.get(ast)
+    if (existing) {
+      return existing
+    }
+    const name = `f${this.nextName++}`
+    this.names.set(ast, name)
+    const body = this.emitBody(ast, path)
+    this.bodies.push(`function ${name}(input) {\n${body}\n}`)
+    return name
+  }
+
+  private emitBody(ast: SchemaAST.AST, path: string): string {
+    switch (ast._tag) {
+      case "Null":
+        return this.returnWithChecks(ast, "input === null", path)
+      case "Undefined":
+      case "Void":
+        return this.returnWithChecks(ast, "input === undefined", path)
+      case "Never":
+        return "return false"
+      case "Any":
+      case "Unknown":
+        return this.returnWithChecks(ast, "true", path)
+      case "ObjectKeyword":
+        return this.returnWithChecks(
+          ast,
+          `((typeof input === "object" && input !== null) || typeof input === "function")`,
+          path
+        )
+      case "String":
+        return this.returnWithChecks(ast, `typeof input === "string"`, path)
+      case "Number":
+        return this.returnWithChecks(ast, `typeof input === "number"`, path)
+      case "Boolean":
+        return this.returnWithChecks(ast, `typeof input === "boolean"`, path)
+      case "Symbol":
+        return this.returnWithChecks(ast, `typeof input === "symbol"`, path)
+      case "BigInt":
+        return this.returnWithChecks(ast, `typeof input === "bigint"`, path)
+      case "Literal":
+        return this.returnWithChecks(ast, `input === ${this.literal(ast.literal)}`, path)
+      case "UniqueSymbol":
+        return this.returnWithChecks(ast, `input === ${this.ref(ast.symbol)}`, path)
+      case "Enum":
+        return this.returnWithChecks(ast, `${this.ref(new Set(ast.enums.map(([, value]) => value)))}.has(input)`, path)
+      case "TemplateLiteral":
+        return this.returnWithChecks(
+          ast,
+          `typeof input === "string" && ${this.ref(SchemaAST.getTemplateLiteralRegExp(ast))}.test(input)`,
+          path
+        )
+      case "Arrays":
+        return this.emitArray(ast, path)
+      case "Objects":
+        return this.emitObject(ast, path)
+      case "Union":
+        return this.emitUnion(ast, path)
+      case "Suspend":
+        return this.returnWithChecks(ast, `${this.ensure(ast.thunk(), `${path}.thunk()`)}(input)`, path)
+      case "Declaration":
+        return `return ${this.ref(SchemaParser._is(ast))}(input)`
+      default:
+        throw new CompilationError({
+          path,
+          tag: (ast as { readonly _tag?: string })._tag ?? "<unknown>",
+          reason: "unsupported AST node"
+        })
+    }
+  }
+
+  private emitArray(ast: SchemaAST.Arrays, path: string): string {
+    const lines: Array<string> = [
+      "if (!Array.isArray(input)) return false",
+      "const len = input.length"
+    ]
+    const elementLen = ast.elements.length
+    for (let i = 0; i < elementLen; i++) {
+      const element = ast.elements[i]
+      const value = this.variable()
+      lines.push(`if (${i} < len) {`)
+      lines.push(`const ${value} = input[${i}]`)
+      lines.push(
+        `if (!(${this.callExpression(element, value, `${path}.elements[${i}]`)})) return false`
+      )
+      lines.push(`} else if (${SchemaAST.isOptional(element) ? "false" : "true"}) return false`)
+    }
+    if (ast.rest.length === 0) {
+      lines.push(`if (len > ${elementLen}) return false`)
+    } else {
+      const [head, ...tail] = ast.rest
+      const tailThreshold = tail.length > 0 ? this.variable() : undefined
+      if (tailThreshold) {
+        lines.push(`const ${tailThreshold} = Math.max(${elementLen}, len - ${tail.length})`)
+      }
+      if (head) {
+        const index = this.variable()
+        const value = this.variable()
+        if (tailThreshold) {
+          lines.push(`for (let ${index} = ${elementLen}; ${index} < ${tailThreshold}; ${index}++) {`)
+        } else {
+          lines.push(`for (let ${index} = ${elementLen}; ${index} < len; ${index}++) {`)
+        }
+        lines.push(`const ${value} = input[${index}]`)
+        lines.push(`if (!(${this.callExpression(head, value, `${path}.rest[0]`)})) return false`)
+        lines.push("}")
+      }
+      for (let i = 0; i < tail.length; i++) {
+        const element = tail[i]
+        const index = this.variable()
+        const value = this.variable()
+        lines.push(`const ${index} = ${tailThreshold} + ${i}`)
+        lines.push(`if (${index} < len) {`)
+        lines.push(`const ${value} = input[${index}]`)
+        lines.push(
+          `if (!(${this.callExpression(element, value, `${path}.rest[${i + 1}]`)})) return false`
+        )
+        lines.push(`} else if (${SchemaAST.isOptional(element) ? "false" : "true"}) return false`)
+      }
+    }
+    lines.push(this.returnChecks(ast, path))
+    return lines.join("\n")
+  }
+
+  private emitObject(ast: SchemaAST.Objects, path: string): string {
+    if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
+      return this.returnWithChecks(ast, "input !== null && input !== undefined", path)
+    }
+    const lines: Array<string> = [
+      `if (!(typeof input === "object" && input !== null && !Array.isArray(input))) return false`
+    ]
+    if (this.canUsePlainObjectFastPath(ast)) {
+      const condition = this.plainObjectFastPathCondition(ast, "input")
+      if (condition) {
+        lines.push(`if (${condition}) {`)
+      }
+      this.pushFastPathPropertyChecks(lines, ast, path)
+      this.pushExcessPropertyCheck(lines, ast, "input")
+      lines.push(this.returnChecks(ast, path))
+      if (!condition) {
+        return lines.join("\n")
+      }
+      lines.push("}")
+    }
+    for (let i = 0; i < ast.propertySignatures.length; i++) {
+      const ps = ast.propertySignatures[i]
+      const key = this.propertyKey(ps.name)
+      const value = this.variable()
+      lines.push(`if (Object.hasOwn(input, ${key})) {`)
+      lines.push(`const ${value} = ${this.propertyAccess("input", ps.name)}`)
+      lines.push(
+        `if (!(${
+          this.callExpression(ps.type, value, `${path}.fields[${this.formatPropertyKey(ps.name)}]`)
+        })) return false`
+      )
+      lines.push(`} else if (${SchemaAST.isOptional(ps.type) ? "false" : "true"}) return false`)
+    }
+    for (let i = 0; i < ast.indexSignatures.length; i++) {
+      const index = ast.indexSignatures[i]
+      const keys = this.variable()
+      const cursor = this.variable()
+      const key = this.variable()
+      const value = this.variable()
+      lines.push(`const ${keys} = ${this.indexKeysExpression(index.parameter)}(input)`)
+      lines.push(`for (let ${cursor} = 0; ${cursor} < ${keys}.length; ${cursor}++) {`)
+      lines.push(`const ${key} = ${keys}[${cursor}]`)
+      const keyPredicate = this.indexKeyPredicate(index.parameter)
+      if (keyPredicate) {
+        lines.push(`if (!${keyPredicate}(${key})) return false`)
+      }
+      lines.push(`const ${value} = input[${key}]`)
+      lines.push(
+        `if (!(${this.callExpression(index.type, value, `${path}.indexSignatures[${i}].type`)})) return false`
+      )
+      lines.push("}")
+    }
+    this.pushExcessPropertyCheck(lines, ast, "input")
+    lines.push(this.returnChecks(ast, path))
+    return lines.join("\n")
+  }
+
+  private emitUnion(ast: SchemaAST.Union, path: string): string {
+    const discriminator = this.getDiscriminator(ast)
+    if (discriminator) {
+      const lines: Array<string> = [
+        `if (!(typeof input === "object" && input !== null && !Array.isArray(input))) return false`,
+        `switch (input[${this.propertyKey(discriminator.key)}]) {`
+      ]
+      for (let i = 0; i < discriminator.cases.length; i++) {
+        const c = discriminator.cases[i]
+        const casePath = `${path}.types[${c.index}]`
+        const caseLines = this.emitDiscriminatorCase(c.ast, casePath, discriminator.key)
+        lines.push(`case ${this.discriminatorLiteral(c.literal)}:`)
+        if (caseLines) {
+          lines.push(...caseLines)
+        } else {
+          lines.push(`if (!(${this.callExpression(c.ast, "input", casePath)})) return false`)
+        }
+        lines.push("break")
+      }
+      lines.push("default:")
+      lines.push("return false")
+      lines.push("}")
+      lines.push(this.returnChecks(ast, path))
+      return lines.join("\n")
+    }
+
+    if (ast.mode === "oneOf") {
+      const count = this.variable()
+      const lines: Array<string> = [`let ${count} = 0`]
+      for (let i = 0; i < ast.types.length; i++) {
+        lines.push(`if (${this.callExpression(ast.types[i], "input", `${path}.types[${i}]`)}) ${count}++`)
+      }
+      lines.push(`if (${count} !== 1) return false`)
+      lines.push(this.returnChecks(ast, path))
+      return lines.join("\n")
+    }
+
+    const expression = ast.types.map((type, i) => this.callExpression(type, "input", `${path}.types[${i}]`)).join(
+      " || "
+    )
+    if (expression.length === 0) {
+      return "return false"
+    }
+    return this.returnWithChecks(ast, `(${expression})`, path)
+  }
+
+  private emitDiscriminatorCase(
+    ast: SchemaAST.AST,
+    path: string,
+    discriminatorKey: PropertyKey
+  ): Array<string> | undefined {
+    if (ast._tag !== "Objects" || ast.indexSignatures.length > 0) {
+      return undefined
+    }
+    const lines: Array<string> = []
+    if (this.canUsePlainObjectFastPath(ast)) {
+      const condition = this.plainObjectFastPathCondition(ast, "input")
+      if (condition) {
+        lines.push(`if (${condition}) {`)
+      }
+      this.pushFastPathPropertyChecks(lines, ast, path, discriminatorKey)
+      this.pushExcessPropertyCheck(lines, ast, "input")
+      this.pushChecks(lines, ast, "input", path)
+      if (condition) {
+        lines.push("} else {")
+        this.pushObjectOwnPropertyChecks(lines, ast, path)
+        lines.push("}")
+      }
+    } else {
+      this.pushObjectOwnPropertyChecks(lines, ast, path)
+    }
+    return lines
+  }
+
+  private pushFastPathPropertyChecks(
+    lines: Array<string>,
+    ast: SchemaAST.Objects,
+    path: string,
+    skipKey?: PropertyKey
+  ): void {
+    for (let i = 0; i < ast.propertySignatures.length; i++) {
+      const ps = ast.propertySignatures[i]
+      if (ps.name === skipKey) {
+        continue
+      }
+      const value = this.variable()
+      lines.push(`const ${value} = ${this.propertyAccess("input", ps.name)}`)
+      lines.push(
+        `if (!(${
+          this.fastPathPropertyExpression(
+            ps,
+            value,
+            `${path}.fields[${this.formatPropertyKey(ps.name)}]`
+          )
+        })) return false`
+      )
+    }
+  }
+
+  private pushObjectOwnPropertyChecks(lines: Array<string>, ast: SchemaAST.Objects, path: string): void {
+    for (let i = 0; i < ast.propertySignatures.length; i++) {
+      const ps = ast.propertySignatures[i]
+      const key = this.propertyKey(ps.name)
+      const value = this.variable()
+      lines.push(`if (Object.hasOwn(input, ${key})) {`)
+      lines.push(`const ${value} = ${this.propertyAccess("input", ps.name)}`)
+      lines.push(
+        `if (!(${
+          this.callExpression(ps.type, value, `${path}.fields[${this.formatPropertyKey(ps.name)}]`)
+        })) return false`
+      )
+      lines.push(`} else if (${SchemaAST.isOptional(ps.type) ? "false" : "true"}) return false`)
+    }
+    this.pushExcessPropertyCheck(lines, ast, "input")
+    this.pushChecks(lines, ast, "input", path)
+  }
+
+  private pushChecks(lines: Array<string>, ast: SchemaAST.AST, value: string, path: string): void {
+    const checks = this.checksExpression(ast.checks, value, ast, `${path}.checks`)
+    if (checks) {
+      lines.push(`if (!(${checks})) return false`)
+    }
+  }
+
+  private callExpression(ast: SchemaAST.AST, value: string, path: string): string {
+    return this.validationExpression(ast, value, path) ?? `${this.ensure(ast, path)}(${value})`
+  }
+
+  private validationExpression(ast: SchemaAST.AST, value: string, path: string): string | undefined {
+    let expression: string | undefined
+    switch (ast._tag) {
+      case "Null":
+        expression = `${value} === null`
+        break
+      case "Undefined":
+      case "Void":
+        expression = `${value} === undefined`
+        break
+      case "Never":
+        expression = "false"
+        break
+      case "Any":
+      case "Unknown":
+        expression = "true"
+        break
+      case "ObjectKeyword":
+        expression = `((typeof ${value} === "object" && ${value} !== null) || typeof ${value} === "function")`
+        break
+      case "String":
+        expression = `typeof ${value} === "string"`
+        break
+      case "Number":
+        expression = `typeof ${value} === "number"`
+        break
+      case "Boolean":
+        expression = `typeof ${value} === "boolean"`
+        break
+      case "Symbol":
+        expression = `typeof ${value} === "symbol"`
+        break
+      case "BigInt":
+        expression = `typeof ${value} === "bigint"`
+        break
+      case "Literal":
+        expression = `${value} === ${this.literal(ast.literal)}`
+        break
+      case "UniqueSymbol":
+        expression = `${value} === ${this.ref(ast.symbol)}`
+        break
+      case "Enum":
+        expression = `${this.ref(new Set(ast.enums.map(([, value]) => value)))}.has(${value})`
+        break
+      case "TemplateLiteral":
+        expression = `typeof ${value} === "string" && ${
+          this.ref(SchemaAST.getTemplateLiteralRegExp(ast))
+        }.test(${value})`
+        break
+      case "Objects":
+        expression = this.objectExpression(ast, value, path)
+        break
+      case "Suspend":
+        expression = `${this.ensure(ast.thunk(), `${path}.thunk()`)}(${value})`
+        break
+      case "Declaration":
+        expression = `${this.ref(SchemaParser._is(ast))}(${value})`
+        break
+    }
+    return expression ? this.withChecksExpression(ast, expression, value, path) : undefined
+  }
+
+  private objectExpression(ast: SchemaAST.Objects, value: string, path: string): string | undefined {
+    if (ast.indexSignatures.length > 0) {
+      return undefined
+    }
+    if (ast.propertySignatures.length === 0) {
+      return `${value} !== null && ${value} !== undefined`
+    }
+    const objectExpression = `typeof ${value} === "object" && ${value} !== null && !Array.isArray(${value})`
+    const slowExpressions: Array<string> = [objectExpression]
+    const fastPathCondition = this.plainObjectFastPathCondition(ast, value)
+    const fastExpressions: Array<string> = [objectExpression]
+    if (fastPathCondition) {
+      fastExpressions.push(fastPathCondition)
+    }
+    for (let i = 0; i < ast.propertySignatures.length; i++) {
+      const ps = ast.propertySignatures[i]
+      const key = this.propertyKey(ps.name)
+      const hasOwn = `Object.hasOwn(${value}, ${key})`
+      const field = this.propertyAccess(value, ps.name)
+      const fieldExpression = this.callExpression(ps.type, field, `${path}.fields[${this.formatPropertyKey(ps.name)}]`)
+      slowExpressions.push(
+        SchemaAST.isOptional(ps.type) ? `(!${hasOwn} || (${fieldExpression}))` : `${hasOwn} && (${fieldExpression})`
+      )
+      fastExpressions.push(
+        this.fastPathPropertyExpression(ps, field, `${path}.fields[${this.formatPropertyKey(ps.name)}]`)
+      )
+    }
+    const excessPropertyExpression = this.strictExcessPropertyExpression(ast, value)
+    if (excessPropertyExpression) {
+      slowExpressions.push(excessPropertyExpression)
+      fastExpressions.push(excessPropertyExpression)
+    }
+    const slowExpression = slowExpressions.map((expression) => `(${expression})`).join(" && ")
+    if (!this.canUsePlainObjectFastPath(ast)) {
+      return slowExpression
+    }
+    const fastExpression = fastExpressions.map((expression) => `(${expression})`).join(" && ")
+    return fastPathCondition ? `((${fastExpression}) || (${slowExpression}))` : fastExpression
+  }
+
+  private pushExcessPropertyCheck(lines: Array<string>, ast: SchemaAST.Objects, value: string): void {
+    const expression = this.strictExcessPropertyExpression(ast, value)
+    if (expression) {
+      lines.push(`if (!(${expression})) return false`)
+    }
+  }
+
+  private strictExcessPropertyExpression(ast: SchemaAST.Objects, value: string): string | undefined {
+    if (!this.options.strict || ast.indexSignatures.length > 0) {
+      return undefined
+    }
+    return this.excessPropertyCheckExpression(ast, value)
+  }
+
+  private excessPropertyCheckExpression(ast: SchemaAST.Objects, value: string): string {
+    return this.exactOwnKeyCountExpression(ast, value) ?? this.ownKeysSubsetExpression(ast, value)
+  }
+
+  private exactOwnKeyCountExpression(ast: SchemaAST.Objects, value: string): string | undefined {
+    if (ast.propertySignatures.every((ps) => !SchemaAST.isOptional(ps.type) && typeof ps.name === "string")) {
+      if (this.options.simpleInputs) {
+        return `Object.keys(${value}).length === ${ast.propertySignatures.length}`
+      }
+      return `Object.getOwnPropertyNames(${value}).length === ${ast.propertySignatures.length} && Object.getOwnPropertySymbols(${value}).length === 0`
+    }
+    if (ast.propertySignatures.every((ps) => !SchemaAST.isOptional(ps.type))) {
+      return `Reflect.ownKeys(${value}).length === ${ast.propertySignatures.length}`
+    }
+  }
+
+  private ownKeysSubsetExpression(ast: SchemaAST.Objects, value: string): string {
+    const stringKeys: Array<string> = []
+    const symbolKeys: Array<symbol> = []
+    for (let i = 0; i < ast.propertySignatures.length; i++) {
+      const key = ast.propertySignatures[i].name
+      if (typeof key === "symbol") {
+        symbolKeys.push(key)
+      } else {
+        stringKeys.push(String(key))
+      }
+    }
+    if (this.options.simpleInputs && symbolKeys.length === 0) {
+      return stringKeys.length === 0
+        ? `Object.keys(${value}).length === 0`
+        : `Object.keys(${value}).every((key) => ${
+          stringKeys.map((key) => `key === ${JSON.stringify(key)}`).join(" || ")
+        })`
+    }
+    const stringExpression = stringKeys.length === 0
+      ? `Object.getOwnPropertyNames(${value}).length === 0`
+      : `Object.getOwnPropertyNames(${value}).every((key) => ${
+        stringKeys.map((key) => `key === ${JSON.stringify(key)}`).join(" || ")
+      })`
+    const symbolExpression = symbolKeys.length === 0
+      ? `Object.getOwnPropertySymbols(${value}).length === 0`
+      : `Object.getOwnPropertySymbols(${value}).every((key) => ${
+        symbolKeys.map((key) => `key === ${this.ref(key)}`).join(" || ")
+      })`
+    return `${stringExpression} && ${symbolExpression}`
+  }
+
+  private withChecksExpression(ast: SchemaAST.AST, expression: string, value: string, path: string): string {
+    const checks = this.checksExpression(ast.checks, value, ast, `${path}.checks`)
+    return checks ? `(${expression}) && (${checks})` : expression
+  }
+
+  private plainObjectFastPathCondition(ast: SchemaAST.Objects, value: string): string | undefined {
+    if (
+      this.options.simpleInputs &&
+      ast.propertySignatures.every((ps) => typeof ps.name === "string" && !(ps.name in Object.prototype))
+    ) {
+      return undefined
+    }
+    const prototypeGuards = ast.propertySignatures.map((ps) => `!(${this.propertyKey(ps.name)} in Object.prototype)`)
+    const protoExpression = `(${value}.__proto__ === Object.prototype || Object.getPrototypeOf(${value}) === null)`
+    return prototypeGuards.length === 0 ? protoExpression : `${protoExpression} && ${prototypeGuards.join(" && ")}`
+  }
+
+  private fastPathPropertyExpression(
+    ps: SchemaAST.PropertySignature,
+    value: string,
+    path: string
+  ): string {
+    return this.callExpression(ps.type, value, path)
+  }
+
+  private canUsePlainObjectFastPath(ast: SchemaAST.Objects): boolean {
+    return ast.indexSignatures.length === 0 &&
+      ast.propertySignatures.length > 0 &&
+      ast.propertySignatures.every((ps) => {
+        if (ps.name === "__proto__") {
+          return false
+        }
+        return SchemaAST.isOptional(ps.type)
+          ? this.definitelyMatchesUndefined(ps.type)
+          : !this.canMatchUndefined(ps.type)
+      })
+  }
+
+  private definitelyMatchesUndefined(ast: SchemaAST.AST): boolean {
+    if (ast.checks) {
+      return false
+    }
+    switch (ast._tag) {
+      case "Undefined":
+      case "Void":
+      case "Any":
+      case "Unknown":
+        return true
+      case "Union":
+        return ast.types.some((type) => this.definitelyMatchesUndefined(type))
+      default:
+        return false
+    }
+  }
+
+  private canMatchUndefined(ast: SchemaAST.AST): boolean {
+    switch (ast._tag) {
+      case "Undefined":
+      case "Void":
+      case "Any":
+      case "Unknown":
+        return true
+      case "Union":
+        return ast.types.some((type) => this.canMatchUndefined(type))
+      case "Suspend":
+      case "Declaration":
+        return true
+      default:
+        return false
+    }
+  }
+
+  private getDiscriminator(ast: SchemaAST.Union): Discriminator | undefined {
+    if (ast.types.length === 0) {
+      return undefined
+    }
+    const first = ast.types[0]
+    if (first._tag !== "Objects") {
+      return undefined
+    }
+    const candidates = first.propertySignatures.filter((ps) =>
+      !SchemaAST.isOptional(ps.type) && (ps.type._tag === "Literal" || ps.type._tag === "UniqueSymbol")
+    )
+    for (const candidate of candidates) {
+      const cases: Array<DiscriminatorCase> = []
+      const seen = new Set<SchemaAST.LiteralValue | symbol>()
+      let ok = true
+      for (let i = 0; i < ast.types.length; i++) {
+        const type = ast.types[i]
+        if (type._tag !== "Objects") {
+          ok = false
+          break
+        }
+        const ps = type.propertySignatures.find((ps) => ps.name === candidate.name)
+        if (!ps || SchemaAST.isOptional(ps.type) || (ps.type._tag !== "Literal" && ps.type._tag !== "UniqueSymbol")) {
+          ok = false
+          break
+        }
+        const literal = ps.type._tag === "Literal" ? ps.type.literal : ps.type.symbol
+        if (seen.has(literal)) {
+          ok = false
+          break
+        }
+        seen.add(literal)
+        cases.push({ ast: type, index: i, literal })
+      }
+      if (ok) {
+        return { key: candidate.name, cases }
+      }
+    }
+    return undefined
+  }
+
+  private returnWithChecks(ast: SchemaAST.AST, expression: string, path: string): string {
+    const checks = this.checksExpression(ast.checks, "input", ast, `${path}.checks`)
+    return checks ? `return (${expression}) && (${checks})` : `return ${expression}`
+  }
+
+  private returnChecks(ast: SchemaAST.AST, path: string): string {
+    const checks = this.checksExpression(ast.checks, "input", ast, `${path}.checks`)
+    return checks ? `return ${checks}` : "return true"
+  }
+
+  private checksExpression(
+    checks: SchemaAST.Checks | undefined,
+    value: string,
+    ast: SchemaAST.AST,
+    path: string
+  ): string | undefined {
+    if (!checks) {
+      return undefined
+    }
+    return checks.map((check, i) => this.checkExpression(check, value, ast, `${path}[${i}]`)).join(" && ")
+  }
+
+  private checkExpression(
+    check: SchemaAST.Check<unknown>,
+    value: string,
+    ast: SchemaAST.AST,
+    path: string
+  ): string {
+    if (check._tag === "FilterGroup") {
+      return check.checks.map((check, i) => this.checkExpression(check, value, ast, `${path}.checks[${i}]`)).join(
+        " && "
+      )
+    }
+
+    const meta = check.annotations?.meta as any
+    switch (meta?._tag) {
+      case "isTrimmed":
+        return `${value}.trim() === ${value}`
+      case "isPattern":
+      case "isStringFinite":
+      case "isStringBigInt":
+      case "isStringSymbol":
+      case "isUUID":
+      case "isGUID":
+      case "isULID":
+      case "isBase64":
+      case "isBase64Url":
+        return `${this.ref(meta.regExp)}.test(${value})`
+      case "isStartsWith":
+        return `${value}.startsWith(${this.literal(meta.startsWith)})`
+      case "isEndsWith":
+        return `${value}.endsWith(${this.literal(meta.endsWith)})`
+      case "isIncludes":
+        return `${value}.includes(${this.literal(meta.includes)})`
+      case "isUppercased":
+        return `${value}.toUpperCase() === ${value}`
+      case "isLowercased":
+        return `${value}.toLowerCase() === ${value}`
+      case "isCapitalized":
+        return `${value}.charAt(0).toUpperCase() === ${value}.charAt(0)`
+      case "isUncapitalized":
+        return `${value}.charAt(0).toLowerCase() === ${value}.charAt(0)`
+      case "isFinite":
+        return `Number.isFinite(${value})`
+      case "isInt":
+        return `Number.isSafeInteger(${value})`
+      case "isGreaterThan":
+        return `${value} > ${this.literal(meta.exclusiveMinimum)}`
+      case "isGreaterThanOrEqualTo":
+        return `${value} >= ${this.literal(meta.minimum)}`
+      case "isLessThan":
+        return `${value} < ${this.literal(meta.exclusiveMaximum)}`
+      case "isLessThanOrEqualTo":
+        return `${value} <= ${this.literal(meta.maximum)}`
+      case "isBetween": {
+        const lower = meta.exclusiveMinimum
+          ? `${value} > ${this.literal(meta.minimum)}`
+          : `${value} >= ${this.literal(meta.minimum)}`
+        const upper = meta.exclusiveMaximum
+          ? `${value} < ${this.literal(meta.maximum)}`
+          : `${value} <= ${this.literal(meta.maximum)}`
+        return `${lower} && ${upper}`
+      }
+      case "isMultipleOf":
+        return `${this.ref(Number_.remainder)}(${value}, ${this.literal(meta.divisor)}) === 0`
+      case "isGreaterThanBigInt":
+        return `${value} > ${this.literal(meta.exclusiveMinimum)}`
+      case "isGreaterThanOrEqualToBigInt":
+        return `${value} >= ${this.literal(meta.minimum)}`
+      case "isLessThanBigInt":
+        return `${value} < ${this.literal(meta.exclusiveMaximum)}`
+      case "isLessThanOrEqualToBigInt":
+        return `${value} <= ${this.literal(meta.maximum)}`
+      case "isBetweenBigInt": {
+        const lower = meta.exclusiveMinimum
+          ? `${value} > ${this.literal(meta.minimum)}`
+          : `${value} >= ${this.literal(meta.minimum)}`
+        const upper = meta.exclusiveMaximum
+          ? `${value} < ${this.literal(meta.maximum)}`
+          : `${value} <= ${this.literal(meta.maximum)}`
+        return `${lower} && ${upper}`
+      }
+      case "isDateValid":
+        return `!Number.isNaN(${value}.getTime())`
+      case "isGreaterThanDate":
+        return `${value} > ${this.ref(meta.exclusiveMinimum)}`
+      case "isGreaterThanOrEqualToDate":
+        return `${value} >= ${this.ref(meta.minimum)}`
+      case "isLessThanDate":
+        return `${value} < ${this.ref(meta.exclusiveMaximum)}`
+      case "isLessThanOrEqualToDate":
+        return `${value} <= ${this.ref(meta.maximum)}`
+      case "isBetweenDate": {
+        const lower = meta.exclusiveMinimum
+          ? `${value} > ${this.ref(meta.minimum)}`
+          : `${value} >= ${this.ref(meta.minimum)}`
+        const upper = meta.exclusiveMaximum
+          ? `${value} < ${this.ref(meta.maximum)}`
+          : `${value} <= ${this.ref(meta.maximum)}`
+        return `${lower} && ${upper}`
+      }
+      case "isMinLength":
+        return `${value}.length >= ${meta.minLength}`
+      case "isMaxLength":
+        return `${value}.length <= ${meta.maxLength}`
+      case "isLengthBetween":
+        return `${value}.length >= ${meta.minimum} && ${value}.length <= ${meta.maximum}`
+      case "isMinSize":
+        return `${value}.size >= ${meta.minSize}`
+      case "isMaxSize":
+        return `${value}.size <= ${meta.maxSize}`
+      case "isSizeBetween":
+        return `${value}.size >= ${meta.minimum} && ${value}.size <= ${meta.maximum}`
+      case "isMinProperties":
+        return `Reflect.ownKeys(${value}).length >= ${meta.minProperties}`
+      case "isMaxProperties":
+        return `Reflect.ownKeys(${value}).length <= ${meta.maxProperties}`
+      case "isPropertiesLengthBetween":
+        return `Reflect.ownKeys(${value}).length >= ${meta.minimum} && Reflect.ownKeys(${value}).length <= ${meta.maximum}`
+      default:
+        return `${
+          this.ref((input: unknown) => check.run(input, ast, SchemaAST.defaultParseOptions) === undefined)
+        }(${value})`
+    }
+  }
+
+  private indexKeysExpression(parameter: SchemaAST.AST): string {
+    switch (parameter._tag) {
+      case "String":
+        return "Object.keys"
+      case "Symbol":
+        return "Object.getOwnPropertySymbols"
+      case "Number":
+        return `${this.ref((input: object) => Object.keys(input).filter((key) => numberStringRegExp.test(key)))}`
+      case "TemplateLiteral": {
+        const regExp = SchemaAST.getTemplateLiteralRegExp(parameter)
+        return `${this.ref((input: object) => Object.keys(input).filter((key) => regExp.test(key)))}`
+      }
+      default:
+        return `${this.ref((input: Record<PropertyKey, unknown>) => SchemaAST.getIndexSignatureKeys(input, parameter))}`
+    }
+  }
+
+  private indexKeyPredicate(parameter: SchemaAST.AST): string | undefined {
+    if (!parameter.checks) {
+      switch (parameter._tag) {
+        case "String":
+        case "Symbol":
+        case "Number":
+        case "TemplateLiteral":
+          return undefined
+      }
+    }
+    const parser = SchemaParser._issue(toIndexSignatureParameter(parameter))
+    return `${this.ref((key: PropertyKey) => parser(key, SchemaAST.defaultParseOptions) === undefined)}`
+  }
+
+  private ref(value: unknown): string {
+    const index = this.refs.length
+    this.refs.push(value)
+    return `refs[${index}]`
+  }
+
+  private variable(): string {
+    return `v${this.nextVar++}`
+  }
+
+  private literal(value: SchemaAST.LiteralValue): string {
+    switch (typeof value) {
+      case "string":
+        return JSON.stringify(value)
+      case "bigint":
+        return `${value}n`
+      default:
+        return String(value)
+    }
+  }
+
+  private discriminatorLiteral(value: SchemaAST.LiteralValue | symbol): string {
+    return typeof value === "symbol" ? this.ref(value) : this.literal(value)
+  }
+
+  private propertyKey(key: PropertyKey): string {
+    return typeof key === "symbol" ? this.ref(key) : JSON.stringify(key)
+  }
+
+  private propertyAccess(value: string, key: PropertyKey): string {
+    if (typeof key === "symbol") {
+      return `${value}[${this.ref(key)}]`
+    }
+    return typeof key === "string" && isPropertyAccessor(key) ? `${value}.${key}` : `${value}[${JSON.stringify(key)}]`
+  }
+
+  private formatPropertyKey(key: PropertyKey): string {
+    return typeof key === "symbol" ? key.toString() : JSON.stringify(key)
+  }
+}
+
+type Discriminator = {
+  readonly key: PropertyKey
+  readonly cases: ReadonlyArray<DiscriminatorCase>
+}
+
+type DiscriminatorCase = {
+  readonly ast: SchemaAST.AST
+  readonly index: number
+  readonly literal: SchemaAST.LiteralValue | symbol
+}
+
+function isPropertyAccessor(value: string): boolean {
+  return value !== "__proto__" && /^[$A-Z_a-z][$\w]*$/.test(value)
+}
+
+function toIndexSignatureParameter(ast: SchemaAST.AST): SchemaAST.AST {
+  switch (ast._tag) {
+    case "Number":
+      return ast.toCodecStringTree()
+    case "Union":
+      return new SchemaAST.Union(
+        ast.types.map(toIndexSignatureParameter),
+        ast.mode,
+        ast.annotations,
+        ast.checks
+      )
+    default:
+      return ast
+  }
+}

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -524,6 +524,11 @@ export * as SchemaAST from "./SchemaAST.ts"
 /**
  * @since 4.0.0
  */
+export * as SchemaCompiler from "./SchemaCompiler.ts"
+
+/**
+ * @since 4.0.0
+ */
 export * as SchemaGetter from "./SchemaGetter.ts"
 
 /**

--- a/packages/effect/test/schema/SchemaCompiler.test.ts
+++ b/packages/effect/test/schema/SchemaCompiler.test.ts
@@ -1,0 +1,362 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Schema, SchemaCompiler } from "effect"
+
+describe("SchemaCompiler", () => {
+  it("compiles primitive, literal, enum, and template literal schemas", () => {
+    const isString = SchemaCompiler.compileTypeGuard(Schema.String)
+    assert.strictEqual(isString("a"), true)
+    assert.strictEqual(isString(1), false)
+
+    const isLiteral = SchemaCompiler.compileTypeGuard(Schema.Literal("ok"))
+    assert.strictEqual(isLiteral("ok"), true)
+    assert.strictEqual(isLiteral("no"), false)
+
+    const isEnum = SchemaCompiler.compileTypeGuard(Schema.Enum({ A: "A", B: 1 }))
+    assert.strictEqual(isEnum("A"), true)
+    assert.strictEqual(isEnum(1), true)
+    assert.strictEqual(isEnum("B"), false)
+
+    const isPath = SchemaCompiler.compileTypeGuard(Schema.TemplateLiteral(["/users/", Schema.Number]))
+    assert.strictEqual(isPath("/users/123"), true)
+    assert.strictEqual(isPath("/users/a"), false)
+  })
+
+  it("compiles keyword schemas", () => {
+    const isAny = SchemaCompiler.compileTypeGuard(Schema.Any)
+    assert.strictEqual(isAny(undefined), true)
+    assert.strictEqual(isAny(Symbol.for("any")), true)
+
+    const isUnknown = SchemaCompiler.compileTypeGuard(Schema.Unknown)
+    assert.strictEqual(isUnknown(null), true)
+    assert.strictEqual(isUnknown({}), true)
+
+    const isNever = SchemaCompiler.compileTypeGuard(Schema.Never)
+    assert.strictEqual(isNever(undefined), false)
+    assert.strictEqual(isNever("a"), false)
+
+    const isNull = SchemaCompiler.compileTypeGuard(Schema.Null)
+    assert.strictEqual(isNull(null), true)
+    assert.strictEqual(isNull(undefined), false)
+
+    const isUndefined = SchemaCompiler.compileTypeGuard(Schema.Undefined)
+    assert.strictEqual(isUndefined(undefined), true)
+    assert.strictEqual(isUndefined(null), false)
+
+    const isVoid = SchemaCompiler.compileTypeGuard(Schema.Void)
+    assert.strictEqual(isVoid(undefined), true)
+    assert.strictEqual(isVoid(null), false)
+
+    const isObjectKeyword = SchemaCompiler.compileTypeGuard(Schema.ObjectKeyword)
+    assert.strictEqual(isObjectKeyword({}), true)
+    assert.strictEqual(isObjectKeyword(() => undefined), true)
+    assert.strictEqual(isObjectKeyword(null), false)
+
+    const isBoolean = SchemaCompiler.compileTypeGuard(Schema.Boolean)
+    assert.strictEqual(isBoolean(true), true)
+    assert.strictEqual(isBoolean("true"), false)
+
+    const isBigInt = SchemaCompiler.compileTypeGuard(Schema.BigInt)
+    assert.strictEqual(isBigInt(1n), true)
+    assert.strictEqual(isBigInt(1), false)
+
+    const isSymbol = SchemaCompiler.compileTypeGuard(Schema.Symbol)
+    assert.strictEqual(isSymbol(Symbol.for("symbol")), true)
+    assert.strictEqual(isSymbol("symbol"), false)
+
+    const unique = Symbol("unique")
+    const isUniqueSymbol = SchemaCompiler.compileTypeGuard(Schema.UniqueSymbol(unique))
+    assert.strictEqual(isUniqueSymbol(unique), true)
+    assert.strictEqual(isUniqueSymbol(Symbol("unique")), false)
+  })
+
+  it("caches successful compiles by type-side AST", () => {
+    const schema = Schema.Struct({ a: Schema.String })
+    const defaultGuard = SchemaCompiler.compileTypeGuard(schema)
+    const simpleInputsGuard = SchemaCompiler.compileTypeGuard(schema, { simpleInputs: true })
+    const strictGuard = SchemaCompiler.compileTypeGuard(schema, { strict: true })
+    const strictSimpleInputsGuard = SchemaCompiler.compileTypeGuard(schema, { simpleInputs: true, strict: true })
+
+    assert.strictEqual(defaultGuard, SchemaCompiler.compileTypeGuard(schema))
+    assert.strictEqual(simpleInputsGuard, SchemaCompiler.compileTypeGuard(schema, { simpleInputs: true }))
+    assert.strictEqual(strictGuard, SchemaCompiler.compileTypeGuard(schema, { strict: true }))
+    assert.strictEqual(
+      strictSimpleInputsGuard,
+      SchemaCompiler.compileTypeGuard(schema, { simpleInputs: true, strict: true })
+    )
+    assert.notStrictEqual(defaultGuard, simpleInputsGuard)
+    assert.notStrictEqual(defaultGuard, strictGuard)
+    assert.notStrictEqual(defaultGuard, strictSimpleInputsGuard)
+    assert.notStrictEqual(simpleInputsGuard, strictGuard)
+    assert.notStrictEqual(simpleInputsGuard, strictSimpleInputsGuard)
+    assert.notStrictEqual(strictGuard, strictSimpleInputsGuard)
+  })
+
+  it("validates the type side of transformed schemas", () => {
+    const isNumber = SchemaCompiler.compileTypeGuard(Schema.NumberFromString)
+    assert.strictEqual(isNumber(1), true)
+    assert.strictEqual(isNumber("1"), false)
+  })
+
+  it("matches struct own-property and optionality semantics", () => {
+    const schema = Schema.Struct({
+      required: Schema.String,
+      optionalKey: Schema.optionalKey(Schema.String),
+      optional: Schema.optional(Schema.String)
+    })
+    const is = SchemaCompiler.compileTypeGuard(schema)
+
+    assert.strictEqual(is({ required: "a" }), true)
+    assert.strictEqual(is({ required: "a", extra: 1 }), true)
+    assert.strictEqual(is({ required: "a", optionalKey: undefined }), false)
+    assert.strictEqual(is({ required: "a", optional: undefined }), true)
+
+    const inherited = Object.create({ required: "a" })
+    assert.strictEqual(is(inherited), false)
+
+    const objectPrototype = Object.prototype as Record<string, unknown>
+    const pollutedRequired = "schemaCompilerPollutedRequired"
+    const isPollutedRequired = SchemaCompiler.compileTypeGuard(Schema.Struct({ [pollutedRequired]: Schema.String }))
+    Object.defineProperty(objectPrototype, pollutedRequired, { configurable: true, value: "a" })
+    const pollutedRequiredResult = isPollutedRequired({})
+    delete objectPrototype[pollutedRequired]
+    assert.strictEqual(pollutedRequiredResult, false)
+
+    const pollutedOptional = "schemaCompilerPollutedOptional"
+    const isPollutedOptional = SchemaCompiler.compileTypeGuard(Schema.Struct({
+      required: Schema.String,
+      [pollutedOptional]: Schema.optional(Schema.String)
+    }))
+    Object.defineProperty(objectPrototype, pollutedOptional, { configurable: true, value: 1 })
+    const pollutedOptionalResult = isPollutedOptional({ required: "a" })
+    delete objectPrototype[pollutedOptional]
+    assert.strictEqual(pollutedOptionalResult, true)
+  })
+
+  it("supports strict mode", () => {
+    const schema = Schema.Struct({
+      a: Schema.Number,
+      nested: Schema.Struct({ b: Schema.String })
+    })
+    const isLoose = SchemaCompiler.compileTypeGuard(schema)
+    const isStrict = SchemaCompiler.compileTypeGuard(schema, { strict: true })
+    const isStrictSimple = SchemaCompiler.compileTypeGuard(schema, { simpleInputs: true, strict: true })
+
+    assert.strictEqual(isLoose({ a: 1, nested: { b: "b" }, extra: 1 }), true)
+    assert.strictEqual(isStrict({ a: 1, nested: { b: "b" } }), true)
+    assert.strictEqual(isStrict({ a: 1, nested: { b: "b" }, extra: 1 }), false)
+    assert.strictEqual(isStrict({ a: 1, nested: { b: "b", extra: 1 } }), false)
+    assert.strictEqual(isStrictSimple({ a: 1, nested: { b: "b" } }), true)
+    assert.strictEqual(isStrictSimple({ a: 1, nested: { b: "b" }, extra: 1 }), false)
+    assert.strictEqual(isStrictSimple({ a: 1, nested: { b: "b", extra: 1 } }), false)
+
+    const symbol = Symbol.for("schema-compiler-extra")
+    assert.strictEqual(isStrict({ a: 1, nested: { b: "b" }, [symbol]: 1 }), false)
+    assert.strictEqual(isStrict({ a: 1, nested: { b: "b", [symbol]: 1 } }), false)
+  })
+
+  it("preserves empty struct type-side semantics with strict mode", () => {
+    const is = SchemaCompiler.compileTypeGuard(Schema.Struct({}), { strict: true })
+
+    assert.strictEqual(is({ a: 1 }), true)
+    assert.strictEqual(is([]), true)
+    assert.strictEqual(is(1), true)
+    assert.strictEqual(is(null), false)
+    assert.strictEqual(is(undefined), false)
+  })
+
+  it("validates nested structs without inherited fields", () => {
+    const is = SchemaCompiler.compileTypeGuard(Schema.Struct({
+      nested: Schema.Struct({ value: Schema.String })
+    }))
+
+    assert.strictEqual(is({ nested: { value: "a" } }), true)
+    assert.strictEqual(is({ nested: { value: 1 } }), false)
+    assert.strictEqual(is({ nested: Object.create({ value: "a" }) }), false)
+  })
+
+  it("validates arrays and tuples", () => {
+    const isArray = SchemaCompiler.compileTypeGuard(Schema.Array(Schema.String))
+    assert.strictEqual(isArray(["a", "b"]), true)
+    assert.strictEqual(isArray(["a", 1]), false)
+
+    const isTuple = SchemaCompiler.compileTypeGuard(Schema.Tuple([Schema.String, Schema.optionalKey(Schema.Number)]))
+    assert.strictEqual(isTuple(["a"]), true)
+    assert.strictEqual(isTuple(["a", 1]), true)
+    assert.strictEqual(isTuple(["a", 1, 2]), false)
+
+    const sparse = new Array(1)
+    assert.strictEqual(isTuple(sparse), false)
+  })
+
+  it("validates TupleWithRest", () => {
+    const is = SchemaCompiler.compileTypeGuard(
+      Schema.TupleWithRest(Schema.Tuple([Schema.String]), [Schema.Boolean, Schema.String])
+    )
+
+    assert.strictEqual(is(["a", "tail"]), true)
+    assert.strictEqual(is(["a", true, "tail"]), true)
+    assert.strictEqual(is(["a", true, true, "tail"]), true)
+    assert.strictEqual(is(["a"]), false)
+    assert.strictEqual(is(["a", true]), false)
+    assert.strictEqual(is(["a", "tail", "extra"]), false)
+  })
+
+  it("validates records and symbol keys", () => {
+    const isRecord = SchemaCompiler.compileTypeGuard(Schema.Record(Schema.String, Schema.Number))
+    assert.strictEqual(isRecord({ a: 1, b: 2 }), true)
+    assert.strictEqual(isRecord({ a: 1, b: "b" }), false)
+
+    const symbol = Symbol.for("key")
+    const isSymbolRecord = SchemaCompiler.compileTypeGuard(Schema.Record(Schema.Symbol, Schema.String))
+    assert.strictEqual(isSymbolRecord({ [symbol]: "value" }), true)
+    assert.strictEqual(isSymbolRecord({ [symbol]: 1 }), false)
+
+    const isNumberRecord = SchemaCompiler.compileTypeGuard(Schema.Record(Schema.Number, Schema.String))
+    assert.strictEqual(isNumberRecord({ "1": "a", "-2": "b" }), true)
+    assert.strictEqual(isNumberRecord({ "1": 1 }), false)
+
+    const isTemplateRecord = SchemaCompiler.compileTypeGuard(
+      Schema.Record(Schema.TemplateLiteral(["x-", Schema.String]), Schema.Number)
+    )
+    assert.strictEqual(isTemplateRecord({ "x-a": 1 }), true)
+    assert.strictEqual(isTemplateRecord({ "x-a": "a" }), false)
+
+    const unionKey = Symbol.for("union-key")
+    const isStringOrSymbolRecord = SchemaCompiler.compileTypeGuard(
+      Schema.Record(Schema.Union([Schema.String, Schema.Symbol]), Schema.Number)
+    )
+    assert.strictEqual(isStringOrSymbolRecord({ a: 1, [unionKey]: 2 }), true)
+    assert.strictEqual(isStringOrSymbolRecord({ a: 1, [unionKey]: "a" }), false)
+  })
+
+  it("validates StructWithRest", () => {
+    const isStringRest = SchemaCompiler.compileTypeGuard(
+      Schema.StructWithRest(Schema.Struct({ a: Schema.Number }), [Schema.Record(Schema.String, Schema.Number)])
+    )
+    assert.strictEqual(isStringRest({ a: 1 }), true)
+    assert.strictEqual(isStringRest({ a: 1, b: 2 }), true)
+    assert.strictEqual(isStringRest({ a: 1, b: "b" }), false)
+    assert.strictEqual(isStringRest({ b: 2 }), false)
+
+    const symbol = Symbol.for("rest")
+    const isSymbolRest = SchemaCompiler.compileTypeGuard(
+      Schema.StructWithRest(Schema.Struct({ a: Schema.Number }), [Schema.Record(Schema.Symbol, Schema.String)])
+    )
+    assert.strictEqual(isSymbolRest({ a: 1, [symbol]: "value" }), true)
+    assert.strictEqual(isSymbolRest({ a: 1, [symbol]: 1 }), false)
+  })
+
+  it("validates discriminated unions", () => {
+    const schema = Schema.Union([
+      Schema.Struct({ _tag: Schema.Literal("A"), a: Schema.String }),
+      Schema.Struct({ _tag: Schema.Literal("B"), b: Schema.Number })
+    ])
+    const is = SchemaCompiler.compileTypeGuard(schema)
+
+    assert.strictEqual(is({ _tag: "A", a: "a" }), true)
+    assert.strictEqual(is({ _tag: "B", b: 1 }), true)
+    assert.strictEqual(is({ _tag: "A", a: 1 }), false)
+    assert.strictEqual(is({ _tag: "C" }), false)
+  })
+
+  it("validates non-discriminated and oneOf unions", () => {
+    const isStringOrNumber = SchemaCompiler.compileTypeGuard(Schema.Union([Schema.String, Schema.Number]))
+    assert.strictEqual(isStringOrNumber("a"), true)
+    assert.strictEqual(isStringOrNumber(1), true)
+    assert.strictEqual(isStringOrNumber(true), false)
+
+    const isExactlyStringOrNonEmptyString = SchemaCompiler.compileTypeGuard(
+      Schema.Union([Schema.String, Schema.NonEmptyString], { mode: "oneOf" })
+    )
+    assert.strictEqual(isExactlyStringOrNonEmptyString(""), true)
+    assert.strictEqual(isExactlyStringOrNonEmptyString("a"), false)
+    assert.strictEqual(isExactlyStringOrNonEmptyString(1), false)
+  })
+
+  it("validates built-in checks", () => {
+    const isString = SchemaCompiler.compileTypeGuard(
+      Schema.String.check(
+        Schema.isStartsWith("a"),
+        Schema.isIncludes("m"),
+        Schema.isEndsWith("z"),
+        Schema.isMinLength(3),
+        Schema.isMaxLength(5)
+      )
+    )
+    assert.strictEqual(isString("amz"), true)
+    assert.strictEqual(isString("az"), false)
+    assert.strictEqual(isString("amzzzz"), false)
+
+    const isNumber = SchemaCompiler.compileTypeGuard(
+      Schema.Number.check(
+        Schema.isFinite(),
+        Schema.isInt(),
+        Schema.isGreaterThan(0),
+        Schema.isLessThan(10),
+        Schema.isMultipleOf(2)
+      )
+    )
+    assert.strictEqual(isNumber(2), true)
+    assert.strictEqual(isNumber(3), false)
+    assert.strictEqual(isNumber(Infinity), false)
+
+    const isBigInt = SchemaCompiler.compileTypeGuard(
+      Schema.BigInt.check(
+        Schema.isGreaterThanBigInt(0n),
+        Schema.isLessThanOrEqualToBigInt(10n)
+      )
+    )
+    assert.strictEqual(isBigInt(1n), true)
+    assert.strictEqual(isBigInt(0n), false)
+    assert.strictEqual(isBigInt(11n), false)
+
+    const isArray = SchemaCompiler.compileTypeGuard(
+      Schema.Array(Schema.String).check(Schema.isMinLength(1), Schema.isMaxLength(2))
+    )
+    assert.strictEqual(isArray(["a"]), true)
+    assert.strictEqual(isArray([]), false)
+    assert.strictEqual(isArray(["a", "b", "c"]), false)
+
+    const isObject = SchemaCompiler.compileTypeGuard(
+      Schema.Struct({ a: Schema.Number }).check(Schema.isPropertiesLengthBetween(1, 2))
+    )
+    assert.strictEqual(isObject({ a: 1 }), true)
+    assert.strictEqual(isObject({ a: 1, b: 2 }), true)
+    assert.strictEqual(isObject({ a: 1, b: 2, c: 3 }), false)
+  })
+
+  it("supports recursive schemas", () => {
+    interface Category {
+      readonly name: string
+      readonly children: ReadonlyArray<Category>
+    }
+
+    const Category = Schema.Struct({
+      name: Schema.String,
+      children: Schema.Array(Schema.suspend((): Schema.Codec<Category> => Category))
+    })
+    const isCategory = SchemaCompiler.compileTypeGuard(Category)
+
+    assert.strictEqual(isCategory({ name: "root", children: [] }), true)
+    assert.strictEqual(isCategory({ name: "root", children: [{ name: "child", children: [] }] }), true)
+    assert.strictEqual(isCategory({ name: "root", children: [{ name: 1, children: [] }] }), false)
+  })
+
+  it("uses opaque refs for custom filters and declarations", () => {
+    const isEven = SchemaCompiler.compileTypeGuard(Schema.Number.check(Schema.makeFilter((n) => n % 2 === 0)))
+    assert.strictEqual(isEven(2), true)
+    assert.strictEqual(isEven(3), false)
+
+    const isRegExp = SchemaCompiler.compileTypeGuard(Schema.RegExp)
+    assert.strictEqual(isRegExp(/a/), true)
+    assert.strictEqual(isRegExp("a"), false)
+  })
+
+  it("lets custom filter exceptions escape", () => {
+    const is = SchemaCompiler.compileTypeGuard(Schema.Number.check(Schema.makeFilter(() => {
+      throw new Error("boom")
+    })))
+
+    assert.throws(() => is(1), /boom/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
     devDependencies:
+      '@sinclair/typebox':
+        specifier: 0.27.10
+        version: 0.27.10
       '@types/ini':
         specifier: ^4.1.1
         version: 4.1.1


### PR DESCRIPTION
```md
┌─────────┬───────────────────────────────────────────────────────────────┬───────────────────┬───────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name                                                     │ Latency avg (ns)  │ Latency med (ns)  │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼───────────────────────────────────────────────────────────────┼───────────────────┼───────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'SchemaCompiler.compileTypeGuard moltar loose object'         │ '6359.2 ± 0.21%'  │ '6250.0 ± 83.00'  │ '158961 ± 0.03%'       │ '160000 ± 2153'        │ 157254  │
│ 1       │ 'SchemaCompiler.compileTypeGuard moltar loose simple object'  │ '4402.7 ± 0.20%'  │ '4292.0 ± 42.00'  │ '230177 ± 0.02%'       │ '232992 ± 2303'        │ 227134  │
│ 2       │ 'TypeBox moltar loose object'                                 │ '5998.6 ± 2.50%'  │ '5416.0 ± 42.00'  │ '181674 ± 0.04%'       │ '184638 ± 1421'        │ 166708  │
│ 3       │ 'Ajv moltar loose object'                                     │ '13001 ± 4.70%'   │ '10041 ± 250.00'  │ '95844 ± 0.11%'        │ '99592 ± 2533'         │ 76918   │
│ 4       │ 'Valibot moltar loose object'                                 │ '433282 ± 4.25%'  │ '382354 ± 7354.0' │ '2491 ± 0.57%'         │ '2615 ± 51'            │ 2308    │
│ 5       │ 'Schema.is moltar loose object'                               │ '639062 ± 1.69%'  │ '602625 ± 14541'  │ '1601 ± 0.50%'         │ '1659 ± 41'            │ 1565    │
│ 6       │ 'SchemaCompiler.compileTypeGuard moltar strict object'        │ '58125 ± 3.98%'   │ '50708 ± 1333.0'  │ '19122 ± 0.20%'        │ '19721 ± 516'          │ 17205   │
│ 7       │ 'SchemaCompiler.compileTypeGuard moltar strict simple object' │ '16436 ± 0.34%'   │ '15709 ± 208.00'  │ '62579 ± 0.07%'        │ '63658 ± 832'          │ 60844   │
│ 8       │ 'TypeBox moltar strict object'                                │ '16129 ± 0.19%'   │ '15625 ± 208.00'  │ '62972 ± 0.06%'        │ '64000 ± 863'          │ 62002   │
│ 9       │ 'Ajv moltar strict object'                                    │ '30757 ± 2.68%'   │ '25709 ± 417.00'  │ '37156 ± 0.16%'        │ '38897 ± 641'          │ 32514   │
│ 10      │ 'Valibot moltar strict object'                                │ '491513 ± 0.40%'  │ '480041 ± 7125.0' │ '2046 ± 0.27%'         │ '2083 ± 31'            │ 2035    │
│ 11      │ 'Schema.decodeUnknownOption moltar strict object'             │ '1225141 ± 7.36%' │ '937708 ± 32083'  │ '975 ± 1.49%'          │ '1066 ± 38'            │ 817     │
│ 12      │ 'SchemaCompiler.compileTypeGuard discriminated union'         │ '4934.9 ± 0.31%'  │ '4791.0 ± 82.00'  │ '206576 ± 0.03%'       │ '208725 ± 3596'        │ 202640  │
│ 13      │ 'TypeBox discriminated union'                                 │ '4926.4 ± 0.12%'  │ '4834.0 ± 1.00'   │ '204746 ± 0.02%'       │ '206868 ± 43'          │ 202990  │
│ 14      │ 'Ajv discriminated union'                                     │ '8393.0 ± 0.44%'  │ '8166.0 ± 124.00' │ '121174 ± 0.03%'       │ '122459 ± 1846'        │ 119147  │
│ 15      │ 'Valibot discriminated union'                                 │ '281193 ± 0.43%'  │ '273792 ± 1501.0' │ '3583 ± 0.21%'         │ '3652 ± 20'            │ 3557    │
│ 16      │ 'Schema.is discriminated union'                               │ '407520 ± 0.19%'  │ '401792 ± 2126.0' │ '2459 ± 0.16%'         │ '2489 ± 13'            │ 2454    │
└─────────┴───────────────────────────────────────────────────────────────┴───────────────────┴───────────────────┴────────────────────────┴────────────────────────┴─────────┘
```