### PR TITLE
Align Schema.Void with typescript behaviour

### DIFF
--- a/.changeset/curvy-birds-float.md
+++ b/.changeset/curvy-birds-float.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Update `Schema.Void` to accept any provided value and decode it to `undefined`.

--- a/.changeset/curvy-birds-float.md
+++ b/.changeset/curvy-birds-float.md
@@ -2,4 +2,9 @@
 "effect": patch
 ---
 
-Update `Schema.Void` to accept any provided value and decode it to `undefined`.
+Update `Schema.Void` to model ignored `void` return values.
+
+Runtime parsing now accepts any present value and discards it as `undefined`.
+This matches TypeScript `void` return values, where callers do not observe the
+returned value. Use `Schema.Undefined` when the input must be exactly
+`undefined`.

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3053,11 +3053,16 @@ export const BigInt: BigInt = make(SchemaAST.bigInt)
  * @category models
  * @since 3.10.0
  */
-export interface Void extends Bottom<void, void | {} | null, never, never, SchemaAST.Void, Void, void | {} | null> {}
+export interface Void extends Bottom<void, void, never, never, SchemaAST.Void, Void> {}
 
 /**
- * Schema for the `void` type. Accepts any provided value and maps it to
- * `undefined`.
+ * Schema for the TypeScript `void` type.
+ *
+ * **Details**
+ *
+ * Accepts any input during construction, decoding, and encoding, and maps the
+ * value to `undefined`. This mirrors TypeScript's `void` type, where a
+ * value may be provided but is not observed by consumers.
  *
  * @category schemas
  * @since 3.10.0

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3056,14 +3056,21 @@ export const BigInt: BigInt = make(SchemaAST.bigInt)
 export interface Void extends Bottom<void, void, never, never, SchemaAST.Void, Void> {}
 
 /**
- * Schema for the TypeScript `void` type.
+ * Schema for a TypeScript `void` return value.
+ *
+ * **When to use**
+ *
+ * Use when you need to model the return value of a function, RPC, or endpoint
+ * whose result is intentionally ignored.
  *
  * **Details**
  *
- * Accepts any input during construction, decoding, and encoding, and maps the
- * value to `undefined`. This mirrors TypeScript's `void` type, where a
- * value may be provided but is not observed by consumers.
+ * Runtime parsing accepts any present value and discards it, producing
+ * `undefined`. The public decoded and encoded TypeScript representation remains
+ * `void`, so typed construction, decoding, and encoding APIs are still modeled
+ * as `void`.
  *
+ * @see {@link Undefined} for a schema that matches only the exact `undefined` value.
  * @category schemas
  * @since 3.10.0
  */

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -3053,10 +3053,11 @@ export const BigInt: BigInt = make(SchemaAST.bigInt)
  * @category models
  * @since 3.10.0
  */
