### PR TITLE
EFF-875 Add custom errors to Effect.fromOption

### DIFF
--- a/.changeset/fuzzy-crews-fold.md
+++ b/.changeset/fuzzy-crews-fold.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add custom error callbacks to Effect.fromOption.

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -1791,7 +1791,9 @@ export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect<A, E> = i
  * **Details**
  *
  * `Option.some` becomes a successful effect with the contained value, while
- * `Option.none` becomes a failed effect with `NoSuchElementError`.
+ * `Option.none` becomes a failed effect. By default the failure is a
+ * `NoSuchElementError`, but you can provide an `onNone` callback to customize
+ * the error value.
  *
  * **Example** (Converting an Option into an Effect)
  *
@@ -1803,6 +1805,7 @@ export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect<A, E> = i
  *
  * const effect1 = Effect.fromOption(some)
  * const effect2 = Effect.fromOption(none)
+ * const effect3 = Effect.fromOption(none, () => new Error("missing"))
  *
  * Effect.runPromise(effect1).then(console.log) // 42
  * Effect.runPromiseExit(effect2).then(console.log)
@@ -1812,9 +1815,12 @@ export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect<A, E> = i
  * @category converting
  * @since 4.0.0
  */
-export const fromOption: <A>(
-  option: Option<A>
-) => Effect<A, Cause.NoSuchElementError> = internal.fromOption
+export const fromOption: <Arg extends Option<unknown> | LazyArg<unknown>, E = Cause.NoSuchElementError>(
+  arg: Arg,
+  ...rest: [Arg] extends [Option<unknown>] ? [onNone?: LazyArg<E>] : []
+) => [Arg] extends [Option<infer A>] ? Effect<A, E>
+  : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option<A>) => Effect<A, E>
+  : never = internal.fromOption
 
 /**
  * Converts an `Option` of an `Effect` into an `Effect` of an `Option`.

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -892,10 +892,18 @@ export const suspend: <A, E, R>(
 })
 
 /** @internal */
-export const fromOption: <A>(option: Option.Option<A>) => Effect.Effect<A, Cause.NoSuchElementError> = Option.match({
-  onNone: () => fail(new NoSuchElementError("Effect.fromOption: Option.none")),
-  onSome: succeed
-})
+export const fromOption: <Arg extends Option.Option<unknown> | LazyArg<unknown>, E = Cause.NoSuchElementError>(
+  arg: Arg,
+  ...rest: [Arg] extends [Option.Option<unknown>] ? [onNone?: LazyArg<E>] : []
+) => [Arg] extends [Option.Option<infer A>] ? Effect.Effect<A, E>
+  : [Arg] extends [LazyArg<infer E>] ? <A>(option: Option.Option<A>) => Effect.Effect<A, E>
+  : never = dual(
+    (args) => args.length >= 2 || Option.isOption(args[0]),
+    <A, E>(option: Option.Option<A>, onNone?: LazyArg<E>): Effect.Effect<A, Cause.NoSuchElementError | E> =>
+      Option.isNone(option)
+        ? fail(onNone ? onNone() : new NoSuchElementError("Effect.fromOption: Option.none"))
+        : succeed(option.value)
+  )
 
 /** @internal */
 export const fromResult: <A, E>(result: Result.Result<A, E>) => Effect.Effect<A, E> = Result.match({

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -176,22 +176,22 @@ describe("Effect", () => {
         Effect.runPromise
       ))
 
-    it.effect("from a none with a custom error", () => {
-      const error = new Error("Missing value")
-      return Effect.fromOption(Option.none(), () => error).pipe(
-        Effect.flip,
-        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error)))
-      )
-    })
+    it.effect("from a none with a custom error", () =>
+      Effect.gen(function*() {
+        const error = new Error("Missing value")
+        const cause = yield* Effect.fromOption(Option.none(), () => error).pipe(Effect.flip)
+        assert.strictEqual(cause, error)
+      }))
 
