### PR TITLE
Fix Postgres runner storage lock expiration

### DIFF
--- a/.changeset/fix-sql-runner-storage-pg-interval.md
+++ b/.changeset/fix-sql-runner-storage-pg-interval.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix the SQL runner storage Postgres shard lock expiration expression.

--- a/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlRunnerStorage.ts
@@ -204,7 +204,7 @@ export const make = Effect.fnUntraced(function*(options: {
     )).toString()
   )
   const lockExpiresAt = sql.onDialectOrElse({
-    pg: () => sql`${sqlNow} - INTERVAL '${expiresSeconds} seconds'`,
+    pg: () => sql`${sqlNow} - (${expiresSeconds} * INTERVAL '1 second')`,
     mysql: () => sql`DATE_SUB(${sqlNow}, INTERVAL ${expiresSeconds} SECOND)`,
     mssql: () => sql`DATEADD(SECOND, -${expiresSeconds}, ${sqlNow})`,
     orElse: () => sql`datetime(${sqlNow}, '-${expiresSeconds} seconds')`

--- a/packages/platform-node/test/cluster/SqlRunnerStorage.test.ts
+++ b/packages/platform-node/test/cluster/SqlRunnerStorage.test.ts
@@ -1,7 +1,7 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { SqliteClient } from "@effect/sql-sqlite-node"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, FileSystem, Layer } from "effect"
+import { Duration, Effect, FileSystem, Layer } from "effect"
 import {
   Runner,
   RunnerAddress,
@@ -88,9 +88,39 @@ describe("SqlRunnerStorage", () => {
         }))
     })
   })
+
+  it.layer(PgExpiringLocksLive, {
+    timeout: 60000
+  })("pg shard lock expiration", (it) => {
+    it.effect("allows another runner to acquire an expired shard lock", () =>
+      Effect.gen(function*() {
+        const storage = yield* RunnerStorage.RunnerStorage
+        const shard = ShardId.make("default", 1)
+
+        let acquired = yield* storage.acquire(runnerAddress1, [shard])
+        expect(acquired.map((_) => _.id)).toEqual([1])
+
+        acquired = yield* storage.acquire(runnerAddress2, [shard])
+        expect(acquired).toEqual([])
+
+        yield* Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, 1000)))
+
+        acquired = yield* storage.acquire(runnerAddress2, [shard])
+        expect(acquired.map((_) => _.id)).toEqual([1])
+      }), 60_000)
+  })
 })
 
 const runnerAddress1 = RunnerAddress.make("localhost", 1234)
+const runnerAddress2 = RunnerAddress.make("localhost", 5678)
+
+const PgExpiringLocksLive = SqlRunnerStorage.layerWith({ prefix: "cluster_expiring_locks" }).pipe(
+  Layer.provideMerge(Layer.orDie(PgContainer.layerClient)),
+  Layer.provide(ShardingConfig.layer({
+    shardLockDisableAdvisory: true,
+    shardLockExpiration: Duration.millis(100)
+  }))
+)
 
 const SqliteLayer = Effect.gen(function*() {
   const fs = yield* FileSystem.FileSystem


### PR DESCRIPTION
Fixes the Postgres shard lock expiration SQL and covers the expiration behavior in the platform-node Postgres suite.

*I used Codex to diagnose and raise this PR*