### PR TITLE
EFF-847 Fix Stream.runForEachWhile chunk continuation

### DIFF
--- a/.changeset/fix-stream-run-for-each-while.md
+++ b/.changeset/fix-stream-run-for-each-while.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Stream.runForEachWhile so it continues across chunk boundaries while the predicate returns true and stops when the predicate returns false.

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -10937,7 +10937,7 @@ export const runForEachWhile: {
           if (!b) done = true
         }
       }),
-      () => done
+      () => !done
     )
   }))
 

--- a/packages/effect/test/Stream.test.ts
+++ b/packages/effect/test/Stream.test.ts
@@ -133,6 +133,36 @@ describe("Stream", () => {
       }))
   })
 
+  describe("destructors", () => {
+    it.effect("runForEachWhile continues across chunk boundaries", () =>
+      Effect.gen(function*() {
+        const seen: Array<number> = []
+        yield* Stream.fromArrays([1, 2], [3, 4]).pipe(
+          Stream.runForEachWhile((n) =>
+            Effect.sync(() => {
+              seen.push(n)
+              return true
+            })
+          )
+        )
+        assert.deepStrictEqual(seen, [1, 2, 3, 4])
+      }))
+
+    it.effect("runForEachWhile stops when predicate returns false", () =>
+      Effect.gen(function*() {
+        const seen: Array<number> = []
+        yield* Stream.fromArrays([1, 2, 3], [4, 5]).pipe(
+          Stream.runForEachWhile((n) =>
+            Effect.sync(() => {
+              seen.push(n)
+              return n < 3
+            })
+          )
+        )
+        assert.deepStrictEqual(seen, [1, 2, 3])
+      }))
+  })
+
   describe("constructors", () => {
     class Greeter extends Context.Service<Greeter, {
       readonly greet: (name: string) => string


### PR DESCRIPTION
## Summary
- Fix `Stream.runForEachWhile` to return the correct chunk-level continue signal to `Channel.runForEachWhile`.
- Add regression tests covering continuing across chunk boundaries and stopping when the predicate returns false.
- Add a patch changeset for `effect`.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Stream.test.ts`
- `pnpm check:tsgo`