-    it.effect("from a none with a custom error data-last", () => {
-      const error = new Error("Missing value")
-      return Option.none().pipe(
-        Effect.fromOption(() => error),
-        Effect.flip,
-        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error)))
-      )
-    })
+    it.effect("from a none with a custom error data-last", () =>
+      Effect.gen(function*() {
+        const error = new Error("Missing value")
+        const cause = yield* Option.none().pipe(
+          Effect.fromOption(() => error),
+          Effect.flip
+        )
+        assert.strictEqual(cause, error)
+      }))
   })
 
   describe("transposeOption", () => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -175,6 +175,25 @@ describe("Effect", () => {
         Effect.tap((error) => Effect.sync(() => assert.ok(error instanceof Cause.NoSuchElementError))),
         Effect.runPromise
       ))
+
+    it("from a none with a custom error", () => {
+      const error = new Error("Missing value")
+      return Effect.fromOption(Option.none(), () => error).pipe(
+        Effect.flip,
+        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error))),
+        Effect.runPromise
+      )
+    })
+
+    it("from a none with a custom error data-last", () => {
+      const error = new Error("Missing value")
+      return Option.none().pipe(
+        Effect.fromOption(() => error),
+        Effect.flip,
+        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error))),
+        Effect.runPromise
+      )
+    })
   })
 
   describe("transposeOption", () => {

--- a/packages/effect/test/Effect.test.ts
+++ b/packages/effect/test/Effect.test.ts
@@ -176,22 +176,20 @@ describe("Effect", () => {
         Effect.runPromise
       ))
 
-    it("from a none with a custom error", () => {
+    it.effect("from a none with a custom error", () => {
       const error = new Error("Missing value")
       return Effect.fromOption(Option.none(), () => error).pipe(
         Effect.flip,
-        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error))),
-        Effect.runPromise
+        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error)))
       )
     })
 
-    it("from a none with a custom error data-last", () => {
+    it.effect("from a none with a custom error data-last", () => {
       const error = new Error("Missing value")
       return Option.none().pipe(
         Effect.fromOption(() => error),
         Effect.flip,
-        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error))),
-        Effect.runPromise
+        Effect.tap((cause) => Effect.sync(() => assert.strictEqual(cause, error)))
       )
     })
   })

--- a/packages/effect/typetest/Effect.tst.ts
+++ b/packages/effect/typetest/Effect.tst.ts
@@ -62,6 +62,7 @@ declare const channelStringOrNumber:
 declare const layerStringOrNumber:
   | Layer.Layer<"out-1", "err-1", "dep-1">
   | Layer.Layer<"out-2", "err-2", "dep-2">
+declare const optionString: Option.Option<string>
 declare const optionStringOrNumber: Option.Option<string> | Option.Option<number>
 declare const resultStringOrNumber: Result.Result<string, "err-1"> | Result.Result<number, "err-2">
 declare const fiberStringOrNumber: Fiber.Fiber<string, "err-1"> | Fiber.Fiber<number, "err-2">
@@ -209,6 +210,31 @@ describe("Effect.transposeOption", () => {
   it("preserves success, error, and requirements", () => {
     const result = Effect.transposeOption(optionalEffect)
     expect(result).type.toBe<Effect.Effect<Option.Option<string>, "err-1", "dep-1">>()
+  })
+})
+
+describe("Effect.fromOption", () => {
+  it("uses NoSuchElementError by default", () => {
+    const result = Effect.fromOption(optionString)
+    expect(result).type.toBe<Effect.Effect<string, Cause.NoSuchElementError>>()
+  })
+
+  it("supports a custom error in data-first form", () => {
+    const result = Effect.fromOption(optionString, () => new SimpleError({ code: 1 }))
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  it("supports a custom error in data-last form", () => {
+    const result = pipe(
+      optionString,
+      Effect.fromOption(() => new SimpleError({ code: 1 }))
+    )
+    expect(result).type.toBe<Effect.Effect<string, SimpleError>>()
+  })
+
+  it("supports callback usage with the default error", () => {
+    const result = Effect.flatMap(Effect.succeed(optionString), Effect.fromOption)
+    expect(result).type.toBe<Effect.Effect<string, Cause.NoSuchElementError>>()
   })
 })
 


### PR DESCRIPTION
## Summary
- Add optional custom onNone error support to Effect.fromOption in data-first and data-last forms.
- Preserve the default NoSuchElementError behavior when onNone is omitted.
- Add runtime and type-level coverage, including higher-order callback usage.

## Validation
- pnpm lint-fix
- pnpm test packages/effect/test/Effect.test.ts
- pnpm test-types packages/effect/typetest/Effect.tst.ts
- pnpm check:tsgo