### PR TITLE
EFF-849 Port Effect.transposeOption from v3

### DIFF
--- a/.changeset/eff-849-transpose-option.md
+++ b/.changeset/eff-849-transpose-option.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Add `Effect.transposeOption` for converting an `Option<Effect<A, E, R>>` into an `Effect<Option<A>, E, R>`.

--- a/.changeset/eff-849-transpose-option.md
+++ b/.changeset/eff-849-transpose-option.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 Add `Effect.transposeOption` for converting an `Option<Effect<A, E, R>>` into an `Effect<Option<A>, E, R>`.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1809,6 +1809,42 @@ export const fromOption: <A>(
 ) => Effect<A, Cause.NoSuchElementError> = internal.fromOption
 
 /**
+ * Converts an `Option` of an `Effect` into an `Effect` of an `Option`.
+ *
+ * **When to use**
+ *
+ * Use when an effect should run only when an optional value is present, while
+ * preserving absence as a successful `None`.
+ *
+ * **Details**
+ *
+ * - `None` becomes an effect that succeeds with `None`
+ * - `Some(effect)` runs the inner effect and wraps its success value in `Some`
+ * - Inner failures are preserved in the resulting effect
+ *
+ * **Example** (Transposing an Option of an Effect)
+ *
+ * ```ts
+ * import { Effect, Option } from "effect"
+ *
+ * const some = Option.some(Effect.succeed(42))
+ *
+ * //      ┌─── Effect<Option<number>, never, never>
+ * //      ▼
+ * const program = Effect.transposeOption(some)
+ *
+ * Effect.runPromise(program).then(console.log)
+ * // Output: { _id: 'Option', _tag: 'Some', value: 42 }
+ * ```
+ *
+ * @category converting
+ * @since 3.13.0
+ */
+export const transposeOption: <A = never, E = never, R = never>(
+  self: Option<Effect<A, E, R>>
+) => Effect<Option<A>, E, R> = internal.transposeOption
+
+/**
  * Converts a nullable value to an `Effect`, failing with a `NoSuchElementError`
  * when the value is `null` or `undefined`.
  *

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -934,6 +934,11 @@ export const succeedNone: Effect.Effect<Option.Option<never>> = succeed(
 )
 
 /** @internal */
+export const transposeOption = <A = never, E = never, R = never>(
+  self: Option.Option<Effect.Effect<A, E, R>>
+): Effect.Effect<Option.Option<A>, E, R> => Option.isNone(self) ? succeedNone : map(self.value, Option.some)
+
+/** @internal */
 export const failCauseSync = <E>(
   evaluate: LazyArg<Cause.Cause<E>>
 ): Effect.Effect<never, E> => suspend(() => failCause(internalCall(evaluate)))

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -155,6 +155,26 @@ describe("Effect", () => {
       ))
   })
 
+  describe("transposeOption", () => {
+    it.effect("transposes a none", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.transposeOption(Option.none())
+        assert.deepStrictEqual(result, Option.none())
+      }))
+
+    it.effect("transposes a some containing a success", () =>
+      Effect.gen(function*() {
+        const result = yield* Effect.transposeOption(Option.some(Effect.succeed("A")))
+        assert.deepStrictEqual(result, Option.some("A"))
+      }))
+
+    it.effect("transposes a some containing a failure", () =>
+      Effect.gen(function*() {
+        const error = yield* Effect.transposeOption(Option.some(Effect.fail("error"))).pipe(Effect.flip)
+        assert.strictEqual(error, "error")
+      }))
+  })
+
   describe("fromResult", () => {
     it("from a success", () =>
       Result.succeed("A").pipe(

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -67,6 +67,7 @@ declare const resultStringOrNumber: Result.Result<string, "err-1"> | Result.Resu
 declare const fiberStringOrNumber: Fiber.Fiber<string, "err-1"> | Fiber.Fiber<number, "err-2">
 declare const stringArray: Array<Effect.Effect<string, "err-3", "dep-3">>
 declare const numberRecord: Record<string, Effect.Effect<number, "err-4", "dep-4">>
+declare const optionalEffect: Option.Option<Effect.Effect<string, "err-1", "dep-1">>
 
 class AcquireReleaseDependency extends Context.Service<AcquireReleaseDependency, string>()(
   "AcquireReleaseDependency"
@@ -165,6 +166,13 @@ describe("Effect.catchReason", () => {
       )
     )
     expect(result).type.toBe<Effect.Effect<string, OtherError | SimpleError>>()
+  })
+})
+
+describe("Effect.transposeOption", () => {
+  it("preserves success, error, and requirements", () => {
+    const result = Effect.transposeOption(optionalEffect)
+    expect(result).type.toBe<Effect.Effect<Option.Option<string>, "err-1", "dep-1">>()
   })
 })
 


### PR DESCRIPTION
## Summary
- Added `Effect.transposeOption` for transposing `Option<Effect<A, E, R>>` into `Effect<Option<A>, E, R>`.
- Covered None, successful Some, and failing Some runtime behavior.
- Added type coverage for preserving success, error, and requirement channels.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Effect.test.ts`
- `pnpm test-types Effect.tst.ts`
- `pnpm check:tsgo`
