### PR TITLE
Add opt-in Undici request body release

### DIFF
--- a/.changeset/fix-node-http-response-body-retention.md
+++ b/.changeset/fix-node-http-response-body-retention.md
@@ -1,5 +1,5 @@
 ---
-"@effect/platform-node": patch
+"@effect/platform-node": minor
 ---
 
-Avoid retaining large uploaded byte-array request bodies for the lifetime of Undici HTTP client responses. Successful responses preserve request metadata but expose an empty request body.
+Add `NodeHttpClient.RetainResponseRequestBody`, which can be disabled to avoid retaining large uploaded byte-array bodies for the lifetime of Undici responses. The existing response API remains unchanged by default; when disabled, successful responses preserve request metadata but expose an empty request body.

--- a/.changeset/fix-node-http-response-body-retention.md
+++ b/.changeset/fix-node-http-response-body-retention.md
@@ -1,0 +1,5 @@
+---
+"@effect/platform-node": patch
+---
+
+Avoid retaining large uploaded byte-array request bodies for the lifetime of Undici HTTP client responses. Successful responses preserve request metadata but expose an empty request body.

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -21,10 +21,10 @@ import type * as Scope from "effect/Scope"
 import * as Stream from "effect/Stream"
 import * as Cookies from "effect/unstable/http/Cookies"
 import * as Headers from "effect/unstable/http/Headers"
-import type * as Body from "effect/unstable/http/HttpBody"
+import * as Body from "effect/unstable/http/HttpBody"
 import * as Client from "effect/unstable/http/HttpClient"
 import * as Error from "effect/unstable/http/HttpClientError"
-import type { HttpClientRequest } from "effect/unstable/http/HttpClientRequest"
+import { type HttpClientRequest, makeWith } from "effect/unstable/http/HttpClientRequest"
 import * as Response from "effect/unstable/http/HttpClientResponse"
 import type { HttpClientResponse } from "effect/unstable/http/HttpClientResponse"
 import * as IncomingMessage from "effect/unstable/http/HttpIncomingMessage"
@@ -167,10 +167,14 @@ export const makeUndici = Effect.gen(function*() {
             })
         })
       ),
-      Effect.map((response) => new UndiciResponse(request, response))
+      Effect.map((response) => new UndiciResponse(withoutBody(request), response))
     )
   )
 })
