### PR TITLE
feat: add graph set operators

### DIFF
--- a/.changeset/fair-jobs-like.md
+++ b/.changeset/fair-jobs-like.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+add a `maxDepth` option to `Graph` search configuration, allowing `dfs` and `bfs` traversals to limit returned nodes by depth from the configured start nodes.

--- a/.changeset/hip-friends-kiss.md
+++ b/.changeset/hip-friends-kiss.md
@@ -1,0 +1,10 @@
+---
+"effect": minor
+---
+
+added graph set operations for combining and comparing graphs
+
+- `Graph.compose` - union of two graphs, merging nodes by identity
+- `Graph.intersection` - intersection of two graphs, keeping only common nodes and edges
+- `Graph.difference` - difference of two graphs, removing edges present in the second graph
+- `Graph.symmetricDifference` - symmetric difference of two graphs, keeping edges present in exactly one graph

--- a/.changeset/six-pumas-take.md
+++ b/.changeset/six-pumas-take.md
@@ -1,0 +1,9 @@
+---
+"effect": minor
+---
+
+add advanced graph set operations for deriving related graph structures
+
+- `Graph.complement` - complement over the existing node set, adding missing edges between distinct nodes
+- `Graph.neighborhood` - induced subgraph containing nodes within a radius of a node
+- `Graph.sum` - disjoint union of two graphs without merging equal node data

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -579,6 +579,444 @@ export const mutate: {
 })
 
 // =============================================================================
