### PR TITLE
EFF-876 Replace better-sqlite3 with node:sqlite in sql-sqlite-node

### DIFF
--- a/.changeset/o8drprcu-sqlite-node-node-sqlite.md
+++ b/.changeset/o8drprcu-sqlite-node-node-sqlite.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-sqlite-node": patch
+---
+
+Replace the `better-sqlite3` dependency with Node.js' built-in `node:sqlite` module.

--- a/packages/sql/sqlite-node/README.md
+++ b/packages/sql/sqlite-node/README.md
@@ -1,6 +1,6 @@
 # `@effect/sql-sqlite-node`
 
-An `@effect/sql` implementation using the `better-sqlite3` library.
+An `@effect/sql` implementation using Node.js' built-in `node:sqlite` module.
 
 ## Documentation
 

--- a/packages/sql/sqlite-node/package.json
+++ b/packages/sql/sqlite-node/package.json
@@ -60,13 +60,10 @@
   },
   "devDependencies": {
     "@effect/platform-node": "workspace:^",
-    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^25.7.0",
     "effect": "workspace:^"
   },
   "peerDependencies": {
     "effect": "workspace:^"
-  },
-  "dependencies": {
-    "better-sqlite3": "^12.9.0"
   }
 }

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -1,5 +1,5 @@
 /**
- * Connects Effect SQL to SQLite on Node.js using `better-sqlite3`.
+ * Connects Effect SQL to SQLite on Node.js using `node:sqlite`.
  *
  * This module opens a SQLite database and exposes it as both `SqliteClient` and
  * the generic Effect SQL client. It serializes access through one connection,
@@ -9,7 +9,6 @@
  *
  * @since 4.0.0
  */
-import Sqlite from "better-sqlite3"
 import * as Cache from "effect/Cache"
 import * as Config from "effect/Config"
 import * as Context from "effect/Context"
@@ -26,11 +25,51 @@ import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
 import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { backup as backupDatabase, DatabaseSync } from "node:sqlite"
+import type { StatementSync } from "node:sqlite"
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
+const sqliteCauseWithErrno = (cause: unknown): unknown => {
+  if (typeof cause !== "object" || cause === null || !("errcode" in cause) || "errno" in cause) {
+    return cause
+  }
+  const errcode = (cause as { readonly errcode: unknown }).errcode
+  if (typeof errcode !== "number") {
+    return cause
+  }
+  return {
+    cause,
+    code: "code" in cause ? (cause as { readonly code: unknown }).code : undefined,
+    errno: errcode,
+    message: "message" in cause ? (cause as { readonly message: unknown }).message : undefined
+  }
+}
+
 const classifyError = (cause: unknown, message: string, operation: string) =>