+
+// Readable uploads can release consumed bytes, but add measurable overhead for
+// small requests. Bound direct-body retention while preserving the small path.
+const oneShotBodyThreshold = 64 * 1024
 
 function convertBody(
   body: Body.HttpBody
@@ -179,7 +183,11 @@ function convertBody(
     case "Empty": {
       return Effect.succeed(null)
     }
-    case "Uint8Array":
+    case "Uint8Array": {
+      return Effect.succeed(
+        body.body.byteLength < oneShotBodyThreshold ? body.body : oneShotBody(body.body)
+      )
+    }
     case "Raw": {
       return Effect.succeed(body.body as Uint8Array)
     }
@@ -192,7 +200,32 @@ function convertBody(
   }
 }
 
+const oneShotBody = (input: Uint8Array): Readable => {
+  let body: Uint8Array | undefined = input
+  return new Readable({
+    read() {
+      const value = body
+      // Undici retains the Readable while the response is active, so release
+      // the emitted byte array as soon as the upload pulls it.
+      body = undefined
+      this.push(value ?? null)
+    }
+  })
+}
+
 function noopErrorHandler(_: any) {}
+
+// Successful responses only need request metadata for diagnostics. Keeping the
+// immutable body here would retain uploaded payloads for the response lifetime.
+const withoutBody = (request: HttpClientRequest): HttpClientRequest =>
+  makeWith(
+    request.method,
+    request.url,
+    request.urlParams,
+    request.hash,
+    request.headers,
+    Body.empty
+  )
 
 class UndiciResponse extends Inspectable.Class implements HttpClientResponse, Pipeable {
   readonly [IncomingMessage.TypeId]: typeof IncomingMessage.TypeId

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -11,7 +11,7 @@
  */
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
-import { flow } from "effect/Function"
+import { constTrue, flow } from "effect/Function"
 import * as Inspectable from "effect/Inspectable"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
@@ -150,7 +150,7 @@ export const UndiciOptions = Context.Reference<Partial<Undici.Dispatcher.Request
  */
 export const RetainResponseRequestBody = Context.Reference<boolean>(
   "@effect/platform-node/NodeHttpClient/RetainResponseRequestBody",
-  { defaultValue: () => true }
+  { defaultValue: constTrue }
 )
 
 /**

--- a/packages/platform-node/src/NodeHttpClient.ts
+++ b/packages/platform-node/src/NodeHttpClient.ts
@@ -132,6 +132,28 @@ export const UndiciOptions = Context.Reference<Partial<Undici.Dispatcher.Request
 )
 
 /**
+ * Controls whether successful Undici responses retain the original request body.
+ *
+ * **When to use**
+ *
+ * Use with long-lived responses when uploaded request bodies are no
+ * longer needed after response headers arrive.
+ *
+ * **Details**
+ *
+ * The default is `true`. When disabled, successful responses expose an empty
+ * request body while preserving request metadata. Large byte-array uploads use
+ * a one-shot `Readable` so Undici can release consumed bytes.
+ *
+ * @category Undici
+ * @since 4.0.0
+ */
+export const RetainResponseRequestBody = Context.Reference<boolean>(
+  "@effect/platform-node/NodeHttpClient/RetainResponseRequestBody",
+  { defaultValue: () => true }
+)
+
+/**
  * Creates an `HttpClient` that sends requests through the current Undici
  * `Dispatcher`, converts Effect HTTP bodies to Undici bodies, and maps
  * transport and decode failures to `HttpClientError`.
@@ -141,8 +163,9 @@ export const UndiciOptions = Context.Reference<Partial<Undici.Dispatcher.Request
  */
 export const makeUndici = Effect.gen(function*() {
   const dispatcher = yield* Dispatcher
-  return Client.make((request, url, signal, fiber) =>
-    convertBody(request.body).pipe(
+  return Client.make((request, url, signal, fiber) => {
+    const retainRequestBody = fiber.getRef(RetainResponseRequestBody)
+    return convertBody(request.body, retainRequestBody).pipe(
       Effect.flatMap((body) =>
         Effect.tryPromise({
           try: () =>
@@ -167,17 +190,18 @@ export const makeUndici = Effect.gen(function*() {
             })
         })
       ),
-      Effect.map((response) => new UndiciResponse(withoutBody(request), response))
+      Effect.map((response) => new UndiciResponse(retainRequestBody ? request : withoutBody(request), response))
     )
-  )
+  })
 })
 
-// Readable uploads can release consumed bytes, but add measurable overhead for
-// small requests. Bound direct-body retention while preserving the small path.
+// The Readable wrapper makes consumed bytes releasable but is slower for small
+// uploads. Keep the direct path where retained memory is strictly bounded.
 const oneShotBodyThreshold = 64 * 1024
 
 function convertBody(
-  body: Body.HttpBody
+  body: Body.HttpBody,
+  retainRequestBody: boolean
 ): Effect.Effect<Exclude<Undici.Dispatcher.DispatchOptions["body"], undefined>> {
   switch (body._tag) {
     case "Empty": {
@@ -185,7 +209,7 @@ function convertBody(
     }
     case "Uint8Array": {
       return Effect.succeed(
-        body.body.byteLength < oneShotBodyThreshold ? body.body : oneShotBody(body.body)
+        retainRequestBody || body.body.byteLength < oneShotBodyThreshold ? body.body : oneShotBody(body.body)
       )
     }
     case "Raw": {

--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -40,43 +40,44 @@ const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
 const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
 
 const makeServer = Effect.acquireRelease(
-  Effect.tryPromise({
-    try: () =>
-      new Promise<{
-        readonly body: Promise<Buffer>
-        readonly server: Http.Server
-        readonly url: string
-      }>((resolve, reject) => {
-        let resolveBody: (body: Buffer) => void = () => {}
-        const body = new Promise<Buffer>((resolve) => {
-          resolveBody = resolve
-        })
-        const server = Http.createServer((request, response) => {
-          const chunks: Array<Buffer> = []
-          request.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
-          request.once("end", () => {
-            resolveBody(Buffer.concat(chunks))
-            response.end("ok")
-          })
-        })
-        server.once("error", reject)
-        server.listen(0, "127.0.0.1", () => {
-          const address = server.address()
-          if (address === null || typeof address === "string") {
-            reject(new Error("Expected the test server to listen on a TCP port"))
-            return
-          }
-          resolve({ body, server, url: `http://127.0.0.1:${address.port}` })
-        })
-      }),
-    catch: (cause) => cause
+  Effect.callback<{
+    readonly body: () => Buffer | undefined
+    readonly server: Http.Server
+    readonly url: string
+  }, Error>((resume) => {
+    let body: Buffer | undefined
+    const server = Http.createServer((request, response) => {
+      const chunks: Array<Buffer> = []
+      request.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
+      request.once("end", () => {
+        body = Buffer.concat(chunks)
+        response.writeHead(200)
+        response.write("open")
+      })
+    })
+    const onError = (cause: Error) => resume(Effect.fail(cause))
+    server.once("error", onError)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError)
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        server.close()
+        resume(Effect.fail(new Error("Expected the test server to listen on a TCP port")))
+        return
+      }
+      resume(Effect.succeed({ body: () => body, server, url: `http://127.0.0.1:${address.port}` }))
+    })
+    return Effect.sync(() => {
+      server.off("error", onError)
+      server.closeAllConnections()
+      server.close()
+    })
   }),
   ({ server }) =>
-    Effect.promise(() =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve())
-      })
-    )
+    Effect.sync(() => {
+      server.closeAllConnections()
+      server.close()
+    })
 )
 ;[
   {
@@ -188,29 +189,49 @@ const makeServer = Effect.acquireRelease(
       }).pipe(Effect.provide(layer), flaky))
   })
 })
