### PR TITLE
Reproduce cluster activity defect reply leak

### DIFF
--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest"
-import { Cause, Context, DateTime, Duration, Effect, Exit, Fiber, Layer, Option, Schema } from "effect"
+import { Cause, Context, DateTime, Duration, Effect, Exit, Fiber, Layer, Option, Result, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
   ClusterSchema,
@@ -306,6 +306,43 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       yield* Fiber.join(fiber)
 
       assert.isTrue(flags.get("catch"))
+    }).pipe(Effect.provide(TestWorkflowLayer)))
+
+  it.effect("roundtrips activity defects through the reply codec before delivery", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      yield* TestClock.adjust(1)
+
+      const exit = yield* ErrorDefectWorkflow.execute({
+        id: "raw-error-defect"
+      }).pipe(Effect.exit)
+
+      assert(Exit.isFailure(exit))
+      const defect = Cause.findDefect(exit.cause)
+      assert(Result.isSuccess(defect))
+      assert(defect.success instanceof Error)
+      assert.strictEqual(defect.success.message, "Batch request error: Request timed out")
+      assert.isUndefined((defect.success as Error & { readonly nonJson?: unknown }).nonJson)
+
+      const activityRequest = driver.journal.find((envelope) =>
+        envelope._tag === "Request" &&
+        envelope.tag === "activity" &&
+        (envelope.payload as { readonly name?: string }).name === "raw-error-defect"
+      )
+      assert(activityRequest)
+      const storedReply = driver.requests.get(activityRequest.requestId)?.replies[0]
+      assert(storedReply?._tag === "WithExit")
+      assert(storedReply.exit._tag === "Success")
+
+      const result = storedReply.exit.value as Workflow.ResultEncoded<any, any>
+      assert(result._tag === "Complete")
+      assert(result.exit._tag === "Failure")
+      const storedDefect = result.exit.cause.find((reason) => reason._tag === "Die")?.defect
+
+      expect(storedDefect).toEqual({
+        name: "Error",
+        message: "Batch request error: Request timed out"
+      })
     }).pipe(Effect.provide(TestWorkflowLayer)))
 })
 
@@ -639,6 +676,31 @@ const CatchWorkflowLayer = CatchWorkflow.toLayer(Effect.fnUntraced(function*() {
   )
 }))
 
+const ErrorDefectWorkflow = Workflow.make("ErrorDefectWorkflow", {
+  payload: {
+    id: Schema.String
+  },
+  idempotencyKey(payload) {
+    return payload.id
+  }
+})
+
+const ErrorDefectWorkflowLayer = ErrorDefectWorkflow.toLayer(Effect.fnUntraced(function*() {
+  yield* Activity.make({
+    name: "raw-error-defect",
+    execute: Effect.die(makeBatchRequestError())
+  })
+}))
+
+const makeBatchRequestError = () => {
+  const error = new Error("Batch request error: Request timed out")
+  Object.defineProperty(error, "nonJson", {
+    enumerable: true,
+    value: 1n
+  })
+  return error
+}
+
 const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(RaceWorkflowLayer),
   Layer.merge(DurableRaceWorkflowLayer),
@@ -647,6 +709,7 @@ const TestWorkflowLayer = EmailWorkflowLayer.pipe(
   Layer.merge(ShardedClockWorkflowLayer),
   Layer.merge(SuspendOnFailureWorkflowLayer),
   Layer.merge(CatchWorkflowLayer),
+  Layer.merge(ErrorDefectWorkflowLayer),
   Layer.provideMerge(Flags.layer),
   Layer.provideMerge(TestWorkflowEngine)
 )


### PR DESCRIPTION
## Summary

Adds a failing cluster/entity/workflow repro for activity defects that contain non-JSON fields. The test asserts that an activity defect is roundtripped through the workflow reply codec before delivery, preserving the JSON-encoded `Error` shape (`name` + `message`) instead of delivering a schema decode failure to the workflow caller.

In the current implementation, the focused test fails because the delivered defect message is:

```
Expected JSON value, got Error: Batch request error: Request timed out
  at ["cause"]["failures"][0]["defect"]
```

## How to run

Focused repro:

```sh
pnpm test packages/effect/test/cluster/ClusterWorkflowEngine.test.ts -t "roundtrips activity defects"
```

Repo checks for this change:

```sh
pnpm lint-fix
pnpm check:tsgo
```

## Validation

- `pnpm test packages/effect/test/cluster/ClusterWorkflowEngine.test.ts -t "roundtrips activity defects"` fails as expected with the schema decode defect above.
- `pnpm lint-fix` passes.
- `pnpm check:tsgo` passes.
