### PR TITLE
fix(Clock): anchor currentTimeNanos against Date.now() when performance.now() is not wall-clock

### DIFF
--- a/.changeset/fix-clock-current-time-nanos-cf-workers.md
+++ b/.changeset/fix-clock-current-time-nanos-cf-workers.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Clock.currentTimeNanos` returning timestamps near the Unix epoch on Cloudflare Workers `wrangler dev` / Miniflare with the `nodejs_compat` flag. The default clock's `performanceNowNanos` helper trusted `performance.timeOrigin === 0` as the signal that `performance.now()` already returns wall-clock ms, but on Miniflare `timeOrigin === 0` while `performance.now()` is unanchored from wall clock (it starts at 0 and grows). Spans then carried 1970 start/end times and were invisible to time-windowed trace backends. The helper now confirms `performance.now() > 86_400_000` before trusting the optimized path; when it doesn't look like wall-clock ms (the Miniflare case), it falls through to the `Date.now()`-anchored path. Fixes #2416.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5827,7 +5827,19 @@ const performanceNowNanos = (function() {
   const bigint1e6 = BigInt(1_000_000)
   if (typeof performance === "undefined" || typeof performance.now === "undefined") {
     return () => BigInt(Date.now()) * bigint1e6
-  } else if (typeof performance.timeOrigin === "number" && performance.timeOrigin === 0) {
+  } else if (
+    typeof performance.timeOrigin === "number"
+    && performance.timeOrigin === 0
+    && performance.now() > 86_400_000
+  ) {
+    // timeOrigin === 0 is normally the signal that performance.now() already
+    // returns wall-clock ms (e.g. browsers in cross-origin-isolated mode), so
+    // we can read it directly. On Miniflare / Cloudflare Workers with
+    // `nodejs_compat` it instead means performance.now() is unanchored from
+    // wall clock — performance.now() at module load is ~0 and grows from
+    // there, which would land every span near the Unix epoch. The
+    // performance.now() > 86_400_000 check confirms the value actually
+    // looks like wall-clock ms before trusting it (#2416).
     return () => BigInt(Math.round(performance.now() * 1_000_000))
   }
   const origin = (BigInt(Date.now()) * bigint1e6) - BigInt(Math.round(performance.now() * 1_000_000))


### PR DESCRIPTION
Closes #2416.

## What's the problem

On Cloudflare Workers `wrangler dev` / Miniflare with the `nodejs_compat` flag, `performance.timeOrigin === 0` is true while `performance.now()` is not anchored to wall clock; it returns milliseconds since module load. The default `performanceNowNanos` helper at `packages/effect/src/internal/effect.ts` treated `timeOrigin === 0` as the browser-isolation convention that `performance.now()` already returns wall-clock ms, and read it directly. The result was that `Clock.currentTimeNanos`, and every span timestamped from it via `Effect.withSpan`, carried start/end times near the Unix epoch and were invisible to time-windowed trace backends like Honeycomb, Datadog, or Application Insights.

The reporter's `Clock.currentTimeMillis` returns the correct wall-clock time because it delegates to `Date.now()`. Only the nanos clock and the spans built on top of it are affected. The bug surfaces on `wrangler dev`; deployed workers go through a different runtime that does not match the `timeOrigin === 0` shortcut and so produced correct timestamps already.

## How the PR fixes it

`performanceNowNanos` now sanity-checks `performance.now()` before trusting the optimized path. If the value at module load is larger than one day's worth of ms (`> 86_400_000`), it really is wall-clock-anchored and the helper keeps reading `performance.now()` directly. Otherwise the helper falls through to the existing `Date.now()`-anchored branch, which subtracts the module-load delta once and produces correct wall-clock nanoseconds on every call. `processOrPerformanceNow` then inherits the corrected anchor automatically because it derives its own `origin` from `performanceNowNanos()`.

The branch is intentionally narrow. Browsers that set `timeOrigin === 0` for cross-origin-isolated fingerprinting protection still hit the fast path because `performance.now()` there is wall-clock-anchored and easily clears the 1-day check. Only environments where `performance.now()` is unanchored (Miniflare and similar polyfills) fall through.

## How to verify

```ts
import { Clock, Effect } from "effect"
const handler = async () => {
  const nanos = await Effect.runPromise(Clock.currentTimeNanos)
  const millis = await Effect.runPromise(Clock.currentTimeMillis)
  return new Response(
    `currentTimeNanos: ${new Date(Number(nanos / 1_000_000n)).toISOString()}\n` +
    `currentTimeMillis: ${new Date(millis).toISOString()}\n`,
  )
}
export default { fetch: handler }
```

With `wrangler.jsonc` setting `compatibility_flags: ["nodejs_compat"]` and `wrangler dev` running, before this PR the response prints `currentTimeNanos: 1970-01-01T00:00:NN.NNNZ` while `currentTimeMillis` prints the wall clock. With this PR both timestamps agree on the current wall clock, and any spans built on top of `Effect.withSpan` carry usable start/end times that show up in Honeycomb / Datadog / Application Insights.

## Tests

I deliberately did not add a unit test for this. `performanceNowNanos` is a module-load-time closure that captures globals once; faithfully reproducing the Miniflare condition would require either `vi.resetModules` plus a dynamic `import()` round trip or promoting `performanceNowNanos` to an internal export so a test can call it under stubbed globals. Happy to take whichever route reviewers prefer before merge.

Validation run locally: `pnpm check:tsgo`, `pnpm lint-fix`, and the existing `pnpm test test/TestClock.test.ts` suite all pass on this branch.