-it.effect("Undici responses do not retain uploaded request bodies", () =>
+it.effect("Undici responses retain uploaded request bodies by default", () =>
   Effect.gen(function*() {
-    const { body, url } = yield* makeServer
+    const { url } = yield* makeServer
     const client = yield* HttpClient.HttpClient
-    const payload = "x".repeat(1024 * 1024)
-    const request = HttpClientRequest.post(`${url}/upload?test=true`).pipe(
-      HttpClientRequest.setHeader("x-test", "retained"),
-      HttpClientRequest.bodyText(payload, "text/plain")
+    const request = HttpClientRequest.post(`${url}/upload`).pipe(
+      HttpClientRequest.bodyText("request body", "text/plain")
     )
     const response = yield* client.execute(request)
-    yield* response.text
 
-    assert.strictEqual(request.body._tag, "Uint8Array")
-    assert.strictEqual(response.request.body._tag, "Empty")
+    assert.strictEqual(response.request.body, request.body)
     assert.strictEqual(response.request.method, request.method)
     assert.strictEqual(response.request.url, request.url)
-    assert.deepStrictEqual(response.request.urlParams, request.urlParams)
-    assert.deepStrictEqual(response.request.hash, request.hash)
-    assert.strictEqual(response.request.headers["x-test"], request.headers["x-test"])
-    assert.strictEqual(response.request.headers["content-type"], request.headers["content-type"])
-    assert.strictEqual(response.request.headers["content-length"], request.headers["content-length"])
-    assert.strictEqual((yield* Effect.promise(() => body)).toString("utf8"), payload)
   }).pipe(Effect.provide(NodeClient.layerUndici), Effect.scoped))
+
+it.effect.each([1024, 1024 * 1024])(
+  "Undici responses can release a %i-byte request body",
+  (bodySize) =>
+    Effect.gen(function*() {
+      const { body, url } = yield* makeServer
+      const client = yield* HttpClient.HttpClient
+      const payload = "x".repeat(bodySize)
+      const request = HttpClientRequest.post(`${url}/upload?test=true`).pipe(
+        HttpClientRequest.setHeader("x-test", "retained"),
+        HttpClientRequest.bodyText(payload, "text/plain")
+      )
+      const response = yield* client.execute(request)
+
+      assert.strictEqual(request.body._tag, "Uint8Array")
+      assert.strictEqual(response.request.body._tag, "Empty")
+      assert.strictEqual(response.request.method, request.method)
+      assert.strictEqual(response.request.url, request.url)
+      assert.deepStrictEqual(response.request.urlParams, request.urlParams)
+      assert.deepStrictEqual(response.request.hash, request.hash)
+      assert.strictEqual(response.request.headers["x-test"], request.headers["x-test"])
+      assert.strictEqual(response.request.headers["content-type"], request.headers["content-type"])
+      assert.strictEqual(response.request.headers["content-length"], request.headers["content-length"])
+      assert.strictEqual(body()?.toString("utf8"), payload)
+    }).pipe(
+      Effect.provideService(NodeClient.RetainResponseRequestBody, false),
+      Effect.provide(NodeClient.layerUndici),
+      Effect.scoped
+    )
+)
 
 const flaky = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(

--- a/packages/platform-node/test/NodeHttpClient.test.ts
+++ b/packages/platform-node/test/NodeHttpClient.test.ts
@@ -1,5 +1,5 @@
 import * as NodeClient from "@effect/platform-node/NodeHttpClient"
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Struct } from "effect"
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
@@ -7,6 +7,7 @@ import * as Layer from "effect/Layer"
 import * as Schema from "effect/Schema"
 import * as Stream from "effect/Stream"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import * as Http from "node:http"
 
 const Todo = Schema.Struct({
   userId: Schema.Number,
@@ -37,6 +38,46 @@ const makeJsonPlaceholder = Effect.gen(function*() {
 interface JsonPlaceholder extends Effect.Success<typeof makeJsonPlaceholder> {}
 const JsonPlaceholder = Context.Service<JsonPlaceholder>("test/JsonPlaceholder")
 const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
+
+const makeServer = Effect.acquireRelease(
+  Effect.tryPromise({
+    try: () =>
+      new Promise<{
+        readonly body: Promise<Buffer>
+        readonly server: Http.Server
+        readonly url: string
+      }>((resolve, reject) => {
+        let resolveBody: (body: Buffer) => void = () => {}
+        const body = new Promise<Buffer>((resolve) => {
+          resolveBody = resolve
+        })
+        const server = Http.createServer((request, response) => {
+          const chunks: Array<Buffer> = []
+          request.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
+          request.once("end", () => {
+            resolveBody(Buffer.concat(chunks))
+            response.end("ok")
+          })
+        })
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => {
+          const address = server.address()
+          if (address === null || typeof address === "string") {
+            reject(new Error("Expected the test server to listen on a TCP port"))
+            return
+          }
+          resolve({ body, server, url: `http://127.0.0.1:${address.port}` })
+        })
+      }),
+    catch: (cause) => cause
+  }),
+  ({ server }) =>
+    Effect.promise(() =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+    )
+)
 ;[
   {
     name: "fetch",
@@ -147,6 +188,29 @@ const JsonPlaceholderLive = Layer.effect(JsonPlaceholder)(makeJsonPlaceholder)
       }).pipe(Effect.provide(layer), flaky))
   })
 })