+// Set Operations
+// =============================================================================
+
+/** @internal */
+type NodeMaps<N> = {
+  readonly byId: Map<string, { readonly index: NodeIndex; readonly data: N }>
+  readonly byIndex: Map<NodeIndex, string>
+}
+
+/** @internal */
+type EdgeIdentity<E> = { readonly sourceId: string; readonly targetId: string; readonly data: E }
+
+/** @internal */
+const buildNodeMaps = <N, E, T extends Kind>(graph: Graph<N, E, T>, nodeId: (node: N) => string): NodeMaps<N> => {
+  const byId = new Map<string, { readonly index: NodeIndex; readonly data: N }>()
+  const byIndex = new Map<NodeIndex, string>()
+
+  for (const [index, data] of graph.nodes) {
+    const id = nodeId(data)
+    byId.set(id, { index, data })
+    byIndex.set(index, id)
+  }
+
+  return { byId, byIndex }
+}
+
+/** @internal */
+const edgeKey = (type: Kind, sourceId: string, targetId: string): string =>
+  type === "undirected" && sourceId > targetId ? `${targetId}\0${sourceId}` : `${sourceId}\0${targetId}`
+
+/** @internal */
+const emptyLike = <N, E, T extends Kind>(
+  graph: Graph<N, E, T>,
+  mutate: (mutable: MutableGraph<N, E, T>) => void
+): Graph<N, E, T> => {
+  const mutable = beginMutation(graph)
+
+  mutable.nodes.clear()
+  mutable.edges.clear()
+  mutable.adjacency.clear()
+  mutable.reverseAdjacency.clear()
+  mutable.nextNodeIndex = 0
+  mutable.nextEdgeIndex = 0
+  mutable.acyclic = Option.some(true)
+
+  mutate(mutable)
+
+  return endMutation(mutable)
+}
+
+/**
+ * Returns the union of two graphs, merging nodes by identity.
+ *
+ * **Details**
+ *
+ * Nodes and edges present in both graphs use data from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∪ G2 = {V1 ∪ V2, E1 ∪ E2}`
+ *
+ * **Example** (Composing graphs)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, { id: "A" })
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ * })
+ *
+ * const right = Graph.directed<{ id: string }, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, { id: "B" })
+ *   const c = Graph.addNode(mutable, { id: "C" })
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const result = Graph.compose(left, right, (node) => node.id)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const compose: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(
+  3,
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>, nodeId: (node: N) => string): Graph<N, E, T> => {
+    const selfMaps = buildNodeMaps(self, nodeId)
+    const thatMaps = buildNodeMaps(that, nodeId)
+    const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+    const edgeMap = new Map<string, EdgeIdentity<E>>()
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (sourceId !== undefined && targetId !== undefined) {
+        edgeMap.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+      }
+    }
+
+    return emptyLike(self, (mutable) => {
+      const newIndexMap = new Map<string, NodeIndex>()
+
+      for (const id of allNodeIds) {
+        const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+        if (entry !== undefined) {
+          newIndexMap.set(id, addNode(mutable, entry.data))
+        }
+      }
+
+      for (const { sourceId, targetId, data } of edgeMap.values()) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    })
+  }
+)
+
+/**
+ * Returns the intersection of two graphs, matching nodes by identity.
+ *
+ * **Details**
+ *
+ * Node data comes from `self`, and edge data comes from `that`. The result has
+ * the same graph kind as `self`.
+ *
+ * `G1 ∩ G2 = {V1 ∩ V2, E1 ∩ E2}`
+ *
+ * **Example** (Finding shared structure)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "left")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "right")
+ * })
+ *
+ * const result = Graph.intersection(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 2
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const intersection: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const commonNodeIds = [...selfMaps.byId.keys()].filter((id) => thatMaps.byId.has(id))
+  const commonNodeIdSet = new Set(commonNodeIds)
+  const selfEdgeKeys = new Set<string>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdgeKeys.add(edgeKey(self.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of commonNodeIds) {
+      const entry = selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const edge of that.edges.values()) {
+      const sourceId = thatMaps.byIndex.get(edge.source)
+      const targetId = thatMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined &&
+        targetId !== undefined &&
+        commonNodeIdSet.has(sourceId) &&
+        commonNodeIdSet.has(targetId) &&
+        selfEdgeKeys.has(edgeKey(that.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns `self` without edges also present in `that`.
+ *
+ * **Details**
+ *
+ * All nodes from `self` are preserved. Edges are matched by endpoint identity,
+ * and edge data is ignored. The result has the same graph kind as `self`.
+ *
+ * `G1 \ G2 = {V1, E1 \ E2}`
+ *
+ * **Example** (Removing shared edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, b, c, "other")
+ * })
+ *
+ * const result = Graph.difference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const difference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const thatEdgeKeys = new Set<string>()
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdgeKeys.add(edgeKey(that.type, sourceId, targetId))
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const [id, entry] of selfMaps.byId) {
+      newIndexMap.set(id, addNode(mutable, entry.data))
+    }
+
+    for (const edge of self.edges.values()) {
+      const sourceId = selfMaps.byIndex.get(edge.source)
+      const targetId = selfMaps.byIndex.get(edge.target)
+      if (
+        sourceId !== undefined && targetId !== undefined && !thatEdgeKeys.has(edgeKey(self.type, sourceId, targetId))
+      ) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns edges present in exactly one of two graphs.
+ *
+ * **Details**
+ *
+ * Keeps nodes from both graphs. Overlapping nodes use data from `that`. The
+ * result has the same graph kind as `self`.
+ *
+ * `G1 Δ G2 = {V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2)}`
+ *
+ * **Gotchas**
+ *
+ * Edges present in both graphs are removed even when their edge data differs.
+ *
+ * **Example** (Finding differing edges)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const left = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const right = Graph.directed<string, string>((mutable) => {
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   const d = Graph.addNode(mutable, "D")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ *   Graph.addEdge(mutable, c, d, "C-D")
+ * })
+ *
+ * const result = Graph.symmetricDifference(left, right, (node) => node)
+ *
+ * console.log(Graph.nodeCount(result)) // 4
+ * console.log(Graph.edgeCount(result)) // 2
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const symmetricDifference: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>,
+    nodeId: (node: N) => string
+  ): Graph<N, E, T>
+} = dual(3, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  that: Graph<N, E, T>,
+  nodeId: (node: N) => string
+): Graph<N, E, T> => {
+  const selfMaps = buildNodeMaps(self, nodeId)
+  const thatMaps = buildNodeMaps(that, nodeId)
+  const allNodeIds = new Set([...selfMaps.byId.keys(), ...thatMaps.byId.keys()])
+  const selfEdges = new Map<string, EdgeIdentity<E>>()
+  const thatEdges = new Map<string, EdgeIdentity<E>>()
+
+  for (const edge of self.edges.values()) {
+    const sourceId = selfMaps.byIndex.get(edge.source)
+    const targetId = selfMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      selfEdges.set(edgeKey(self.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  for (const edge of that.edges.values()) {
+    const sourceId = thatMaps.byIndex.get(edge.source)
+    const targetId = thatMaps.byIndex.get(edge.target)
+    if (sourceId !== undefined && targetId !== undefined) {
+      thatEdges.set(edgeKey(that.type, sourceId, targetId), { sourceId, targetId, data: edge.data })
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<string, NodeIndex>()
+
+    for (const id of allNodeIds) {
+      const entry = thatMaps.byId.get(id) ?? selfMaps.byId.get(id)
+      if (entry !== undefined) {
+        newIndexMap.set(id, addNode(mutable, entry.data))
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of selfEdges) {
+      if (!thatEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+
+    for (const [key, { sourceId, targetId, data }] of thatEdges) {
+      if (!selfEdges.has(key)) {
+        const sourceIndex = newIndexMap.get(sourceId)
+        const targetIndex = newIndexMap.get(targetId)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, data)
+        }
+      }
+    }
+  })
+})
+
+// =============================================================================
 // Basic Node Operations
 // =============================================================================
 

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -1016,6 +1016,212 @@ export const symmetricDifference: {
   })
 })
 
+/**
+ * Returns the complement over the existing node set.
+ *
+ * **Details**
+ *
+ * Adds every missing edge between distinct nodes. The `createEdge` function
+ * receives the source and target node data for each added edge. The result has
+ * the same graph kind as `self`.
+ *
+ * `G' = {V, (V x V) \ E}`
+ *
+ * **Example** (Finding missing relationships)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ * })
+ *
+ * const result = Graph.complement(graph, (source, target) => `${source}-${target}`)
+ *
+ * console.log(Graph.edgeCount(result)) // 1
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const complement: {
+  <N, E>(
+    createEdge: (source: N, target: N) => E
+  ): <T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    createEdge: (source: N, target: N) => E
+  ): Graph<N, E, T>
+} = dual(2, <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  createEdge: (source: N, target: N) => E
+): Graph<N, E, T> => {
+  const nodeEntries = Array.from(self.nodes)
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<NodeIndex, NodeIndex>()
+
+    for (const [oldIndex, data] of nodeEntries) {
+      newIndexMap.set(oldIndex, addNode(mutable, data))
+    }
+
+    for (let i = 0; i < nodeEntries.length; i++) {
+      const [sourceOldIndex, sourceData] = nodeEntries[i]
+      const start = self.type === "undirected" ? i + 1 : 0
+
+      for (let j = start; j < nodeEntries.length; j++) {
+        const [targetOldIndex, targetData] = nodeEntries[j]
+        if (sourceOldIndex === targetOldIndex || hasEdge(self, sourceOldIndex, targetOldIndex)) {
+          continue
+        }
+
+        const sourceIndex = newIndexMap.get(sourceOldIndex)
+        const targetIndex = newIndexMap.get(targetOldIndex)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, createEdge(sourceData, targetData))
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Direction for neighborhood expansion in directed graphs.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type NeighborhoodDirection = "outgoing" | "incoming" | "both"
+
+/**
+ * Returns the induced subgraph containing nodes within a radius of a node.
+ *
+ * **Details**
+ *
+ * The `radius` option is the maximum edge distance from `nodeIndex` and
+ * defaults to `1`. The `direction` option controls directed graph traversal and
+ * defaults to `"both"`. The result has the same graph kind as `self` and keeps
+ * all original edges whose endpoints are both reached.
+ *
+ * **Example** (Getting a local neighborhood)
+ *
+ * ```ts
+ * import { Graph } from "effect"
+ *
+ * const graph = Graph.directed<string, string>((mutable) => {
+ *   const a = Graph.addNode(mutable, "A")
+ *   const b = Graph.addNode(mutable, "B")
+ *   const c = Graph.addNode(mutable, "C")
+ *   Graph.addEdge(mutable, a, b, "A-B")
+ *   Graph.addEdge(mutable, b, c, "B-C")
+ * })
+ *
+ * const result = Graph.neighborhood(graph, 1, { radius: 1 })
+ *
+ * console.log(Graph.nodeCount(result)) // 3
+ * ```
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const neighborhood: {
+  (
+    nodeIndex: NodeIndex,
+    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+  ): <N, E, T extends Kind = "directed">(self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    nodeIndex: NodeIndex,
+    options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+  ): Graph<N, E, T>
+} = dual((args) => isGraph(args[0]), <N, E, T extends Kind>(
+  self: Graph<N, E, T>,
+  nodeIndex: NodeIndex,
+  options?: { readonly radius?: number; readonly direction?: NeighborhoodDirection }
+): Graph<N, E, T> => {
+  const radius = options?.radius ?? 1
+  const direction = options?.direction ?? "both"
+  const reached = new Set<NodeIndex>()
+
+  if (direction === "outgoing" || direction === "both") {
+    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "outgoing", maxDepth: radius }))) {
+      reached.add(index)
+    }
+  }
+
+  if (direction === "incoming" || direction === "both") {
+    for (const index of indices(bfs(self, { start: [nodeIndex], direction: "incoming", maxDepth: radius }))) {
+      reached.add(index)
+    }
+  }
+
+  return emptyLike(self, (mutable) => {
+    const newIndexMap = new Map<NodeIndex, NodeIndex>()
+
+    for (const oldIndex of reached) {
+      newIndexMap.set(oldIndex, addNode(mutable, Option.getOrThrow(getNode(self, oldIndex))))
+    }
+
+    for (const edge of self.edges.values()) {
+      if (reached.has(edge.source) && reached.has(edge.target)) {
+        const sourceIndex = newIndexMap.get(edge.source)
+        const targetIndex = newIndexMap.get(edge.target)
+        if (sourceIndex !== undefined && targetIndex !== undefined) {
+          addEdge(mutable, sourceIndex, targetIndex, edge.data)
+        }
+      }
+    }
+  })
+})
+
+/**
+ * Returns the disjoint union of two graphs.
+ *
+ * **Details**
+ *
+ * Copies all nodes and edges from both graphs without merging equal node data.
+ * The result has the same graph kind as `self`.
+ *
+ * `G1 + G2 = {disjoint V1 + V2, disjoint E1 + E2}`
+ *
+ * @category set operations
+ * @since 4.0.0
+ */
+export const sum: {
+  <N, E, T extends Kind = "directed">(
+    that: Graph<N, E, T>
+  ): (self: Graph<N, E, T>) => Graph<N, E, T>
+  <N, E, T extends Kind = "directed">(
+    self: Graph<N, E, T>,
+    that: Graph<N, E, T>
+  ): Graph<N, E, T>
+} = dual(
+  2,
+  <N, E, T extends Kind>(self: Graph<N, E, T>, that: Graph<N, E, T>): Graph<N, E, T> =>
+    emptyLike(self, (mutable) => {
+      const copyInto = (graph: Graph<N, E, T>) => {
+        const indexMap = new Map<NodeIndex, NodeIndex>()
+
+        for (const [oldIndex, data] of graph.nodes) {
+          indexMap.set(oldIndex, addNode(mutable, data))
+        }
+
+        for (const edge of graph.edges.values()) {
+          const sourceIndex = indexMap.get(edge.source)
+          const targetIndex = indexMap.get(edge.target)
+          if (sourceIndex !== undefined && targetIndex !== undefined) {
+            addEdge(mutable, sourceIndex, targetIndex, edge.data)
+          }
+        }
+      }
+
+      copyInto(self)
+      copyInto(that)
+    })
+)
+
 // =============================================================================
 // Basic Node Operations
 // =============================================================================

