### PR TITLE
EFF-863 Add SQL valuesUnprepared

### DIFF
--- a/.changeset/add-values-unprepared.md
+++ b/.changeset/add-values-unprepared.md
@@ -1,0 +1,17 @@
+---
+"effect": patch
+"@effect/sql-clickhouse": patch
+"@effect/sql-d1": patch
+"@effect/sql-libsql": patch
+"@effect/sql-mssql": patch
+"@effect/sql-mysql2": patch
+"@effect/sql-pg": patch
+"@effect/sql-pglite": patch
+"@effect/sql-sqlite-bun": patch
+"@effect/sql-sqlite-do": patch
+"@effect/sql-sqlite-node": patch
+"@effect/sql-sqlite-react-native": patch
+"@effect/sql-sqlite-wasm": patch
+---
+
+Add `Statement.valuesUnprepared` for returning unprepared SQL statement rows as arrays.

--- a/packages/effect/src/unstable/sql/SqlConnection.ts
+++ b/packages/effect/src/unstable/sql/SqlConnection.ts
@@ -50,6 +50,11 @@ export interface Connection {
     params: ReadonlyArray<unknown>
   ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
 
+  readonly executeValuesUnprepared: (
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ) => Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+
   readonly executeUnprepared: (
     sql: string,
     params: ReadonlyArray<unknown>,

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -72,6 +72,7 @@ export interface Statement<A> extends Fragment, Effect.Effect<ReadonlyArray<A>, 
   readonly withoutTransform: Effect.Effect<ReadonlyArray<A>, SqlError>
   readonly stream: Stream.Stream<A, SqlError>
   readonly values: Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+  readonly valuesUnprepared: Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
   readonly unprepared: Effect.Effect<ReadonlyArray<A>, SqlError>
   readonly compile: (withoutTransform?: boolean | undefined) => readonly [
     sql: string,
@@ -1352,6 +1353,16 @@ const StatementProto: Omit<
     SqlError
   > {
     return this.withConnection("executeValues", (connection, sql, params) => connection.executeValues(sql, params))
+  },
+
+  get valuesUnprepared(): Effect.Effect<
+    ReadonlyArray<ReadonlyArray<unknown>>,
+    SqlError
+  > {
+    return this.withConnection(
+      "executeValuesUnprepared",
+      (connection, sql, params) => connection.executeValuesUnprepared(sql, params)
+    )
   },
 
   get unprepared(): Effect.Effect<ReadonlyArray<any>, SqlError> {

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -290,6 +290,9 @@ export const make = (
       executeValues(sql: string, params: ReadonlyArray<unknown>) {
         return this.run(sql, params, "JSONCompact")
       }
+      executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+        return this.executeValues(sql, params)
+      }
       executeUnprepared(sql: string, params: ReadonlyArray<unknown>, transformRows?: any) {
         return this.execute(sql, params, transformRows)
       }

--- a/packages/sql/d1/src/D1Client.ts
+++ b/packages/sql/d1/src/D1Client.ts
@@ -167,6 +167,21 @@ export const make = (
             })
         )
 
+      const runValuesUncached = (
+        sql: string,
+        params: ReadonlyArray<unknown>
+      ) =>
+        Effect.tryPromise({
+          try: () => {
+            return db.prepare(sql).bind(...params).raw() as Promise<
+              ReadonlyArray<
+                ReadonlyArray<unknown>
+              >
+            >
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
+
       return identity<Connection>({
         execute(sql, params, transformRows) {
           return transformRows
@@ -178,6 +193,9 @@ export const make = (
         },
         executeValues(sql, params) {
           return runValues(sql, params)
+        },
+        executeValuesUnprepared(sql, params) {
+          return runValuesUncached(sql, params)
         },
         executeUnprepared(sql, params, transformRows) {
           return transformRows

--- a/packages/sql/libsql/src/LibsqlClient.ts
+++ b/packages/sql/libsql/src/LibsqlClient.ts
@@ -240,6 +240,9 @@ export const make = (
       executeValues(sql: string, params: ReadonlyArray<unknown>) {
         return Effect.map(this.run(sql, params), (rows) => rows.map((row) => Array.from(row) as Array<any>))
       }
+      executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+        return this.executeValues(sql, params)
+      }
       executeUnprepared(
         sql: string,
         params: ReadonlyArray<unknown>,

--- a/packages/sql/mssql/src/MssqlClient.ts
+++ b/packages/sql/mssql/src/MssqlClient.ts
@@ -416,6 +416,9 @@ export const make = (
         executeValues(sql, params) {
           return run(sql, params, true)
         },
+        executeValuesUnprepared(sql, params) {
+          return run(sql, params, true)
+        },
         executeUnprepared(sql, params, transformRows) {
           return this.execute(sql, params, transformRows)
         },

--- a/packages/sql/mysql2/src/MysqlClient.ts
+++ b/packages/sql/mysql2/src/MysqlClient.ts
@@ -275,6 +275,9 @@ export const make = (
       executeValues(sql: string, params: ReadonlyArray<unknown>) {
         return this.run(sql, params, true)
       }
+      executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+        return this.run(sql, params, true, "query")
+      }
       executeUnprepared(
         sql: string,
         params: ReadonlyArray<unknown>,

--- a/packages/sql/pg/src/PgClient.ts
+++ b/packages/sql/pg/src/PgClient.ts
@@ -711,6 +711,9 @@ class ConnectionImpl implements Connection {
       )
     })
   }
+  executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+    return this.executeValues(sql, params)
+  }
   executeUnprepared(
     sql: string,
     params: ReadonlyArray<unknown>,

--- a/packages/sql/pglite/src/PgliteClient.ts
+++ b/packages/sql/pglite/src/PgliteClient.ts
@@ -308,6 +308,16 @@ class PgliteConnection implements Connection {
       (result) => result.rows as ReadonlyArray<ReadonlyArray<any>>
     )
   }
+  executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.map(
+      Effect.tryPromise({
+        try: () => this.pglite.query<any>(sql, params as Array<any>, { rowMode: "array" }),
+        catch: (cause) =>
+          new SqlError({ reason: classifyError(cause, "Failed to execute statement", "executeValuesUnprepared") })
+      }),
+      (result) => result.rows as ReadonlyArray<ReadonlyArray<any>>
+    )
+  }
   executeUnprepared(
     sql: string,
     params: ReadonlyArray<unknown>,

--- a/packages/sql/sqlite-bun/src/SqliteClient.ts
+++ b/packages/sql/sqlite-bun/src/SqliteClient.ts
@@ -170,6 +170,9 @@ export const make = (
         executeValues(sql, params) {
           return runValues(sql, params)
         },
+        executeValuesUnprepared(sql, params) {
+          return runValues(sql, params)
+        },
         executeUnprepared(sql, params, transformRows) {
           return this.execute(sql, params, transformRows)
         },

--- a/packages/sql/sqlite-do/src/SqliteClient.ts
+++ b/packages/sql/sqlite-do/src/SqliteClient.ts
@@ -160,6 +160,9 @@ export const make = (
         executeValues(sql, params) {
           return runValues(sql, params)
         },
+        executeValuesUnprepared(sql, params) {
+          return runValues(sql, params)
+        },
         executeUnprepared(sql, params, transformRows) {
           return transformRows
             ? Effect.map(runStatement(sql, params), transformRows)

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -199,6 +199,25 @@ export const make = (
           (statement) => Effect.sync(() => statement.reader && statement.raw(false))
         )
 
+      const runValuesUnprepared = (
+        sql: string,
+        params: ReadonlyArray<unknown>
+      ) =>
+        Effect.try({
+          try: () => {
+            const statement = db.prepare(sql)
+            if (statement.reader) {
+              statement.raw(true)
+              return statement.all(...params) as ReadonlyArray<
+                ReadonlyArray<unknown>
+              >
+            }
+            statement.run(...params)
+            return []
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
+
       return identity<SqliteConnection>({
         execute(sql, params, transformRows) {
           return transformRows
@@ -210,6 +229,9 @@ export const make = (
         },
         executeValues(sql, params) {
           return runValues(sql, params)
+        },
+        executeValuesUnprepared(sql, params) {
+          return runValuesUnprepared(sql, params)
         },
         executeUnprepared(sql, params, transformRows) {
           const effect = runStatement(db.prepare(sql), params ?? [], false)

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -23,6 +23,8 @@ describe("Client", () => {
       assert.deepStrictEqual(response, [])
       response = yield* sql`SELECT * FROM test`
       assert.deepStrictEqual(response, [{ id: 1, name: "hello" }])
+      response = yield* sql`SELECT * FROM test`.valuesUnprepared
+      assert.deepStrictEqual(response, [[1, "hello"]])
       response = yield* sql`INSERT INTO test (name) VALUES ('world')`.pipe(sql.withTransaction)
       assert.deepStrictEqual(response, [])
       response = yield* sql`SELECT * FROM test`

--- a/packages/sql/sqlite-react-native/src/SqliteClient.ts
+++ b/packages/sql/sqlite-react-native/src/SqliteClient.ts
@@ -178,6 +178,9 @@ export const make = (
         executeValues(sql, params) {
           return run(sql, params, true)
         },
+        executeValuesUnprepared(sql, params) {
+          return run(sql, params, true)
+        },
         executeUnprepared(sql, params, transformRows) {
           return this.execute(sql, params, transformRows)
         },

--- a/packages/sql/sqlite-wasm/src/SqliteClient.ts
+++ b/packages/sql/sqlite-wasm/src/SqliteClient.ts
@@ -208,6 +208,9 @@ export const makeMemory = (
         executeValues(sql, params) {
           return run(sql, params, "array")
         },
+        executeValuesUnprepared(sql, params) {
+          return run(sql, params, "array")
+        },
         executeUnprepared(sql, params, transformRows) {
           return this.execute(sql, params, transformRows)
         },
@@ -392,6 +395,9 @@ export const make = (
           return run(sql, params)
         },
         executeValues(sql, params) {
+          return run(sql, params, "array")
+        },
+        executeValuesUnprepared(sql, params) {
           return run(sql, params, "array")
         },
         executeUnprepared(sql, params, transformRows) {


### PR DESCRIPTION
## Summary
- Added `Statement.valuesUnprepared` to return SQL rows as arrays through unprepared execution.
- Extended the SQL connection contract and all SQL driver implementations with `executeValuesUnprepared`.
- Added sqlite-node coverage for `.valuesUnprepared` and a changeset.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/sql/sqlite-node/test/Client.test.ts`
- `pnpm check:tsgo`