-  classifySqliteError(cause, { message, operation })
+  classifySqliteError(sqliteCauseWithErrno(cause), { message, operation })
+
+const normalizeRows = (rows: ReadonlyArray<Record<string, unknown>>): ReadonlyArray<Record<string, unknown>> =>
+  rows.map((row) => ({ ...row }))
+
+const hasResultColumns = (statement: StatementSync): boolean => statement.columns().length > 0
+
+const exportDatabase = (db: DatabaseSync): Promise<Uint8Array> => {
+  const serialize = (db as { readonly serialize?: () => Uint8Array }).serialize
+  if (serialize !== undefined) {
+    return Promise.resolve(serialize.call(db))
+  }
+  return Promise.resolve().then(() => {
+    const directory = mkdtempSync(join(tmpdir(), "effect-sqlite-node-"))
+    const destination = join(directory, "export.db")
+    return backupDatabase(db, destination).then((): Uint8Array => readFileSync(destination)).finally(() => {
+      rmSync(directory, { recursive: true, force: true })
+    })
+  })
+}
 
 /**
  * Runtime type identifier used to mark Node `SqliteClient` values.
@@ -85,7 +124,7 @@ export interface BackupMetadata {
 export const SqliteClient = Context.Service<SqliteClient>("@effect/sql-sqlite-node/SqliteClient")
 
 /**
- * Configuration for a node SQLite client backed by `better-sqlite3`, including the database filename, read-only mode, statement cache settings, WAL behavior, span attributes, and query/result name transforms.
+ * Configuration for a node SQLite client backed by `node:sqlite`, including the database filename, read-only mode, statement cache settings, WAL behavior, span attributes, and query/result name transforms.
  *
  * @category models
  * @since 4.0.0
@@ -127,13 +166,15 @@ export const make = (
 
     const makeConnection = Effect.gen(function*() {
       const scope = yield* Effect.scope
-      const db = new Sqlite(options.filename, {
-        readonly: options.readonly ?? false
+      const db = new DatabaseSync(options.filename, {
+        readOnly: options.readonly ?? false,
+        allowExtension: true
       })
       yield* Scope.addFinalizer(scope, Effect.sync(() => db.close()))
+      db.enableLoadExtension(false)
 
       if (options.disableWAL !== true) {
-        db.pragma("journal_mode = WAL")
+        db.exec("PRAGMA journal_mode = WAL")
       }
 
       const prepareCache = yield* Cache.make({
@@ -147,23 +188,62 @@ export const make = (
       })
 
       const runStatement = (
-        statement: Sqlite.Statement,
+        statement: StatementSync,
         params: ReadonlyArray<unknown>,
         raw: boolean
       ) =>
         Effect.withFiber<ReadonlyArray<any>, SqlError>((fiber) => {
-          if (Context.get(fiber.context, Client.SafeIntegers)) {
-            statement.safeIntegers(true)
-          }
-          try {
-            if (statement.reader) {
-              return Effect.succeed(statement.all(...params))
-            }
-            const result = statement.run(...params)
-            return Effect.succeed(raw ? result as unknown as ReadonlyArray<any> : [])
-          } catch (cause) {
-            return Effect.fail(new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") }))
-          }
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
+          return Effect.try({
+            try: () => {
+              statement.setReadBigInts(useSafeIntegers)
+              if (hasResultColumns(statement)) {
+                return normalizeRows(statement.all(...(params as Array<any>))) as ReadonlyArray<any>
+              }
+              const result = statement.run(...(params as Array<any>))
+              return raw ? { changes: result.changes, lastInsertRowid: result.lastInsertRowid } as any : []
+            },
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          })
+        })
+
+      const runStatementValues = (
+        statement: StatementSync,
+        params: ReadonlyArray<unknown>
+      ) =>
+        Effect.withFiber<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>((fiber) => {
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
+          return Effect.try({
+            try: () => {
+              statement.setReadBigInts(useSafeIntegers)
+              if (hasResultColumns(statement)) {
+                return statement.all(...(params as Array<any>)) as unknown as ReadonlyArray<ReadonlyArray<unknown>>
+              }
+              statement.run(...(params as Array<any>))
+              return []
+            },
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          })
+        })
+
+      const runStatementValuesUnprepared = (
+        statement: StatementSync,
+        params: ReadonlyArray<unknown>
+      ) =>
+        Effect.withFiber<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>((fiber) => {
+          const useSafeIntegers = Context.get(fiber.context, Client.SafeIntegers)
+          return Effect.try({
+            try: () => {
+              statement.setReadBigInts(useSafeIntegers)
+              statement.setReturnArrays(true)
+              if (hasResultColumns(statement)) {
+                return statement.all(...(params as Array<any>)) as unknown as ReadonlyArray<ReadonlyArray<unknown>>
+              }
+              statement.run(...(params as Array<any>))
+              return []
+            },
+            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+          })
         })
 
       const run = (
@@ -183,40 +263,17 @@ export const make = (
         Effect.acquireUseRelease(
           Cache.get(prepareCache, sql),
           (statement) =>
-            Effect.try({
-              try: () => {
-                if (statement.reader) {
-                  statement.raw(true)
-                  return statement.all(...params) as ReadonlyArray<
-                    ReadonlyArray<unknown>
-                  >
-                }
-                statement.run(...params)
-                return []
-              },
-              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
-            }),
-          (statement) => Effect.sync(() => statement.reader && statement.raw(false))
+            Effect.andThen(
+              Effect.sync(() => statement.setReturnArrays(true)),
+              runStatementValues(statement, params)
+            ),
+          (statement) => Effect.sync(() => statement.setReturnArrays(false))
         )
 
       const runValuesUnprepared = (
         sql: string,
         params: ReadonlyArray<unknown>
-      ) =>
-        Effect.try({
-          try: () => {
-            const statement = db.prepare(sql)
-            if (statement.reader) {
-              statement.raw(true)
-              return statement.all(...params) as ReadonlyArray<
-                ReadonlyArray<unknown>
-              >
-            }
-            statement.run(...params)
-            return []
-          },
-          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
-        })
+      ) => runStatementValuesUnprepared(db.prepare(sql), params)
 
       return identity<SqliteConnection>({
         execute(sql, params, transformRows) {
@@ -240,22 +297,33 @@ export const make = (
         executeStream(_sql, _params) {
           return Stream.die("executeStream not implemented")
         },
-        export: Effect.try({
-          try: () => db.serialize(),
+        export: Effect.tryPromise({
+          try: () => exportDatabase(db),
           catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to export database", "export") })
         }),
         backup(destination) {
+          let totalPages = 0
           return Effect.tryPromise({
-            try: () => db.backup(destination),
+            try: () =>
+              backupDatabase(db, destination, {
+                progress: (progress) => {
+                  totalPages = progress.totalPages
+                }
+              }).then((pages): BackupMetadata => ({ totalPages: totalPages || pages, remainingPages: 0 })),
             catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to backup database", "backup") })
           })
         },
         loadExtension(path) {
-          return Effect.try({
-            try: () => db.loadExtension(path),
-            catch: (cause) =>
-              new SqlError({ reason: classifyError(cause, "Failed to load extension", "loadExtension") })
-          })
+          return Effect.acquireUseRelease(
+            Effect.sync(() => db.enableLoadExtension(true)),
+            () =>
+              Effect.try({
+                try: () => db.loadExtension(path),
+                catch: (cause) =>
+                  new SqlError({ reason: classifyError(cause, "Failed to load extension", "loadExtension") })
+              }),
+            () => Effect.sync(() => db.enableLoadExtension(false))
+          )
         }
       })
     })

--- a/packages/sql/sqlite-node/src/SqliteClient.ts
+++ b/packages/sql/sqlite-node/src/SqliteClient.ts
@@ -4,7 +4,7 @@
  * This module opens a SQLite database and exposes it as both `SqliteClient` and
  * the generic Effect SQL client. It serializes access through one connection,
  * caches prepared statements, enables WAL mode unless disabled, and supports
- * database export, backup, and extension loading. Streaming queries and
+ * database backup, and extension loading. Streaming queries and
  * `updateValues` are not supported by this driver.
  *
  * @since 4.0.0
@@ -25,51 +25,10 @@ import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
 import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
-import { mkdtempSync, readFileSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
 import { backup as backupDatabase, DatabaseSync } from "node:sqlite"
 import type { StatementSync } from "node:sqlite"
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
-
-const sqliteCauseWithErrno = (cause: unknown): unknown => {
-  if (typeof cause !== "object" || cause === null || !("errcode" in cause) || "errno" in cause) {
-    return cause
-  }
-  const errcode = (cause as { readonly errcode: unknown }).errcode
-  if (typeof errcode !== "number") {
-    return cause
-  }
-  return {
-    cause,
-    code: "code" in cause ? (cause as { readonly code: unknown }).code : undefined,
-    errno: errcode,
-    message: "message" in cause ? (cause as { readonly message: unknown }).message : undefined
-  }
-}
-
-const classifyError = (cause: unknown, message: string, operation: string) =>
-  classifySqliteError(sqliteCauseWithErrno(cause), { message, operation })
-
-const normalizeRows = (rows: ReadonlyArray<Record<string, unknown>>): ReadonlyArray<Record<string, unknown>> =>
-  rows.map((row) => ({ ...row }))
-
-const hasResultColumns = (statement: StatementSync): boolean => statement.columns().length > 0
-
-const exportDatabase = (db: DatabaseSync): Promise<Uint8Array> => {
-  const serialize = (db as { readonly serialize?: () => Uint8Array }).serialize
-  if (serialize !== undefined) {
-    return Promise.resolve(serialize.call(db))
-  }
-  return Promise.resolve().then(() => {
-    const directory = mkdtempSync(join(tmpdir(), "effect-sqlite-node-"))
-    const destination = join(directory, "export.db")
-    return backupDatabase(db, destination).then((): Uint8Array => readFileSync(destination)).finally(() => {
-      rmSync(directory, { recursive: true, force: true })
-    })
-  })
-}
 
 /**
  * Runtime type identifier used to mark Node `SqliteClient` values.
@@ -96,7 +55,6 @@ export type TypeId = "~@effect/sql-sqlite-node/SqliteClient"
 export interface SqliteClient extends Client.SqlClient {
   readonly [TypeId]: TypeId
   readonly config: SqliteClientConfig
-  readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly backup: (destination: string) => Effect.Effect<BackupMetadata, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 
@@ -142,7 +100,6 @@ export interface SqliteClientConfig {
 }
 
 interface SqliteConnection extends Connection {
-  readonly export: Effect.Effect<Uint8Array, SqlError>
   readonly backup: (destination: string) => Effect.Effect<BackupMetadata, SqlError>
   readonly loadExtension: (path: string) => Effect.Effect<void, SqlError>
 }
@@ -197,8 +154,8 @@ export const make = (
           return Effect.try({
             try: () => {
               statement.setReadBigInts(useSafeIntegers)
-              if (hasResultColumns(statement)) {
-                return normalizeRows(statement.all(...(params as Array<any>))) as ReadonlyArray<any>
+              if (statement.columns().length > 0) {
+                return statement.all(...(params as Array<any>)) as ReadonlyArray<any>
               }
               const result = statement.run(...(params as Array<any>))
               return raw ? { changes: result.changes, lastInsertRowid: result.lastInsertRowid } as any : []
@@ -216,7 +173,7 @@ export const make = (
           return Effect.try({
             try: () => {
               statement.setReadBigInts(useSafeIntegers)
-              if (hasResultColumns(statement)) {
+              if (statement.columns().length > 0) {
                 return statement.all(...(params as Array<any>)) as unknown as ReadonlyArray<ReadonlyArray<unknown>>
               }
               statement.run(...(params as Array<any>))
@@ -236,7 +193,7 @@ export const make = (
             try: () => {
               statement.setReadBigInts(useSafeIntegers)
               statement.setReturnArrays(true)
-              if (hasResultColumns(statement)) {
+              if (statement.columns().length > 0) {
                 return statement.all(...(params as Array<any>)) as unknown as ReadonlyArray<ReadonlyArray<unknown>>
               }
               statement.run(...(params as Array<any>))
@@ -262,11 +219,10 @@ export const make = (
       ) =>
         Effect.acquireUseRelease(
           Cache.get(prepareCache, sql),
-          (statement) =>
-            Effect.andThen(
-              Effect.sync(() => statement.setReturnArrays(true)),
-              runStatementValues(statement, params)
-            ),
+          (statement) => {
+            statement.setReturnArrays(true)
+            return runStatementValues(statement, params)
+          },
           (statement) => Effect.sync(() => statement.setReturnArrays(false))
         )
 
@@ -297,20 +253,18 @@ export const make = (
         executeStream(_sql, _params) {
           return Stream.die("executeStream not implemented")
         },
-        export: Effect.tryPromise({
-          try: () => exportDatabase(db),
-          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to export database", "export") })
-        }),
         backup(destination) {
-          let totalPages = 0
-          return Effect.tryPromise({
-            try: () =>
-              backupDatabase(db, destination, {
-                progress: (progress) => {
-                  totalPages = progress.totalPages
-                }
-              }).then((pages): BackupMetadata => ({ totalPages: totalPages || pages, remainingPages: 0 })),
-            catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to backup database", "backup") })
+          return Effect.suspend(() => {
+            let totalPages = 0
+            return Effect.tryPromise({
+              try: () =>
+                backupDatabase(db, destination, {
+                  progress: (progress) => {
+                    totalPages = progress.totalPages
+                  }
+                }).then((pages): BackupMetadata => ({ totalPages: totalPages || pages, remainingPages: 0 })),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to backup database", "backup") })
+            })
           })
         },
         loadExtension(path) {
@@ -358,7 +312,6 @@ export const make = (
       {
         [TypeId]: TypeId as TypeId,
         config: options,
-        export: Effect.flatMap(acquirer, (_) => _.export),
         backup: (destination: string) => Effect.flatMap(acquirer, (_) => _.backup(destination)),
         loadExtension: (path: string) => Effect.flatMap(acquirer, (_) => _.loadExtension(path))
       }
@@ -400,3 +353,19 @@ export const layer = (
         Context.add(Client.SqlClient, client)
       ))
   ).pipe(Layer.provide(Reactivity.layer))
+
+// internal
+
+const classifyError = (cause: unknown, message: string, operation: string) =>
+  classifySqliteError(sqliteCauseWithErrno(cause), { message, operation })
+
+const sqliteCauseWithErrno = (cause: unknown): unknown => {
+  if (typeof cause !== "object" || cause === null || !("errcode" in cause) || "errno" in cause) {
+    return cause
+  }
+  const errcode = (cause as { readonly errcode: unknown }).errcode
+  if (typeof errcode !== "number") {
+    return cause
+  }
+  return Object.assign(cause, { errno: errcode })
+}

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -74,4 +74,18 @@ describe("Client", () => {
       const rows = yield* sql`SELECT * FROM test`
       assert.deepStrictEqual(rows, [])
     }))
+
+  it.effect("supports backup and export", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql`INSERT INTO test (name) VALUES ('hello')`
+
+      const exported = yield* sql.export
+      assert(exported.byteLength > 0)
+
+      const metadata = yield* sql.backup(sql.config.filename + ".backup")
+      assert(metadata.totalPages > 0)
+      assert.strictEqual(metadata.remainingPages, 0)
+    }))
 })

--- a/packages/sql/sqlite-node/test/Client.test.ts
+++ b/packages/sql/sqlite-node/test/Client.test.ts
@@ -81,9 +81,6 @@ describe("Client", () => {
       yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
       yield* sql`INSERT INTO test (name) VALUES ('hello')`
 
-      const exported = yield* sql.export
-      assert(exported.byteLength > 0)
-
       const metadata = yield* sql.backup(sql.config.filename + ".backup")
       assert(metadata.totalPages > 0)
       assert.strictEqual(metadata.remainingPages, 0)

--- a/packages/sql/sqlite-node/tsconfig.json
+++ b/packages/sql/sqlite-node/tsconfig.json
@@ -4,5 +4,8 @@
   "include": ["src"],
   "references": [
     { "path": "../../effect" }
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,17 +650,13 @@ importers:
         version: link:../../effect
 
   packages/sql/sqlite-node:
-    dependencies:
-      better-sqlite3:
-        specifier: ^12.9.0
-        version: 12.9.0
     devDependencies:
       '@effect/platform-node':
         specifier: workspace:^
         version: link:../../platform-node
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.7.0
       effect:
         specifier: workspace:^
         version: link:../../effect
@@ -3180,9 +3176,6 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
@@ -3730,10 +3723,6 @@ packages:
   better-sqlite3@12.10.0:
     resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
-
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -9203,10 +9192,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 25.7.0
-
   '@types/bun@1.3.13':
     dependencies:
       bun-types: 1.3.13
@@ -9872,11 +9857,6 @@ snapshots:
       is-windows: 1.0.2
 
   better-sqlite3@12.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
-  better-sqlite3@12.9.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
## Summary

- Replaced @effect/sql-sqlite-node's better-sqlite3 driver with Node.js' built-in node:sqlite DatabaseSync APIs.
- Updated package metadata, README, TypeScript config, and lockfile to remove the package-level better-sqlite3 dependency.
- Added coverage for the SQLite backup and export helpers.

## Validation

- pnpm lint-fix
- pnpm --dir packages/sql/sqlite-node test
- pnpm check:tsgo