--- a/packages/effect/src/Graph.ts
+++ b/packages/effect/src/Graph.ts
@@ -4649,6 +4649,7 @@ export const entries = <T, N>(walker: Walker<T, N>): Iterable<[T, N]> =>
 export interface SearchConfig {
   readonly start?: Array<NodeIndex>
   readonly direction?: Direction
+  readonly maxDepth?: number
 }
 
 /**
@@ -4658,7 +4659,8 @@ export interface SearchConfig {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. Throws a `GraphError`
+ * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
  * **Example** (Traversing depth-first)
@@ -4702,6 +4704,7 @@ export const dfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
+  const maxDepth = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -4712,12 +4715,12 @@ export const dfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const stack = [...start]
+      const stack: Array<readonly [NodeIndex, number]> = start.map((node) => [node, 0])
       const discovered = new Set<NodeIndex>()
 
       const nextMapped = () => {
         while (stack.length > 0) {
-          const current = stack.pop()!
+          const [current, depth] = stack.pop()!
 
           if (discovered.has(current)) {
             continue
@@ -4730,11 +4733,13 @@ export const dfs: {
             continue
           }
 
-          const neighbors = getTraversalNeighbors(graph, current, direction)
-          for (let i = neighbors.length - 1; i >= 0; i--) {
-            const neighbor = neighbors[i]
-            if (!discovered.has(neighbor)) {
-              stack.push(neighbor)
+          if (depth < maxDepth) {
+            const neighbors = getTraversalNeighbors(graph, current, direction)
+            for (let i = neighbors.length - 1; i >= 0; i--) {
+              const neighbor = neighbors[i]
+              if (!discovered.has(neighbor)) {
+                stack.push([neighbor, depth + 1])
+              }
             }
           }
 
@@ -4756,7 +4761,8 @@ export const dfs: {
  * **Details**
  *
  * If no start nodes are supplied, the iterator is empty. The `direction` option
- * chooses whether to follow outgoing or incoming edges. Throws a `GraphError`
+ * chooses whether to follow outgoing or incoming edges. The `maxDepth` option
+ * limits traversal by edge distance from the start nodes. Throws a `GraphError`
  * if any configured start node does not exist.
  *
  * **Example** (Traversing breadth-first)
@@ -4800,6 +4806,7 @@ export const bfs: {
 ): NodeWalker<N> => {
   const start = config.start ?? []
   const direction = config.direction ?? "outgoing"
+  const maxDepth = config.maxDepth ?? Infinity
 
   // Validate that all start nodes exist
   for (const nodeIndex of start) {
@@ -4810,20 +4817,22 @@ export const bfs: {
 
   return new Walker((f) => ({
     [Symbol.iterator]: () => {
-      const queue = [...start]
+      const queue: Array<readonly [NodeIndex, number]> = start.map((node) => [node, 0])
       const discovered = new Set<NodeIndex>()
 
       const nextMapped = () => {
         while (queue.length > 0) {
-          const current = queue.shift()!
+          const [current, depth] = queue.shift()!
 
           if (!discovered.has(current)) {
             discovered.add(current)
 
-            const neighbors = getTraversalNeighbors(graph, current, direction)
-            for (const neighbor of neighbors) {
-              if (!discovered.has(neighbor)) {
-                queue.push(neighbor)
+            if (depth < maxDepth) {
+              const neighbors = getTraversalNeighbors(graph, current, direction)
+              for (const neighbor of neighbors) {
+                if (!discovered.has(neighbor)) {
+                  queue.push([neighbor, depth + 1])
+                }
               }
             }
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1,5 +1,5 @@
 import { assertNone, assertSome, strictEqual } from "@effect/vitest/utils"
-import { Equal, Graph, Hash, Match, Option } from "effect"
+import { Equal, Graph, Hash, Option } from "effect"
 import { describe, expect, it } from "vitest"
 
 const assertSomeEdge = <E>(edge: Option.Option<Graph.Edge<E>>): Graph.Edge<E> => {
@@ -20,32 +20,31 @@ const makeReversedUndirectedPath = () =>
 
 type SetNode = { readonly id: string; readonly label: string }
 
-const graphNodeIds = <E>(graph: Graph.Graph<SetNode, E>) => new Set(Array.from(graph, ([, node]) => node.id))
+const graphNodeIds = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
+  new Set(Array.from(graph, ([, node]) => node.id))
 
-const graphNodeLabels = <E>(graph: Graph.Graph<SetNode, E>) =>
+const graphNodeLabels = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) =>
   new Map(Array.from(graph, ([, node]) => [node.id, node.label]))
 
-const graphEdgeKeys = <E>(graph: Graph.Graph<SetNode, E>) => {
+const graphEdgeKeys = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
   const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
   return new Set(
     Array.from(Graph.edges(graph), ([, edge]) =>
-      Match.value(graph.type).pipe(
-        Match.when("directed", () => `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`),
-        Match.orElse(() => `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
-      ))
+      graph.type === "directed"
+        ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+        : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
   )
 }
 
-const graphEdgeData = <E>(graph: Graph.Graph<SetNode, E>) => {
+const graphEdgeData = <E, T extends Graph.Kind>(graph: Graph.Graph<SetNode, E, T>) => {
   const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
   return new Map(
     Array.from(
       Graph.edges(graph),
       ([, edge]) => [
-        Match.value(graph.type).pipe(
-          Match.when("directed", () => `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`),
-          Match.orElse(() => `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
-        ),
+        graph.type === "directed"
+          ? `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`
+          : `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`,
         edge.data
       ]
     )
@@ -176,6 +175,101 @@ describe("Graph", () => {
 
       strictEqual(Graph.edgeCount(Graph.intersection(left, right, (n) => n)), 1)
       strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
+    })
+
+    it("complement adds missing directed edges", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "a", label: "A" })
+        const b = Graph.addNode(mutable, { id: "b", label: "B" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+      })
+
+      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
+
+      expect(Graph.nodeCount(result)).toBe(3)
+      expect(Graph.edgeCount(result)).toBe(4)
+      expect(graphEdgeData(result)).toEqual(
+        new Map([
+          ["a->c", "A-C"],
+          ["b->a", "B-A"],
+          ["c->a", "C-A"],
+          ["c->b", "C-B"]
+        ])
+      )
+    })
+
+    it("complement adds missing undirected edges once", () => {
+      const graph = Graph.undirected<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        Graph.addNode(mutable, { id: "C", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+      })
+
+      const result = Graph.complement(graph, (source, target) => `${source.label}-${target.label}`)
+
+      expect(result.type).toBe("undirected")
+      expect(Graph.edgeCount(result)).toBe(2)
+      expect(graphEdgeData(result)).toEqual(
+        new Map([
+          ["A--C", "A-C"],
+          ["B--C", "B-C"]
+        ])
+      )
+    })
+
+    it("neighborhood returns the induced subgraph within radius", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        const c = Graph.addNode(mutable, { id: "C", label: "C" })
+        const d = Graph.addNode(mutable, { id: "D", label: "D" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+        Graph.addEdge(mutable, c, d, "C-D")
+        Graph.addEdge(mutable, c, b, "C-B")
+      })
+
+      const result = Graph.neighborhood(graph, 1, { radius: 1, direction: "outgoing" })
+
+      expect(graphNodeIds(result)).toEqual(new Set(["B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["B->C", "C->B"]))
+    })
+
+    it("neighborhood can include incoming and outgoing nodes", () => {
+      const graph = Graph.directed<SetNode, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "A", label: "A" })
+        const b = Graph.addNode(mutable, { id: "B", label: "B" })
+        const c = Graph.addNode(mutable, { id: "C", label: "C" })
+        Graph.addEdge(mutable, a, b, "A-B")
+        Graph.addEdge(mutable, b, c, "B-C")
+      })
+
+      const result = Graph.neighborhood(graph, 1)
+
+      expect(graphNodeIds(result)).toEqual(new Set(["A", "B", "C"]))
+      expect(graphEdgeKeys(result)).toEqual(new Set(["A->B", "B->C"]))
+    })
+
+    it("sum keeps equal nodes disjoint", () => {
+      const left = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "left")
+      })
+      const right = Graph.directed<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "right")
+      })
+
+      const result = Graph.sum(left, right)
+
+      expect(Graph.nodeCount(result)).toBe(4)
+      expect(Graph.edgeCount(result)).toBe(2)
+      expect(Array.from(Graph.values(Graph.nodes(result)))).toEqual(["A", "B", "A", "B"])
     })
   })
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -1,5 +1,5 @@
 import { assertNone, assertSome, strictEqual } from "@effect/vitest/utils"
-import { Equal, Graph, Hash, Option } from "effect"
+import { Equal, Graph, Hash, Match, Option } from "effect"
 import { describe, expect, it } from "vitest"
 
 const assertSomeEdge = <E>(edge: Option.Option<Graph.Edge<E>>): Graph.Edge<E> => {
@@ -18,6 +18,40 @@ const makeReversedUndirectedPath = () =>
     Graph.addEdge(mutable, c, b, 1)
   })
 
+type SetNode = { readonly id: string; readonly label: string }
+
+const graphNodeIds = <E>(graph: Graph.Graph<SetNode, E>) => new Set(Array.from(graph, ([, node]) => node.id))
+
+const graphNodeLabels = <E>(graph: Graph.Graph<SetNode, E>) =>
+  new Map(Array.from(graph, ([, node]) => [node.id, node.label]))
+
+const graphEdgeKeys = <E>(graph: Graph.Graph<SetNode, E>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Set(
+    Array.from(Graph.edges(graph), ([, edge]) =>
+      Match.value(graph.type).pipe(
+        Match.when("directed", () => `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`),
+        Match.orElse(() => `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
+      ))
+  )
+}
+
+const graphEdgeData = <E>(graph: Graph.Graph<SetNode, E>) => {
+  const nodeIds = new Map(Array.from(graph, ([index, node]) => [index, node.id]))
+  return new Map(
+    Array.from(
+      Graph.edges(graph),
+      ([, edge]) => [
+        Match.value(graph.type).pipe(
+          Match.when("directed", () => `${nodeIds.get(edge.source)}->${nodeIds.get(edge.target)}`),
+          Match.orElse(() => `${nodeIds.get(edge.source)}--${nodeIds.get(edge.target)}`)
+        ),
+        edge.data
+      ]
+    )
+  )
+}
+
 describe("Graph", () => {
   describe("constructors", () => {
     it("should create empty directed graph", () => {
@@ -34,6 +68,114 @@ describe("Graph", () => {
       expect(graph.type).toBe("undirected")
       expect(Graph.nodeCount(graph)).toBe(0)
       expect(Graph.edgeCount(graph)).toBe(0)
+    })
+  })
+
+  describe("set operations", () => {
+    const makeLeft = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const a = Graph.addNode(mutable, { id: "a", label: "A1" })
+        const b = Graph.addNode(mutable, { id: "b", label: "B1" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C1" })
+        Graph.addEdge(mutable, a, b, "left-ab")
+        Graph.addEdge(mutable, b, c, "left-bc")
+      })
+
+    const makeRight = () =>
+      Graph.directed<{ readonly id: string; readonly label: string }, string>((mutable) => {
+        const b = Graph.addNode(mutable, { id: "b", label: "B2" })
+        const c = Graph.addNode(mutable, { id: "c", label: "C2" })
+        const d = Graph.addNode(mutable, { id: "d", label: "D2" })
+        Graph.addEdge(mutable, b, c, "right-bc")
+        Graph.addEdge(mutable, c, d, "right-cd")
+      })
+
+    it("compose merges nodes and edges by identity", () => {
+      const graph = Graph.compose(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "b->c", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["b->c", "right-bc"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("intersection keeps shared nodes and shared edges", () => {
+      const graph = Graph.intersection(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["b->c"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["b->c", "right-bc"]]))
+    })
+
+    it("difference preserves self nodes and removes shared edges", () => {
+      const graph = Graph.difference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B1"],
+          ["c", "C1"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b"]))
+      expect(graphEdgeData(graph)).toEqual(new Map([["a->b", "left-ab"]]))
+    })
+
+    it("symmetricDifference keeps edges present in exactly one graph", () => {
+      const graph = Graph.symmetricDifference(makeLeft(), makeRight(), (n) => n.id)
+
+      expect(graphNodeIds(graph)).toEqual(new Set(["a", "b", "c", "d"]))
+      expect(graphNodeLabels(graph)).toEqual(
+        new Map([
+          ["a", "A1"],
+          ["b", "B2"],
+          ["c", "C2"],
+          ["d", "D2"]
+        ])
+      )
+      expect(graphEdgeKeys(graph)).toEqual(new Set(["a->b", "c->d"]))
+      expect(graphEdgeData(graph)).toEqual(
+        new Map([
+          ["a->b", "left-ab"],
+          ["c->d", "right-cd"]
+        ])
+      )
+    })
+
+    it("matches undirected edges regardless of endpoint order", () => {
+      const left = Graph.undirected<string, string>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, "left")
+      })
+      const right = Graph.undirected<string, string>((mutable) => {
+        const b = Graph.addNode(mutable, "B")
+        const a = Graph.addNode(mutable, "A")
+        Graph.addEdge(mutable, b, a, "right")
+      })
+
+      strictEqual(Graph.edgeCount(Graph.intersection(left, right, (n) => n)), 1)
+      strictEqual(Graph.edgeCount(Graph.difference(left, right, (n) => n)), 0)
     })
   })
 

--- a/packages/effect/test/Graph.test.ts
+++ b/packages/effect/test/Graph.test.ts
@@ -3009,6 +3009,49 @@ describe("Graph", () => {
       expect(entries).toEqual([[0, "A"], [1, "B"], [2, "C"]])
     })
 
+    it("should limit DFS traversal by maxDepth", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        const d = Graph.addNode(mutable, "D")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, b, c, 2)
+        Graph.addEdge(mutable, c, d, 3)
+      })
+
+      const dfsIterator = Graph.dfs(graph, { start: [0], maxDepth: 1 })
+
+      expect(Array.from(Graph.indices(dfsIterator))).toEqual([0, 1])
+    })
+
+    it("should limit BFS traversal by maxDepth", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        const c = Graph.addNode(mutable, "C")
+        const d = Graph.addNode(mutable, "D")
+        Graph.addEdge(mutable, a, b, 1)
+        Graph.addEdge(mutable, a, c, 2)
+        Graph.addEdge(mutable, b, d, 3)
+      })
+
+      const bfsIterator = Graph.bfs(graph, { start: [0], maxDepth: 1 })
+
+      expect(Array.from(Graph.indices(bfsIterator))).toEqual([0, 1, 2])
+    })
+
+    it("should only include start nodes when maxDepth is zero", () => {
+      const graph = Graph.directed<string, number>((mutable) => {
+        const a = Graph.addNode(mutable, "A")
+        const b = Graph.addNode(mutable, "B")
+        Graph.addEdge(mutable, a, b, 1)
+      })
+
+      expect(Array.from(Graph.indices(Graph.dfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
+      expect(Array.from(Graph.indices(Graph.bfs(graph, { start: [0], maxDepth: 0 })))).toEqual([0])
+    })
+
     it("should provide values() method for Topo iterator", () => {
       const graph = Graph.directed<string, number>((mutable) => {
         const a = Graph.addNode(mutable, "A")

--- a/packages/effect/typetest/Graph.tst.ts
+++ b/packages/effect/typetest/Graph.tst.ts
@@ -1,0 +1,106 @@
+import { Graph, pipe } from "effect"
+import { describe, expect, it } from "tstyche"
+
+declare const directed: Graph.DirectedGraph<string, number>
+declare const undirected: Graph.UndirectedGraph<string, number>
+
+interface Node {
+  readonly id: string
+}
+
+declare const directedNodes: Graph.DirectedGraph<Node, number>
+declare const undirectedNodes: Graph.UndirectedGraph<Node, number>
+
+describe("Graph", () => {
+  it("compose", () => {
+    expect(Graph.compose(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.compose(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("intersection", () => {
+    expect(Graph.intersection(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.intersection(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("difference", () => {
+    expect(Graph.difference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.difference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("symmetricDifference", () => {
+    expect(Graph.symmetricDifference(directedNodes, directedNodes, (node) => {
+      expect(node).type.toBe<Node>()
+      return node.id
+    })).type.toBe<Graph.DirectedGraph<Node, number>>()
+
+    expect(pipe(
+      undirectedNodes,
+      Graph.symmetricDifference(undirectedNodes, (node) => {
+        expect(node).type.toBe<Node>()
+        return node.id
+      })
+    )).type.toBe<Graph.UndirectedGraph<Node, number>>()
+  })
+
+  it("complement", () => {
+    expect(Graph.complement(directed, (source, target) => {
+      expect(source).type.toBe<string>()
+      expect(target).type.toBe<string>()
+      return source.length + target.length
+    })).type.toBe<Graph.DirectedGraph<string, number>>()
+
+    expect(pipe(
+      undirected,
+      Graph.complement((source, target) => {
+        expect(source).type.toBe<string>()
+        expect(target).type.toBe<string>()
+        return source.length + target.length
+      })
+    )).type.toBe<Graph.UndirectedGraph<string, number>>()
+  })
+
+  it("neighborhood", () => {
+    expect(Graph.neighborhood(directed, 0)).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(Graph.neighborhood(directed, 0, { radius: 2, direction: "both" })).type.toBe<
+      Graph.DirectedGraph<string, number>
+    >()
+    expect(pipe(undirected, Graph.neighborhood(0, { radius: 2, direction: "outgoing" }))).type.toBe<
+      Graph.UndirectedGraph<string, number>
+    >()
+  })
+
+  it("sum", () => {
+    expect(Graph.sum(directed, directed)).type.toBe<Graph.DirectedGraph<string, number>>()
+    expect(pipe(undirected, Graph.sum(undirected))).type.toBe<Graph.UndirectedGraph<string, number>>()
+  })
+})


### PR DESCRIPTION
## Type

- [x] Refactor
- [x] Feature

## Description

Have added 4 basic and 3 advanced set operators to the Graph module to be able to build and explore for interesting structures. These include:

- `Graph.compose` - $(G1 ∪ G2 = { V1 ∪ V2, E1 ∪ E2 })$
  merges two graphs by node identity, combining nodes and edges from both. Overlapping data from that wins.
- `Graph.intersection` - $(G1 ∩ G2 = { V1 ∩ V2, E1 ∩ E2 })$
  keeps only nodes and edges present in both graphs.
- `Graph.difference` - $(G1 \ G2 = { V1, E1 \ E2 })$
  keeps all nodes from self, but removes edges that also exist in that.
- `Graph.symmetricDifference` - $(G1 Δ G2 = { V1 ∪ V2, (E1 ∪ E2) \ (E1 ∩ E2) })$
  keeps edges that exist in exactly one graph, removing shared edges.
- `Graph.complement` - $(G' = { V, (V × V) \ E })$
  keeps the same nodes, but adds every missing non-self edge.
- `Graph.neighborhood` - $(Nᵣ(v) = G[{ u ∈ V | distance(v, u) ≤ r }])$
  builds an induced subgraph around a node within a radius.
- `Graph.sum` - $(G1 + G2 = { V1 ⊔ V2, E1 ⊔ E2 })$
  creates a disjoint union of two graphs without merging equal nodes.

Most of the implementation was done similar to `NetworkX` when it came to making decisions around when `self` or `that` would win on conflict and the main decision on node equality is left to the implementor where they need to pass a nodeId callback to be able to identify each node.

One additional refactor (separate commit) was the additional logic to `Graph.bfs` and `Graph.dfs` to allow for a `maxDepth`.  This was important to be able to reuse the BFS in the `neighbordhood` op and create a custom version like I did in my utils experiment.

Some fun and exciting things can be done with this functionality.

<img width="916" height="363" alt="Screenshot 2026-06-23 at 22 26 49" src="https://github.com/user-attachments/assets/a5a7b6f4-9112-45e5-891e-490e5e9862d8" />

## For Reviewing

To make things easier to review I've broken up the three main parts so they can be reviewed separately and left off the type tests till last. Any feedback or requests I will initial add as commits on top of the current tree and then rebase together to clean up once approved


## Related

Came up as a request in Slack with a bit of back and forth discussion with @fubhy.  I then spend a couple of days building [similar functions in my own repo](https://github.com/lloydrichards/edu_effect-okf/blob/main/apps/cli/src/lib/graph-utils.ts) to be sure of the api as well as test out their implementation with some real examples.

- Slack [thread](https://discord.com/channels/795981131316985866/1518570933864894485)
