### PR TITLE
fix(ai-anthropic): emit null (not undefined) for caller toolId in non-streaming responses

### DIFF
--- a/.changeset/fix-anthropic-caller-toolid.md
+++ b/.changeset/fix-anthropic-caller-toolid.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Fix non-streaming Anthropic responses throwing when a tool call carries `caller` metadata. The mapper emitted `caller.toolId: undefined`, but `ProviderMetadata` is `Record(String, NullOr(Json))` and `undefined` is not a valid Json value, so decoding the model's own response threw `Expected JSON value`. Emit `null` instead, matching the streaming mappers.

--- a/packages/ai/anthropic/src/AnthropicLanguageModel.ts
+++ b/packages/ai/anthropic/src/AnthropicLanguageModel.ts
@@ -1620,7 +1620,7 @@ const makeResponse = Effect.fnUntraced(
             const callerInfo = Predicate.isNotNullish(caller)
               ? {
                 type: caller.type,
-                toolId: "tool_id" in caller ? caller.tool_id : undefined
+                toolId: "tool_id" in caller ? caller.tool_id : null
               }
               : undefined
 


### PR DESCRIPTION
## What

TLDR; Tried to use LanguageModel.generateObject with Sonnet, which does not support structured output. When I instruct the model to reason first, the model will generate prosa + json, but effect will collect all response and try to JSON parse (and fails). What we do is to force the structured output through a forced single-tool call, where the tool params are the output schema, then read the structured output from the args of that tool call. But still needs the following patch.

The non-streaming Anthropic response mapper builds a tool-call part whose
`metadata.anthropic.caller.toolId` is the literal `undefined` for a "direct"
caller (one with no `tool_id`). But the response schema's `ProviderMetadata`
is `Record(String, NullOr(Json))` — and `undefined` is not a valid `Json`
value — so decoding the model's *own* response throws.

## Reproduction

**Schema level (deterministic, no network)** — decodes the exact metadata
shape the provider emits:

```ts
import { Schema } from "effect"
import { Response } from "effect/unstable/ai"

const decode = Schema.decodeUnknownSync(Response.ProviderMetadata)

// What the non-streaming path produced for a "direct" caller (no tool_id):
decode({ anthropic: { caller: { type: "direct", toolId: undefined } } })
// ✗ throws: Expected JSON value, got {"caller":{"type":"direct","toolId":undefined}}

// What the streaming paths already produce — and what this fix emits:
decode({ anthropic: { caller: { type: "direct", toolId: null } } })
// ✓ ok
```

**Real-world trigger** — a `LanguageModel.generateText` call that forces a
single tool and gets back a `tool_use` from a "direct" caller:

```ts
yield* LanguageModel.generateText({
  prompt,
  toolkit,                          // a Toolkit with one tool, e.g. "extract"
  toolChoice: { tool: "extract" },
  disableToolCallResolution: true
})
// ✗ AiError: LanguageModel.generateText: Invalid output: Expected JSON value,
//   got {"caller":{"type":"direct","toolId":undefined}}  at [1]["metadata"]["anthropic"]
```

Reproduces against `claude-sonnet-4-6` (and an Azure AI Foundry Anthropic
endpoint). Not specific to `disableToolCallResolution`: `generateText` decodes
`rawContent` unconditionally in both branches, so providing a tool handler does
not avoid it.

## Root cause & fix

- Non-streaming mapper: `AnthropicLanguageModel.ts:1623` used `… : undefined`.
- Streaming mappers (lines 2041, 2209) already use `… : null`.

Fix = make non-streaming match streaming (`undefined` → `null`); `null` is a
valid `Json` value, so the decode succeeds. One-line change.