-export interface Void extends Bottom<void, void, never, never, SchemaAST.Void, Void> {}
+export interface Void extends Bottom<void, void | {} | null, never, never, SchemaAST.Void, Void, void | {} | null> {}
 
 /**
- * Schema for the `void` type. Accepts `undefined` as the encoded value.
+ * Schema for the `void` type. Accepts any provided value and maps it to
+ * `undefined`.
  *
  * @category schemas
  * @since 3.10.0

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -793,14 +793,20 @@ export {
 }
 
 /**
- * AST node matching the TypeScript `void` type.
+ * AST node matching TypeScript `void` return-value semantics.
+ *
+ * **When to use**
+ *
+ * Use when you need an AST node for a value whose result is intentionally
+ * ignored.
  *
  * **Details**
  *
- * Accepts any input while parsing and maps it to `undefined`. This mirrors
- * TypeScript's `void` type, where a value may be provided but is not observed
- * by consumers.
+ * Parsers built from this node accept any present runtime input and map it to
+ * `undefined`. Public schemas built from it may still expose `void` as their
+ * typed decoded and encoded representation.
  *
+ * @see {@link undefined} for the AST singleton that matches only exact `undefined`
  * @see {@link void_ void}
  * @see {@link isVoid}
  * @category models
@@ -829,8 +835,13 @@ export {
    *
    * **When to use**
    *
-   * Use when constructing or comparing AST nodes that represent the TypeScript
-   * `void` type and accept any input while mapping it to `undefined`.
+   * Use when constructing or comparing AST nodes for TypeScript `void` return
+   * values whose result is intentionally ignored.
+   *
+   * **Details**
+   *
+   * The node parses any present runtime value as `undefined`; schemas may still
+   * expose `void` on their typed decoded and encoded sides.
    *
    * @see {@link Void} for the AST node class
    * @see {@link undefined} for the sibling AST singleton that matches exactly `undefined`

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -2427,7 +2427,6 @@ function getCandidateTypes(ast: AST): ReadonlyArray<Type> {
     case "Null":
       return ["null"]
     case "Undefined":
-    case "Void":
       return ["undefined"]
     case "String":
     case "TemplateLiteral":

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -793,13 +793,13 @@ export {
 }
 
 /**
- * AST node matching the `void` type (accepts any provided value at runtime
- * and discards it as `undefined`).
+ * AST node matching the TypeScript `void` type.
  *
  * **Details**
  *
- * Behaves like TypeScript's `void` by accepting any provided value while
- * representing the value as `undefined` semantically.
+ * Accepts any input while parsing and maps it to `undefined`. This mirrors
+ * TypeScript's `void` type, where a value may be provided but is not observed
+ * by consumers.
  *
  * @see {@link void_ void}
  * @see {@link isVoid}
@@ -830,7 +830,7 @@ export {
    * **When to use**
    *
    * Use when constructing or comparing AST nodes that represent the TypeScript
-   * `void` type and accept `undefined` at runtime.
+   * `void` type and accept any input while mapping it to `undefined`.
    *
    * @see {@link Void} for the AST node class
    * @see {@link undefined} for the sibling AST singleton that matches exactly `undefined`

--- a/packages/effect/src/SchemaAST.ts
+++ b/packages/effect/src/SchemaAST.ts
@@ -793,12 +793,13 @@ export {
 }
 
 /**
- * AST node matching the `void` type (accepts `undefined` at runtime).
+ * AST node matching the `void` type (accepts any provided value at runtime
+ * and discards it as `undefined`).
  *
  * **Details**
  *
- * Behaves like {@link Undefined} for parsing but represents the TypeScript
- * `void` type semantically.
+ * Behaves like TypeScript's `void` by accepting any provided value while
+ * representing the value as `undefined` semantically.
  *
  * @see {@link void_ void}
  * @see {@link isVoid}
@@ -809,7 +810,7 @@ export class Void extends Base {
   readonly _tag = "Void"
   /** @internal */
   getParser() {
-    return fromConst(this, undefined)
+    return fromAnyToConst(undefined)
   }
   /** @internal */
   toCodecJson(): AST {
@@ -3491,6 +3492,11 @@ function fromConst<const T>(
       ? succeed
       : Effect.fail(new SchemaIssue.InvalidType(ast, oinput))
   }
+}
+
+function fromAnyToConst<const T>(value: T): SchemaParser.Parser {
+  const succeed = Effect.succeedSome(value)
+  return (oinput) => oinput._tag === "None" ? Effect.succeedNone : succeed
 }
 
 function fromRefinement<T>(

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -434,9 +434,12 @@ Missing key
     const schema = Schema.Void
     const asserts = new TestSchema.Asserts(schema)
 
+    // The public make input stays typed as void; these callbacks exercise runtime parser behavior.
     let fn: () => void
 
     const make = asserts.make()
+    await make.succeed()
+    await make.succeed(undefined)
     fn = () => undefined
     await make.succeed(fn())
     fn = () => null

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -436,15 +436,18 @@ Missing key
 
     const make = asserts.make()
     await make.succeed(undefined)
-    await make.fail(null, `Expected void, got null`)
+    await make.succeed(null, undefined)
+    await make.succeed("a", undefined)
 
     const decoding = asserts.decoding()
     await decoding.succeed(undefined)
-    await decoding.fail(null, `Expected void, got null`)
+    await decoding.succeed(null, undefined)
+    await decoding.succeed("a", undefined)
 
     const encoding = asserts.encoding()
     await encoding.succeed(undefined)
-    await encoding.fail("1", `Expected void, got "1"`)
+    await encoding.succeed(null, undefined)
+    await encoding.succeed("1", undefined)
   })
 
   it("ObjectKeyword", async () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -4020,6 +4020,27 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
       await decoding.fail(null, `Expected string, got null`)
     })
 