+it.effect("Undici responses do not retain uploaded request bodies", () =>
+  Effect.gen(function*() {
+    const { body, url } = yield* makeServer
+    const client = yield* HttpClient.HttpClient
+    const payload = "x".repeat(1024 * 1024)
+    const request = HttpClientRequest.post(`${url}/upload?test=true`).pipe(
+      HttpClientRequest.setHeader("x-test", "retained"),
+      HttpClientRequest.bodyText(payload, "text/plain")
+    )
+    const response = yield* client.execute(request)
+    yield* response.text
+
+    assert.strictEqual(request.body._tag, "Uint8Array")
+    assert.strictEqual(response.request.body._tag, "Empty")
+    assert.strictEqual(response.request.method, request.method)
+    assert.strictEqual(response.request.url, request.url)
+    assert.deepStrictEqual(response.request.urlParams, request.urlParams)
+    assert.deepStrictEqual(response.request.hash, request.hash)
+    assert.strictEqual(response.request.headers["x-test"], request.headers["x-test"])
+    assert.strictEqual(response.request.headers["content-type"], request.headers["content-type"])
+    assert.strictEqual(response.request.headers["content-length"], request.headers["content-length"])
+    assert.strictEqual((yield* Effect.promise(() => body)).toString("utf8"), payload)
+  }).pipe(Effect.provide(NodeClient.layerUndici), Effect.scoped))
 
 const flaky = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(


### PR DESCRIPTION
## Motivation

Large uploads followed by long-lived streaming responses can retain the completed request body for the full response lifetime when using the Undici client.

In that workload, retained memory grows with:

```text
active streaming responses * request body size
```

This PR adds an opt-in way to release that memory.

## Change

```ts
client.execute(request).pipe(
  Effect.provideService(NodeHttpClient.RetainResponseRequestBody, false)
)
```

The option defaults to `true`, so this is not a breaking change. Existing users keep the current behavior and `response.request.body` still contains the original body.

When disabled:

- successful responses keep request method, URL fields, and headers
- `response.request.body` is empty
- the caller-owned request is unchanged
- transport errors before response headers still keep the original request

For byte-array uploads of at least 64 KiB, the Undici adapter uses a one-shot `Readable` and drops its byte-array reference after upload. Smaller bodies keep the existing direct path. The opt-in response API is the same for both sizes.

## Benchmark

Node 24.15.0, local Undici server, five alternating runs per variant. Responses remained open after upload; retained memory was measured after diagnostic GC.

**Main result:** the opt-out removes almost exactly the uploaded payload total from live memory: about **100 MiB** for 100 x 1 MiB uploads and **160 MiB** for 40 x 4 MiB uploads.

### 100 concurrent 1 MiB uploads

| Metric | Default | Opt-out | Gain |
| --- | ---: | ---: | ---: |
| Throughput | 1,451 req/s | 1,451 req/s | unchanged |
| Retained ArrayBuffers | 108.1 MiB | 8.1 MiB | **100 MiB / 92.5% lower** |
| Retained external | 132.5 MiB | 32.5 MiB | **100 MiB / 75.5% lower** |
| Retained RSS | 306.7 MiB | 286.6 MiB | **20.1 MiB / 6.5% lower** |

### 40 concurrent 4 MiB uploads

| Metric | Default | Opt-out | Gain |
| --- | ---: | ---: | ---: |
| Throughput | 509 req/s | 498 req/s | 2.0% lower |
| Retained ArrayBuffers | 168.1 MiB | 8.1 MiB | **160 MiB / 95.2% lower** |
| Retained external | 192.5 MiB | 32.5 MiB | **160 MiB / 83.1% lower** |
| Retained RSS | 373.7 MiB | 368.2 MiB | **5.5 MiB / 1.5% lower** |

RSS falls less than live external memory because V8 and the native allocator keep freed pages available for reuse. The uploaded payloads are no longer live and cannot accumulate with active responses.

A separate small-body benchmark found that wrapping every 1 KiB upload in a `Readable` reduced throughput by about 10%, so bodies below 64 KiB stay on the current fast path. Default behavior has no new overhead.

## Scope / open question

This only covers the Node.js Undici client. Fetch and native `node:http` have different retention paths and should be measured separately.

I am not sure whether this policy belongs upstream as an opt-in, or whether Effect should instead document the application-level workaround for long-lived streaming responses.

Without the new API, an application can avoid retaining the uploaded bytes by using a one-shot request stream and clearing its source after the HTTP client pulls it:

```ts
const encoder = new TextEncoder()

const releasingBody = (input: string) =>
  Stream.fromEffect(
    Effect.sync(() => {
      const bytes = encoder.encode(input)
      input = ""
      return bytes
    })
  )

const body = JSON.stringify(payload)
const request = HttpClientRequest.post(url).pipe(
  HttpClientRequest.bodyStream(releasingBody(body), {
    contentType: "application/json",
    contentLength: Buffer.byteLength(body)
  })
)
```

This releases the source string after upload, but `response.request.body` still contains the stream object. The proposed option handles this centrally and also keeps request metadata without retaining the body.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/platform-node/test/NodeHttpClient.test.ts` (27 passed)
- `pnpm --filter @effect/platform-node build:tsgo`

Tests cover default compatibility, opt-in behavior for small and large bodies, exact payload delivery while the response stays open, preserved metadata, and scoped server cleanup.
