### PR TITLE
[Redis][Queue]:change default operation in redis from LPUSH TO RPUSH

### DIFF
--- a/.changeset/every-olives-burn.md
+++ b/.changeset/every-olives-burn.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+change default operation in redis from LPUSH TO RPUSH

--- a/.changeset/every-olives-burn.md
+++ b/.changeset/every-olives-burn.md
@@ -1,5 +1,5 @@
 ---
-"effect": minor
+"effect": patch
 ---
 
 change default operation in redis from LPUSH TO RPUSH

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -508,7 +508,7 @@ export const makeStoreRedis = Effect.fnUntraced(function*(
             id,
             JSON.stringify({ id, element, attempts: 0 })
           )
-          : redis.send("LPUSH", `${prefix}${name}`, JSON.stringify({ id, element, attempts: 0 })),
+          : redis.send("RPUSH", `${prefix}${name}`, JSON.stringify({ id, element, attempts: 0 })),
         ({ cause }) =>
           new PersistedQueueError({
             message: "Failed to offer element to persisted queue",


### PR DESCRIPTION
## Type
- ✅  Bug Fix


## Description
As reported in the below issue, the default behavior in case of not passing a custom ID to persistedQueue using redis as storage layer is LIFO basis which is against the default behavior, this PR make the default operation FIFO, we can add a flag to select wether a queue should add on LIFO or FIFO as an option.

## Related

- Related Issue : https://github.com/Effect-TS/effect-smol/issues/2427