### PR TITLE
fix(rpc): error on truncated HTTP streaming response

### DIFF
--- a/.changeset/rpc-http-fail-truncated-stream.md
+++ b/.changeset/rpc-http-fail-truncated-stream.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+`RpcClient` HTTP protocol now fails a request whose response stream closes before a terminal frame (`Exit` / `Defect` / `ClientProtocolError`) is received, instead of completing silently, closes #2440.
+
+Previously, if a proxy or load balancer idle-timeout closed a streaming ndjson response mid-body (after the `200` was already committed, so no `504` could be sent), `runForEachArray` over the response body ended normally, `send` succeeded, and the per-request queue was never closed — the consumer hung forever with no error. The truncated stream is now surfaced as an `RpcClientError` defect.

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -923,6 +923,14 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
       }
 
       let hasResponse = false
+      // The request is only complete once a terminal frame arrives in-band
+      // (Exit / Defect / ClientProtocolError). The HTTP connection ending is
+      // NOT a terminal signal: a proxy idle-timeout can close the stream mid
+      // body after a 200 was already committed (it cannot send a 504 then).
+      // Without this guard such a truncated stream ends the runForEachArray
+      // normally, `send` succeeds, and the per-request queue is never closed —
+      // the consumer hangs forever instead of seeing an error.
+      let sawTerminal = false
       yield* Stream.runForEachArray(response.stream, (chunk) =>
         Effect.try({
           try: () => chunk.flatMap(parser.decode) as Array<FromServerEncoded>,
@@ -934,7 +942,17 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
             let i = 0
             return Effect.whileLoop({
               while: () => i < responses.length,
-              body: () => writeResponse(clientId, responses[i++]),
+              body: () => {
+                const response = responses[i++]
+                if (
+                  response._tag === "Exit" ||
+                  response._tag === "Defect" ||
+                  response._tag === "ClientProtocolError"
+                ) {
+                  sawTerminal = true
+                }
+                return writeResponse(clientId, response)
+              },
               step: constVoid
             })
           })
@@ -943,6 +961,12 @@ export const makeProtocolHttp = (client: HttpClient.HttpClient): Effect.Effect<
         )
       if (!hasResponse) {
         return yield* emptyResponseError(request)
+      }
+      if (!sawTerminal) {
+        return yield* protocolDefect(
+          "RPC response stream closed before completion (no terminal frame received)",
+          request
+        )
       }
     })
 


### PR DESCRIPTION
Closes #2440

## Problem

When a load balancer / reverse proxy idle-timeout closes a long-lived streaming ndjson RPC response **mid-body** — after the `200` and `content-type` headers are already committed, so the proxy cannot send a `504` — the client `makeProtocolHttp` drains the response body to EOF, `send` resolves successfully, and the per-request queue is never closed. The consumer (`Stream.fromQueue`) then parks on `Queue.take` forever: the stream hangs indefinitely with no error.

The HTTP protocol's only completion signal is an **in-band terminal frame** (`Exit` / `Defect` / `ClientProtocolError`); the TCP/HTTP connection ending is not treated as terminal. The existing `!hasResponse` guard only catches a *fully empty* response, not a response that delivered some chunks and was then truncated.

## Fix

Track whether a terminal frame arrived while draining the response stream. If the stream ends without one (and the response was non-empty), fail with an `RpcClientError` defect so the dropped connection surfaces as an error instead of an infinite hang.

This keys off the transport (EOF without a terminal frame), not application-level activity, so a slow-but-alive stream (socket open, no chunks for a while) does **not** false-trigger.

Reproduced against a real deployment (cluster node taken offline behind an idle-timeout ingress): before, the client stream hung on the last received event; after, it surfaces the error.