### PR TITLE
Emit Schema.ConstraintDecoder in generated SSE clients

### DIFF
--- a/.changeset/openapi-generator-sse-constraint-decoder.md
+++ b/.changeset/openapi-generator-sse-constraint-decoder.md
@@ -1,0 +1,7 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Fix the generated SSE `sseRequest` helper to reference `Schema.ConstraintDecoder` instead of the no-longer-exported `Schema.Decoder`.
+
+For specs with `text/event-stream` responses the generator emitted a helper typed as `Schema.Decoder<Type, DecodingServices>`, but `Schema` exports that decode-only interface as `ConstraintDecoder`, so generated clients failed to compile (`'"effect/Schema"' has no exported member named 'Decoder'`). The emitted helper now uses `Schema.ConstraintDecoder`.

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -917,7 +917,7 @@ const sseRequestSource = (_importName: string) =>
      Type,
      DecodingServices
     >(
-      schema: Schema.Decoder<Type, DecodingServices>
+      schema: Schema.ConstraintDecoder<Type, DecodingServices>
     ) =>
     (
       request: HttpClientRequest.HttpClientRequest

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -520,7 +520,8 @@ export const TestClientError = <Tag extends string, E>(
           `import * as Sse from "effect/unstable/encoding/Sse"`,
           `readonly "streamEventsSse": () => Stream.Stream<{ readonly event: string; readonly id: string | undefined; readonly data: typeof StreamEvents200Sse.Type }, HttpClientError.HttpClientError | SchemaError | Sse.Retry, typeof StreamEvents200Sse.DecodingServices>`,
           `"streamEventsSse": () => HttpClientRequest.get(\`/events\`).pipe(`,
-          `sseRequest(StreamEvents200Sse)`
+          `sseRequest(StreamEvents200Sse)`,
+          `schema: Schema.ConstraintDecoder<Type, DecodingServices>`
         ]
       ))
 


### PR DESCRIPTION
## What

For OpenAPI specs with `text/event-stream` responses, `@effect/openapi-generator` emits a shared `sseRequest` helper typed as `Schema.Decoder<Type, DecodingServices>`. `Schema` exports that decode-only interface as `ConstraintDecoder` (there is no `Schema.Decoder` export), so generated clients fail to compile:

```
'"effect/Schema"' has no exported member named 'Decoder'. Did you mean 'decode'?
```

## Change

- `OpenApiTransformer.ts`: the generated `sseRequest` helper now references `Schema.ConstraintDecoder<Type, DecodingServices>`.
- `OpenApiGenerator.test.ts`: the SSE generation test asserted the method signature and the `sseRequest(...)` call site but never the helper *definition* (where the type lived), so the broken type slipped through. Added an assertion on the emitted `schema: Schema.ConstraintDecoder<Type, DecodingServices>` definition.
- Added a changeset (`patch`).

## Verification

`pnpm --filter @effect/openapi-generator test` — all 68 tests pass.