### PR TITLE
EFF-851 Port Random.choice from effect v3

### DIFF
--- a/.changeset/random-choice.md
+++ b/.changeset/random-choice.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add Random.choice for selecting a random element from an iterable.

--- a/packages/effect/src/Random.ts
+++ b/packages/effect/src/Random.ts
@@ -8,10 +8,13 @@
  *
  * @since 4.0.0
  */
+import type * as Arr from "./Array.ts"
+import * as Cause from "./Cause.ts"
 import type * as Context from "./Context.ts"
 import * as Effect from "./Effect.ts"
 import { dual } from "./Function.ts"
 import * as random from "./internal/random.ts"
+import type * as NonEmptyIterable from "./NonEmptyIterable.ts"
 import * as Predicate from "./Predicate.ts"
 
 /**
@@ -224,6 +227,45 @@ export const shuffle = <A>(elements: Iterable<A>): Effect.Effect<Array<A>> =>
     }
     return buffer
   })
+
+/**
+ * Gets a random element from an iterable.
+ *
+ * **When to use**
+ *
+ * Use to select one value uniformly from a collection using the active `Random`
+ * service.
+ *
+ * **Details**
+ *
+ * If the input type is known to be non-empty, the returned effect cannot fail.
+ * Otherwise, empty iterables fail with `Cause.NoSuchElementError`.
+ *
+ * **Example** (Choosing a random value)
+ *
+ * ```ts
+ * import { Effect, Random } from "effect"
+ *
+ * const program = Effect.gen(function*() {
+ *   const value = yield* Random.choice(["red", "green", "blue"] as const)
+ *   console.log(value)
+ * })
+ * ```
+ *
+ * @category Random Number Generators
+ * @since 3.6.0
+ */
+export const choice: <Self extends Iterable<unknown>>(
+  elements: Self
+) => Self extends NonEmptyIterable.NonEmptyIterable<infer A> ? Effect.Effect<A>
+  : Self extends Arr.NonEmptyReadonlyArray<infer A> ? Effect.Effect<A>
+  : Self extends Iterable<infer A> ? Effect.Effect<A, Cause.NoSuchElementError>
+  : never = ((elements: Iterable<unknown>) => {
+    const buffer = Array.from(elements)
+    return buffer.length === 0
+      ? Effect.fail(new Cause.NoSuchElementError("Cannot select a random element from an empty array"))
+      : randomWith((r) => buffer[Math.min(buffer.length - 1, Math.floor(r.nextDoubleUnsafe() * buffer.length))]!)
+  }) as any
 
 /**
  * Seeds the pseudo-random number generator with the specified value.

--- a/packages/effect/test/Random.test.ts
+++ b/packages/effect/test/Random.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
+import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 import * as Random from "effect/Random"
 
@@ -142,6 +143,42 @@ describe("Random", () => {
 
         const result1 = yield* program.pipe(Random.withSeed("shuffle-seed"))
         const result2 = yield* program.pipe(Random.withSeed("shuffle-seed"))
+
+        assert.deepStrictEqual(result1, result2)
+      }))
+  })
+
+  describe("choice", () => {
+    it.effect("selects a random element from an iterable", () =>
+      Effect.gen(function*() {
+        const value = yield* Random.choice(["a", "b", "c"]).pipe(
+          Effect.provideService(Random.Random, {
+            nextIntUnsafe: () => 0,
+            nextDoubleUnsafe: () => 0.75
+          })
+        )
+
+        assert.strictEqual(value, "c")
+      }))
+
+    it.effect("fails with NoSuchElementError for an empty iterable", () =>
+      Effect.gen(function*() {
+        const error = yield* Random.choice([]).pipe(Effect.flip)
+
+        assert.isTrue(Cause.isNoSuchElementError(error))
+        assert.strictEqual(error.message, "Cannot select a random element from an empty array")
+      }))
+
+    it.effect("is deterministic with the same seed", () =>
+      Effect.gen(function*() {
+        const program = Effect.all([
+          Random.choice([1, 2, 3, 4, 5]),
+          Random.choice([1, 2, 3, 4, 5]),
+          Random.choice([1, 2, 3, 4, 5])
+        ])
+
+        const result1 = yield* program.pipe(Random.withSeed("choice-seed"))
+        const result2 = yield* program.pipe(Random.withSeed("choice-seed"))
 
         assert.deepStrictEqual(result1, result2)
       }))

--- a/packages/effect/typetest/Random.tst.ts
+++ b/packages/effect/typetest/Random.tst.ts
@@ -1,0 +1,22 @@
+import type { Cause, Effect, NonEmptyIterable } from "effect"
+import { Random } from "effect"
+import { describe, expect, it } from "tstyche"
+
+declare const nonEmptyIterable: NonEmptyIterable.NonEmptyIterable<string>
+declare const readonlyValues: ReadonlyArray<number>
+
+describe("Random", () => {
+  describe("choice", () => {
+    it("returns an infallible effect for non-empty arrays", () => {
+      expect(Random.choice([1, 2, 3] as const)).type.toBe<Effect.Effect<1 | 2 | 3>>()
+    })
+
+    it("returns an infallible effect for non-empty iterables", () => {
+      expect(Random.choice(nonEmptyIterable)).type.toBe<Effect.Effect<string>>()
+    })
+
+    it("can fail for iterables not known to be non-empty", () => {
+      expect(Random.choice(readonlyValues)).type.toBe<Effect.Effect<number, Cause.NoSuchElementError>>()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Port Random.choice from effect v3 with typed non-empty input overload behavior
- Fail empty iterables with Cause.NoSuchElementError
- Add runtime and type-level coverage plus a patch changeset

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Random.test.ts
- pnpm test-types packages/effect/typetest/Random.tst.ts
- pnpm check:tsgo