+    it(`Void`, async () => {
+      const schema = Schema.Union([Schema.Void])
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding()
+      await decoding.succeed(undefined)
+      await decoding.succeed(null, undefined)
+      await decoding.succeed("a", undefined)
+      await decoding.succeed(1, undefined)
+      await decoding.succeed({}, undefined)
+      await decoding.succeed([], undefined)
+    })
+
+    it(`Void | String`, async () => {
+      const schema = Schema.Union([Schema.Void, Schema.String])
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding()
+      await decoding.succeed("a", undefined)
+    })
+
     it(`String | Number`, async () => {
       const schema = Schema.Union([Schema.String, Schema.Number])
       const asserts = new TestSchema.Asserts(schema)
@@ -4078,6 +4099,14 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
         { a: "a", b: 1 },
         `Expected exactly one member to match the input {"a":"a","b":1}`
       )
+    })
+
+    it(`mode: "oneOf" with Void`, async () => {
+      const schema = Schema.Union([Schema.Void, Schema.String], { mode: "oneOf" })
+      const asserts = new TestSchema.Asserts(schema)
+
+      const decoding = asserts.decoding()
+      await decoding.fail("a", `Expected exactly one member to match the input "a"`)
     })
 
     it("{} & Literal", async () => {

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -434,10 +434,15 @@ Missing key
     const schema = Schema.Void
     const asserts = new TestSchema.Asserts(schema)
 
+    let fn: () => void
+
     const make = asserts.make()
-    await make.succeed(undefined)
-    await make.succeed(null, undefined)
-    await make.succeed("a", undefined)
+    fn = () => undefined
+    await make.succeed(fn())
+    fn = () => null
+    await make.succeed(fn(), undefined)
+    fn = () => "a"
+    await make.succeed(fn(), undefined)
 
     const decoding = asserts.decoding()
     await decoding.succeed(undefined)

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -86,11 +86,6 @@ describe("Schema", () => {
       expect(schema.makeEffect).type.toBe<MakeEffect<string, string>>()
     })
 
-    it("Void", () => {
-      const schema = Schema.Void
-      expect(schema.makeEffect).type.toBe<MakeEffect<void | {} | null, void>>()
-    })
-
     it("refine", () => {
       const schema = Schema.Option(Schema.String).pipe(Schema.refine(Option.isSome))
       expect(schema.makeEffect).type.toBe<MakeEffect<Option.Option<string>, Option.Some<string>>>()
@@ -136,12 +131,6 @@ describe("Schema", () => {
     it("Undefined", () => {
       const schema = Schema.Undefined
       expect(schema.make).type.toBe<Make<undefined, undefined>>()
-    })
-
-    it("Void", () => {
-      const schema = Schema.Void
-      expect(schema.make).type.toBe<Make<void | {} | null, void>>()
-      expect(Schema.revealCodec(schema)).type.toBe<Schema.Codec<void, void | {} | null, never, never>>()
     })
 
     it("String", () => {

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -86,6 +86,11 @@ describe("Schema", () => {
       expect(schema.makeEffect).type.toBe<MakeEffect<string, string>>()
     })
 
+    it("Void", () => {
+      const schema = Schema.Void
+      expect(schema.makeEffect).type.toBe<MakeEffect<void | {} | null, void>>()
+    })
+
     it("refine", () => {
       const schema = Schema.Option(Schema.String).pipe(Schema.refine(Option.isSome))
       expect(schema.makeEffect).type.toBe<MakeEffect<Option.Option<string>, Option.Some<string>>>()
@@ -131,6 +136,12 @@ describe("Schema", () => {
     it("Undefined", () => {
       const schema = Schema.Undefined
       expect(schema.make).type.toBe<Make<undefined, undefined>>()
+    })
+
+    it("Void", () => {
+      const schema = Schema.Void
+      expect(schema.make).type.toBe<Make<void | {} | null, void>>()
+      expect(Schema.revealCodec(schema)).type.toBe<Schema.Codec<void, void | {} | null, never, never>>()
     })
 
     it("String", () => {


### PR DESCRIPTION
```ts
// this is valid
let fn: () => void
fn = () => null
fn = () => "a"
```