### PR TITLE
Add a DuckDB adapter for Effect SQL

### DIFF
--- a/.changeset/duckdb-sql-adapter.md
+++ b/.changeset/duckdb-sql-adapter.md
@@ -1,0 +1,6 @@
+---
+"effect": patch
+"@effect/sql-duckdb": patch
+---
+
+Add a DuckDB adapter for Effect SQL, backed by `@duckdb/node-api`.

--- a/ai-docs/package.json
+++ b/ai-docs/package.json
@@ -16,6 +16,7 @@
     "@effect/platform-node": "workspace:*",
     "@effect/sql-clickhouse": "workspace:*",
     "@effect/sql-d1": "workspace:*",
+    "@effect/sql-duckdb": "workspace:*",
     "@effect/sql-libsql": "workspace:*",
     "@effect/sql-mssql": "workspace:*",
     "@effect/sql-mysql2": "workspace:*",

--- a/packages/effect/src/unstable/sql/Statement.ts
+++ b/packages/effect/src/unstable/sql/Statement.ts
@@ -57,7 +57,7 @@ export const fragment = (
  * @category models
  * @since 4.0.0
  */
-export type Dialect = "sqlite" | "pg" | "mysql" | "mssql" | "clickhouse"
+export type Dialect = "sqlite" | "pg" | "mysql" | "mssql" | "clickhouse" | "duckdb"
 
 /**
  * Executable SQL statement that is also a `Fragment` and `Effect`, with helpers
@@ -503,22 +503,24 @@ export interface Constructor {
     fallback?: string
   ) => (clauses: ReadonlyArray<string | Fragment>) => Fragment
 
-  readonly onDialect: <A, B, C, D, E>(options: {
+  readonly onDialect: <A, B, C, D, E, F>(options: {
     readonly sqlite: () => A
     readonly pg: () => B
     readonly mysql: () => C
     readonly mssql: () => D
     readonly clickhouse: () => E
-  }) => A | B | C | D | E
+    readonly duckdb: () => F
+  }) => A | B | C | D | E | F
 
-  readonly onDialectOrElse: <A, B = never, C = never, D = never, E = never, F = never>(options: {
+  readonly onDialectOrElse: <A, B = never, C = never, D = never, E = never, F = never, G = never>(options: {
     readonly orElse: () => A
     readonly sqlite?: () => B
     readonly pg?: () => C
     readonly mysql?: () => D
     readonly mssql?: () => E
     readonly clickhouse?: () => F
-  }) => A | B | C | D | E | F
+    readonly duckdb?: () => G
+  }) => A | B | C | D | E | F | G
 }
 
 /**

--- a/packages/sql/duckdb/CHANGELOG.md
+++ b/packages/sql/duckdb/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @effect/sql-duckdb

--- a/packages/sql/duckdb/LICENSE
+++ b/packages/sql/duckdb/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Effectful Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sql/duckdb/README.md
+++ b/packages/sql/duckdb/README.md
@@ -1,0 +1,5 @@
+# `@effect/sql-duckdb`
+
+This package provides a DuckDB adapter for Effect SQL.
+
+- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/sql-duckdb).

--- a/packages/sql/duckdb/docgen.json
+++ b/packages/sql/duckdb/docgen.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../node_modules/@effect/docgen/schema.json",
+  "srcLink": "https://github.com/Effect-TS/effect-smol/tree/main/packages/sql/duckdb/src/",
+  "exclude": ["src/internal/**/*.ts"],
+  "tscExecutable": "tsgo",
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rewriteRelativeImportExtensions": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "effect": ["../../../effect/src/index.js"],
+      "effect/*": ["../../../effect/src/*.js"]
+    },
+    "plugins": [
+      { "name": "@effect/language-service", "includeSuggestionsInTsc": false }
+    ]
+  }
+}

--- a/packages/sql/duckdb/package.json
+++ b/packages/sql/duckdb/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@effect/sql-duckdb",
+  "version": "4.0.0-beta.90",
+  "type": "module",
+  "license": "MIT",
+  "description": "A DuckDB toolkit for Effect",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect-smol.git",
+    "directory": "packages/sql/duckdb"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect-smol/issues"
+  },
+  "tags": [
+    "typescript",
+    "sql",
+    "duckdb",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "sql",
+    "duckdb",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "codegen": "effect-utils codegen",
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "build:tsgo": "tsgo -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "devDependencies": {
+    "effect": "workspace:^"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^"
+  },
+  "dependencies": {
+    "@duckdb/node-api": "^1.5.4-r.1"
+  }
+}

--- a/packages/sql/duckdb/src/Duckdb.ts
+++ b/packages/sql/duckdb/src/Duckdb.ts
@@ -1,0 +1,23 @@
+/**
+ * Re-exports the public `@duckdb/node-api` surface used by the DuckDB SQL
+ * adapter, including value constructors, logical type constructors, data
+ * chunks, appenders, prepared statements, and scalar functions.
+ *
+ * @since 4.0.0
+ */
+
+import duckdbDefault from "@duckdb/node-api"
+
+/**
+ * Default `@duckdb/node-api` export.
+ *
+ * @category re-exports
+ * @since 4.0.0
+ */
+export const duckdb = duckdbDefault
+
+/**
+ * @category re-exports
+ * @since 4.0.0
+ */
+export * from "@duckdb/node-api"

--- a/packages/sql/duckdb/src/DuckdbClient.ts
+++ b/packages/sql/duckdb/src/DuckdbClient.ts
@@ -1,0 +1,899 @@
+/**
+ * DuckDB driver for Effect SQL, backed by `@duckdb/node-api`.
+ *
+ * This module can create a managed DuckDB instance, connect to an existing
+ * instance, or wrap an existing connection. It exposes both the DuckDB-specific
+ * {@link DuckdbClient} service and the generic Effect SQL client service. Rows
+ * are returned as JavaScript values by default, while native DuckDB values and
+ * JSON-compatible values are available through configuration. DuckDB does not
+ * support SQL savepoints, so nested transaction failures roll back the outer
+ * transaction.
+ *
+ * @since 4.0.0
+ */
+import * as DuckDB from "@duckdb/node-api"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import * as Stream from "effect/Stream"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Client from "effect/unstable/sql/SqlClient"
+import type { Connection as SqlConnection } from "effect/unstable/sql/SqlConnection"
+import {
+  ConnectionError,
+  ConstraintError,
+  LockTimeoutError,
+  SerializationError,
+  SqlError,
+  SqlSyntaxError,
+  StatementTimeoutError,
+  UniqueViolation,
+  UnknownError
+} from "effect/unstable/sql/SqlError"
+import type { Custom, Fragment } from "effect/unstable/sql/Statement"
+import * as Statement from "effect/unstable/sql/Statement"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const TypedParameterTypeId = "~@effect/sql-duckdb/DuckdbClient/TypedParameter"
+let clientIdCounter = 0
+
+/**
+ * Runtime type identifier used to mark `DuckdbClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-duckdb/DuckdbClient"
+
+/**
+ * Type-level identifier used to mark `DuckdbClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-duckdb/DuckdbClient"
+
+/**
+ * Result conversion mode for DuckDB query rows.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ResultMode = "js" | "native" | "json"
+
+/**
+ * DuckDB-specific `SqlClient` extension with access to the live connection,
+ * optional instance, typed parameter fragments, appender/prepared statement
+ * helpers, query interruption/progress, table-name discovery, and scalar
+ * function registration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DuckdbClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId
+  readonly config: DuckdbClientConfig
+  readonly instance: DuckDB.DuckDBInstance | undefined
+  readonly connection: DuckDB.DuckDBConnection
+  readonly typed: (value: unknown, type: DuckDB.DuckDBType) => Fragment
+  readonly interrupt: Effect.Effect<void, SqlError>
+  readonly progress: Effect.Effect<DuckDB.DuckDBConnection["progress"]>
+  readonly getTableNames: (
+    query: string,
+    qualified?: boolean | undefined
+  ) => Effect.Effect<ReadonlyArray<string>, SqlError>
+  readonly createAppender: (
+    table: string,
+    options?: {
+      readonly schema?: string | null | undefined
+      readonly catalog?: string | null | undefined
+    } | undefined
+  ) => Effect.Effect<DuckDB.DuckDBAppender, SqlError, Scope.Scope>
+  readonly prepare: (sql: string) => Effect.Effect<DuckDB.DuckDBPreparedStatement, SqlError, Scope.Scope>
+  readonly extractStatements: (sql: string) => Effect.Effect<DuckDB.DuckDBExtractedStatements, SqlError, Scope.Scope>
+  readonly registerScalarFunction: (scalarFunction: DuckDB.DuckDBScalarFunction) => Effect.Effect<void, SqlError>
+}
+
+/**
+ * Service tag for the active DuckDB SQL client.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const DuckdbClient = Context.Service<DuckdbClient>("@effect/sql-duckdb/DuckdbClient")
+
+/**
+ * Configuration for a DuckDB client, either by creating an instance, wrapping an
+ * existing instance, or wrapping an existing connection.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type DuckdbClientConfig =
+  | DuckdbClientConfig.Create
+  | DuckdbClientConfig.LiveInstance
+  | DuckdbClientConfig.LiveConnection
+
+/**
+ * Namespace containing the configuration variants for `DuckdbClient`.
+ *
+ * @since 4.0.0
+ */
+export declare namespace DuckdbClientConfig {
+  /**
+   * Shared DuckDB client options for span attributes, query/result name
+   * transformations, and result value conversion.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Base {
+    readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly transformResultNames?: ((str: string) => string) | undefined
+    readonly transformQueryNames?: ((str: string) => string) | undefined
+    readonly resultMode?: ResultMode | undefined
+  }
+
+  /**
+   * Configuration used to create a managed DuckDB instance.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Create extends Base {
+    readonly path?: string | undefined
+    readonly configuration?: Record<string, string> | undefined
+    readonly readonly?: boolean | undefined
+    readonly cache?: boolean | undefined
+  }
+
+  /**
+   * Configuration that connects to an existing DuckDB instance. The supplied
+   * instance is caller-owned unless `closeInstance` is set to `true`.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface LiveInstance extends Base {
+    readonly liveInstance: DuckDB.DuckDBInstance
+    readonly closeInstance?: boolean | undefined
+  }
+
+  /**
+   * Configuration that wraps an existing DuckDB connection. The supplied
+   * connection and instance are caller-owned unless the close flags are set.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface LiveConnection extends Base {
+    readonly liveConnection: DuckDB.DuckDBConnection
+    readonly liveInstance?: DuckDB.DuckDBInstance | undefined
+    readonly closeConnection?: boolean | undefined
+    readonly closeInstance?: boolean | undefined
+  }
+
+  /**
+   * Config-friendly subset of DuckDB creation options.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface ConfigBase extends Base {
+    readonly path?: string | undefined
+    readonly configuration?: Record<string, string> | undefined
+    readonly readonly?: boolean | undefined
+    readonly cache?: boolean | undefined
+  }
+}
+
+interface TypedParameter {
+  readonly [TypedParameterTypeId]: typeof TypedParameterTypeId
+  readonly value: DuckDB.DuckDBValue
+  readonly type: DuckDB.DuckDBType
+}
+
+interface TransactionState {
+  readonly rollback: {
+    value: boolean
+  }
+}
+
+const TransactionState = Context.Service<TransactionState>("@effect/sql-duckdb/DuckdbClient/TransactionState")
+
+type NormalizedParameters = readonly [
+  values: ReadonlyArray<DuckDB.DuckDBValue> | undefined,
+  types: ReadonlyArray<DuckDB.DuckDBType | undefined> | undefined
+]
+
+/**
+ * Creates a scoped DuckDB SQL client. When `cache` is true, the client uses
+ * DuckDB's process-local instance cache and only closes the connection.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (
+  options: DuckdbClientConfig.Create = {}
+): Effect.Effect<DuckdbClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const configuration = makeConfiguration(options)
+    const instance = options.cache === true
+      ? yield* Effect.tryPromise({
+        try: () => DuckDB.DuckDBInstance.fromCache(options.path, configuration),
+        catch: (cause) =>
+          new SqlError({
+            reason: classifyError(cause, "DuckdbClient: Failed to create instance", "connect", "connection")
+          })
+      })
+      : yield* Effect.acquireRelease(
+        Effect.tryPromise({
+          try: () => DuckDB.DuckDBInstance.create(options.path, configuration),
+          catch: (cause) =>
+            new SqlError({
+              reason: classifyError(cause, "DuckdbClient: Failed to create instance", "connect", "connection")
+            })
+        }),
+        closeInstance
+      )
+
+    return yield* fromInstance({
+      ...options,
+      liveInstance: instance,
+      closeInstance: false
+    })
+  })
+
+/**
+ * Creates a scoped DuckDB SQL client from an existing DuckDB instance.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromInstance = (
+  options:
+    & DuckdbClientConfig.Base
+    & {
+      readonly liveInstance: DuckDB.DuckDBInstance
+      readonly closeInstance?: boolean | undefined
+    }
+): Effect.Effect<DuckdbClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const connection = yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => options.liveInstance.connect(),
+        catch: (cause) =>
+          new SqlError({ reason: classifyError(cause, "DuckdbClient: Failed to connect", "connect", "connection") })
+      }),
+      (connection) =>
+        closeConnection(connection).pipe(
+          Effect.andThen(options.closeInstance === true ? closeInstance(options.liveInstance) : Effect.void)
+        )
+    )
+
+    return yield* fromConnection({
+      ...options,
+      liveConnection: connection,
+      closeConnection: false,
+      closeInstance: false
+    })
+  })
+
+/**
+ * Builds a `DuckdbClient` around an existing DuckDB connection.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const fromConnection = (
+  options:
+    & DuckdbClientConfig.Base
+    & {
+      readonly liveConnection: DuckDB.DuckDBConnection
+      readonly liveInstance?: DuckDB.DuckDBInstance | undefined
+      readonly closeConnection?: boolean | undefined
+      readonly closeInstance?: boolean | undefined
+    }
+): Effect.Effect<DuckdbClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    if (options.closeConnection === true || options.closeInstance === true) {
+      const scope = yield* Effect.scope
+      yield* Scope.addFinalizer(
+        scope,
+        (options.closeConnection === true ? closeConnection(options.liveConnection) : Effect.void).pipe(
+          Effect.andThen(
+            options.closeInstance === true && options.liveInstance !== undefined
+              ? closeInstance(options.liveInstance)
+              : Effect.void
+          )
+        )
+      )
+    }
+
+    const compiler = makeCompiler(options.transformQueryNames)
+    const transformRows = options.transformResultNames
+      ? Statement.defaultTransforms(options.transformResultNames).array
+      : undefined
+
+    const spanAttributes: Array<[string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "duckdb"]
+    ]
+
+    const semaphore = Semaphore.makeUnsafe(1)
+    const transactionService = Client.TransactionConnection(clientIdCounter++)
+    const connection = new DuckdbConnection(
+      options.liveConnection,
+      options.resultMode ?? "js",
+      options.liveInstance,
+      transactionService
+    )
+    const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
+    const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
+      const fiber = Fiber.getCurrent()!
+      const scope = Context.getUnsafe(fiber.context, Scope.Scope)
+      return Effect.as(
+        Effect.tap(
+          restore(semaphore.take(1)),
+          () => Scope.addFinalizer(scope, semaphore.release(1))
+        ),
+        connection
+      )
+    })
+
+    const client = yield* Client.make({
+      acquirer,
+      compiler,
+      transactionAcquirer,
+      transactionService,
+      spanAttributes,
+      transformRows
+    })
+    const withTransaction = makeWithTransaction({
+      connection,
+      semaphore,
+      transactionService
+    })
+
+    return Object.assign(
+      client,
+      {
+        [TypeId]: TypeId as TypeId,
+        config: options as DuckdbClientConfig,
+        instance: options.liveInstance,
+        connection: options.liveConnection,
+        withTransaction,
+        transactionService,
+        typed: (value: unknown, type: DuckDB.DuckDBType) => Statement.fragment([DuckdbTyped(value, type, undefined)]),
+        interrupt: Effect.try({
+          try: () => options.liveConnection.interrupt(),
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to interrupt query", "interrupt") })
+        }),
+        progress: Effect.sync(() => options.liveConnection.progress),
+        getTableNames: (query: string, qualified = false) =>
+          semaphore.withPermit(
+            Effect.try({
+              try: () => options.liveConnection.getTableNames(query, qualified),
+              catch: (cause) =>
+                new SqlError({ reason: classifyError(cause, "Failed to get table names", "getTableNames") })
+            })
+          ),
+        createAppender: (
+          table: string,
+          appenderOptions?: {
+            readonly schema?: string | null | undefined
+            readonly catalog?: string | null | undefined
+          } | undefined
+        ) =>
+          acquireWithPermit(
+            semaphore,
+            Effect.tryPromise({
+              try: () =>
+                options.liveConnection.createAppender(
+                  table,
+                  appenderOptions?.schema ?? undefined,
+                  appenderOptions?.catalog ?? undefined
+                ),
+              catch: (cause) =>
+                new SqlError({ reason: classifyError(cause, "Failed to create appender", "createAppender") })
+            }),
+            (appender) => Effect.sync(() => appender.closeSync()).pipe(Effect.ignore)
+          ),
+        prepare: (sql: string) =>
+          acquireWithPermit(
+            semaphore,
+            Effect.tryPromise({
+              try: () => options.liveConnection.prepare(sql),
+              catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") })
+            }),
+            (prepared) => Effect.sync(() => prepared.destroySync()).pipe(Effect.ignore)
+          ),
+        extractStatements: (sql: string) =>
+          acquireWithPermit(
+            semaphore,
+            Effect.tryPromise({
+              try: () => options.liveConnection.extractStatements(sql),
+              catch: (cause) =>
+                new SqlError({ reason: classifyError(cause, "Failed to extract statements", "extractStatements") })
+            }),
+            () => Effect.void
+          ),
+        registerScalarFunction: (scalarFunction: DuckDB.DuckDBScalarFunction) =>
+          semaphore.withPermit(
+            Effect.try({
+              try: () => options.liveConnection.registerScalarFunction(scalarFunction),
+              catch: (cause) =>
+                new SqlError({
+                  reason: classifyError(cause, "Failed to register scalar function", "registerScalarFunction")
+                })
+            })
+          )
+      }
+    )
+  })
+
+const acquireWithPermit = <A, E, R>(
+  semaphore: Semaphore.Semaphore,
+  acquire: Effect.Effect<A, E, R>,
+  release: (resource: A) => Effect.Effect<unknown>
+): Effect.Effect<A, E, R | Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.uninterruptibleMask((restore) =>
+      // Only release the permit if `take(1)` actually acquired it. Attaching the
+      // compensating release to `take` as well would over-release when `take` is
+      // interrupted while waiting (no permit held), driving the semaphore's
+      // permit count negative and permanently breaking serialization.
+      Effect.flatMap(restore(semaphore.take(1)), () =>
+        restore(acquire).pipe(
+          Effect.onError(() => semaphore.release(1))
+        ))
+    ),
+    (resource) => release(resource).pipe(Effect.andThen(semaphore.release(1)))
+  )
+
+class DuckdbConnection implements SqlConnection {
+  readonly connection: DuckDB.DuckDBConnection
+  readonly resultMode: ResultMode
+  readonly instance: DuckDB.DuckDBInstance | undefined
+  readonly transactionService: Context.Service<Client.TransactionConnection, Client.TransactionConnection.Service>
+
+  constructor(
+    connection: DuckDB.DuckDBConnection,
+    resultMode: ResultMode,
+    instance: DuckDB.DuckDBInstance | undefined,
+    transactionService: Context.Service<Client.TransactionConnection, Client.TransactionConnection.Service>
+  ) {
+    this.connection = connection
+    this.resultMode = resultMode
+    this.instance = instance
+    this.transactionService = transactionService
+  }
+
+  // `normalizeParameters` runs inside the `try` so a parameter that cannot be
+  // converted (e.g. an empty array, whose element type cannot be inferred)
+  // surfaces as a recoverable `SqlError` instead of an eager defect.
+  private runReader(method: string, sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.tryPromise({
+      try: () => {
+        const [values, types] = normalizeParameters(params)
+        return this.connection.runAndReadAll(sql, values as any, types as any)
+      },
+      catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", method) })
+    })
+  }
+
+  private runRaw(method: string, sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.tryPromise({
+      try: () => {
+        const [values, types] = normalizeParameters(params)
+        return this.connection.run(sql, values as any, types as any)
+      },
+      catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", method) })
+    })
+  }
+
+  execute(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    const rows = Effect.map(this.runReader("execute", sql, params), (reader) => getRowObjects(reader, this.resultMode))
+    return transformRows ? Effect.map(rows, transformRows) : rows
+  }
+
+  executeRaw(sql: string, params: ReadonlyArray<unknown>) {
+    return this.runRaw("executeRaw", sql, params)
+  }
+
+  executeValues(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.map(this.runReader("executeValues", sql, params), (reader) => getRows(reader, this.resultMode))
+  }
+
+  executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+    return this.executeValues(sql, params)
+  }
+
+  executeUnprepared(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    return this.execute(sql, params, transformRows)
+  }
+
+  executeStream(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    // oxlint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this
+    const mode = this.resultMode
+    const emit = (rows: ReadonlyArray<any>) =>
+      Stream.fromIterable(transformRows ? transformRows(rows as any) as any : rows)
+    // A DuckDB streaming result is bound to its connection and is silently
+    // truncated if any other statement runs on that connection before it is
+    // fully consumed. Outside a transaction we therefore stream on a dedicated
+    // connection (closed when the stream finishes/interrupts) so concurrent
+    // queries on the main connection — including per-row queries during
+    // consumption — cannot interfere. Inside a transaction (or when no instance
+    // is available to open a connection) we must use the routed connection to
+    // preserve transactional visibility, so we materialize the result up front
+    // to avoid the truncation hazard.
+    return Stream.unwrap(
+      Effect.gen(function*() {
+        const inTransaction = yield* Effect.serviceOption(self.transactionService)
+        if (inTransaction._tag === "Some" || self.instance === undefined) {
+          const reader = yield* self.runReader("executeStream", sql, params)
+          return emit(getRowObjects(reader, mode))
+        }
+        const connection = yield* Effect.acquireRelease(
+          Effect.tryPromise({
+            try: () => self.instance!.connect(),
+            catch: (cause) =>
+              new SqlError({ reason: classifyError(cause, "Failed to connect", "executeStream", "connection") })
+          }),
+          (connection) => closeConnection(connection)
+        )
+        const result = yield* Effect.tryPromise({
+          try: () => {
+            const [values, types] = normalizeParameters(params)
+            return connection.stream(sql, values as any, types as any)
+          },
+          catch: (cause) =>
+            new SqlError({ reason: classifyError(cause, "Failed to stream statement", "executeStream") })
+        })
+        return Stream.fromAsyncIterable(
+          rowObjectIterable(result, mode),
+          (cause) => new SqlError({ reason: classifyError(cause, "Failed to stream statement", "executeStream") })
+        ).pipe(Stream.flatMap(emit))
+      })
+    )
+  }
+}
+
+/**
+ * Creates a layer from an effect that acquires a `DuckdbClient`, providing both
+ * `DuckdbClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerFrom = <E, R>(
+  acquire: Effect.Effect<DuckdbClient, E, R>
+): Layer.Layer<DuckdbClient | Client.SqlClient, E, Exclude<R, Scope.Scope | Reactivity.Reactivity>> =>
+  Layer.effectContext(
+    Effect.map(acquire, (client) =>
+      Context.make(DuckdbClient, client).pipe(
+        Context.add(Client.SqlClient, client)
+      ))
+  ).pipe(Layer.provide(Reactivity.layer)) as any
+
+/**
+ * Creates a layer from a `Config`-wrapped DuckDB client configuration,
+ * providing both `DuckdbClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerConfig: (
+  config: Config.Wrap<DuckdbClientConfig.ConfigBase>
+) => Layer.Layer<DuckdbClient | Client.SqlClient, Config.ConfigError | SqlError> = (
+  config: Config.Wrap<DuckdbClientConfig.ConfigBase>
+): Layer.Layer<DuckdbClient | Client.SqlClient, Config.ConfigError | SqlError> =>
+  layerFrom(Effect.flatMap(Config.unwrap(config), (resolved) => make(resolved)))
+
+/**
+ * Creates a layer from a concrete DuckDB client configuration, providing both
+ * `DuckdbClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (
+  config?: DuckdbClientConfig.Create | undefined
+): Layer.Layer<DuckdbClient | Client.SqlClient, SqlError> => layerFrom(make(config))
+
+/**
+ * Creates the DuckDB statement compiler, using `?` placeholders and
+ * double-quoted identifiers.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeCompiler = (transform?: (_: string) => string): Statement.Compiler =>
+  Statement.makeCompiler<DuckdbCustom>({
+    dialect: "duckdb",
+    placeholder(_) {
+      return "?"
+    },
+    onIdentifier: transform ?
+      function(value, withoutTransform) {
+        return withoutTransform ? escape(value) : escape(transform(value))
+      } :
+      escape,
+    onRecordUpdate(placeholders, valueAlias, valueColumns, values, returning) {
+      return [
+        `(values ${placeholders}) AS ${valueAlias}${valueColumns}${returning ? ` RETURNING ${returning[0]}` : ""}`,
+        returning ?
+          values.flat().concat(returning[1]) :
+          values.flat()
+      ]
+    },
+    onCustom(type, placeholder) {
+      switch (type.kind) {
+        case "DuckdbTyped": {
+          return [
+            placeholder(undefined),
+            [makeTypedParameter(type.paramA, type.paramB)]
+          ]
+        }
+      }
+    }
+  })
+
+const makeWithTransaction = (options: {
+  readonly connection: DuckdbConnection
+  readonly semaphore: Semaphore.Semaphore
+  readonly transactionService: Context.Service<Client.TransactionConnection, Client.TransactionConnection.Service>
+}) =>
+// DuckDB does not support SAVEPOINT / ROLLBACK TO, so nested transactions are
+// modeled by marking the whole outer transaction for rollback on nested failure.
+<R, E, A>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | SqlError, R> =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.withFiber((fiber) => {
+      const services = fiber.context
+      const existing = Context.getOption(services, options.transactionService)
+      if (existing._tag === "Some") {
+        return Effect.flatMap(Effect.exit(restore(effect)), (exit) =>
+          Exit.isSuccess(exit)
+            ? exit
+            : markTransactionRollback(services).pipe(Effect.andThen(exit)))
+      }
+
+      return Effect.acquireUseRelease(
+        restore(options.semaphore.take(1)),
+        () => {
+          const state: TransactionState = { rollback: { value: false } }
+          const context = Context.mutate(services, (services) =>
+            services.pipe(
+              Context.add(options.transactionService, [options.connection, 0]),
+              Context.add(TransactionState, state)
+            ))
+          return options.connection.executeUnprepared("BEGIN", [], undefined).pipe(
+            Effect.flatMap(() => Effect.exit(Effect.provideContext(restore(effect), context))),
+            Effect.flatMap((exit) => {
+              const finalizer = Exit.isSuccess(exit) && state.rollback.value === false
+                ? options.connection.executeUnprepared("COMMIT", [], undefined)
+                : options.connection.executeUnprepared("ROLLBACK", [], undefined)
+              return Effect.flatMap(Effect.orDie(finalizer), () => exit)
+            })
+          )
+        },
+        () => options.semaphore.release(1)
+      )
+    })
+  )
+
+const markTransactionRollback = (context: Context.Context<never>) =>
+  Effect.sync(() => {
+    const state = Context.getOption(context, TransactionState)
+    if (state._tag === "Some") {
+      state.value.rollback.value = true
+    }
+  })
+
+const closeConnection = (connection: DuckDB.DuckDBConnection) =>
+  Effect.sync(() => connection.closeSync()).pipe(Effect.ignore)
+
+const closeInstance = (instance: DuckDB.DuckDBInstance) => Effect.sync(() => instance.closeSync()).pipe(Effect.ignore)
+
+const escape = Statement.defaultEscape("\"")
+
+type DuckdbCustom = DuckdbTyped
+interface DuckdbTyped extends Custom<"DuckdbTyped", unknown, DuckDB.DuckDBType> {}
+const DuckdbTyped = Statement.custom<DuckdbTyped>("DuckdbTyped")
+
+const makeTypedParameter = (value: unknown, type: DuckDB.DuckDBType): TypedParameter => ({
+  [TypedParameterTypeId]: TypedParameterTypeId,
+  value: normalizeValue(value),
+  type
+})
+
+const isTypedParameter = (u: unknown): u is TypedParameter =>
+  typeof u === "object" && u !== null && TypedParameterTypeId in u
+
+const makeConfiguration = (options: DuckdbClientConfig.Create): Record<string, string> | undefined => {
+  const configuration = { ...options.configuration }
+  if (options.readonly === true && configuration.access_mode === undefined) {
+    configuration.access_mode = "READ_ONLY"
+  }
+  return Object.keys(configuration).length === 0 ? undefined : configuration
+}
+
+const normalizeParameters = (params: ReadonlyArray<unknown>): NormalizedParameters => {
+  if (params.length === 0) {
+    return [undefined, undefined]
+  }
+  const values: Array<DuckDB.DuckDBValue> = new Array(params.length)
+  let types: Array<DuckDB.DuckDBType | undefined> | undefined
+  for (let i = 0; i < params.length; i++) {
+    const param = params[i]
+    if (isTypedParameter(param)) {
+      values[i] = param.value
+      if (types === undefined) {
+        types = new Array(params.length)
+      }
+      types[i] = param.type
+    } else {
+      values[i] = normalizeValue(param)
+    }
+  }
+  return [values, types]
+}
+
+const normalizeValue = (value: unknown): DuckDB.DuckDBValue => {
+  if (value === undefined || value === null) {
+    return null
+  }
+  switch (typeof value) {
+    case "boolean":
+    case "number":
+    case "bigint":
+    case "string": {
+      return value
+    }
+  }
+  if (value instanceof Date) {
+    return DuckDB.timestampMillisValue(BigInt(value.getTime()))
+  }
+  if (value instanceof Uint8Array) {
+    return DuckDB.blobValue(value)
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      // DuckDB cannot infer the element type of an empty list, so binding it
+      // would fail with an opaque `LIST(ANY)` error. Direct the caller to the
+      // typed-parameter API where the list type can be supplied explicitly.
+      throw new Error(
+        "Cannot bind an empty array: DuckDB cannot infer its element type. " +
+          "Use `sql.typed(value, DuckDB.LIST(<elementType>))` instead."
+      )
+    }
+    return DuckDB.listValue(value.map(normalizeValue))
+  }
+  if (typeof value === "object" && value !== null && value.constructor === Object) {
+    const entries: Record<string, DuckDB.DuckDBValue> = {}
+    for (const key in value as Record<string, unknown>) {
+      entries[key] = normalizeValue((value as Record<string, unknown>)[key])
+    }
+    return DuckDB.structValue(entries)
+  }
+  return value as DuckDB.DuckDBValue
+}
+
+const getRowObjects = (
+  reader: DuckDB.DuckDBResultReader,
+  mode: ResultMode
+): ReadonlyArray<any> => {
+  switch (mode) {
+    case "native": {
+      return reader.getRowObjects()
+    }
+    case "json": {
+      return reader.getRowObjectsJson()
+    }
+    case "js": {
+      return reader.getRowObjectsJS()
+    }
+  }
+}
+
+const getRows = (
+  reader: DuckDB.DuckDBResultReader,
+  mode: ResultMode
+): ReadonlyArray<ReadonlyArray<unknown>> => {
+  switch (mode) {
+    case "native": {
+      return reader.getRows() as ReadonlyArray<ReadonlyArray<unknown>>
+    }
+    case "json": {
+      return reader.getRowsJson() as ReadonlyArray<ReadonlyArray<unknown>>
+    }
+    case "js": {
+      return reader.getRowsJS() as ReadonlyArray<ReadonlyArray<unknown>>
+    }
+  }
+}
+
+const rowObjectIterable = (
+  result: DuckDB.DuckDBResult,
+  mode: ResultMode
+): AsyncIterable<ReadonlyArray<any>> => {
+  switch (mode) {
+    case "native": {
+      return result.yieldRowObjects()
+    }
+    case "json": {
+      return result.yieldRowObjectJson()
+    }
+    case "js": {
+      return result.yieldRowObjectJs()
+    }
+  }
+}
+
+const causeMessage = (cause: unknown): string => {
+  if (typeof cause === "object" && cause !== null && "message" in cause && typeof cause.message === "string") {
+    return cause.message
+  }
+  return String(cause)
+}
+
+const classifyError = (
+  cause: unknown,
+  message: string,
+  operation: string,
+  fallback: "connection" | "unknown" = "unknown"
+) => {
+  const props = { cause, message, operation }
+  const errorMessage = causeMessage(cause)
+  const lower = errorMessage.toLowerCase()
+
+  if (lower.includes("duplicate key") || lower.includes("unique constraint")) {
+    return new UniqueViolation({ ...props, constraint: duckdbConstraintFromMessage(errorMessage) })
+  }
+  if (lower.includes("constraint error") || lower.includes("violates")) {
+    return new ConstraintError(props)
+  }
+  if (lower.includes("parser error") || lower.includes("syntax error")) {
+    return new SqlSyntaxError(props)
+  }
+  if (lower.includes("transaction conflict") || lower.includes("write-write conflict")) {
+    return new SerializationError(props)
+  }
+  if (lower.includes("database is locked") || lower.includes("lock timeout")) {
+    return new LockTimeoutError(props)
+  }
+  if (lower.includes("interrupted") || lower.includes("cancelled") || lower.includes("canceled")) {
+    return new StatementTimeoutError(props)
+  }
+  return fallback === "connection" ? new ConnectionError(props) : new UnknownError(props)
+}
+
+const duckdbConstraintFromMessage = (message: string): string => {
+  const quoted = message.match(/constraint ["']([^"']+)["']/i)
+  if (quoted !== null) {
+    return quoted[1].trim() || "unknown"
+  }
+  const duplicate = message.match(/Duplicate key ["']?([^"'\n]+)["']?/i)
+  if (duplicate !== null) {
+    return duplicate[1].trim() || "unknown"
+  }
+  return "unknown"
+}

--- a/packages/sql/duckdb/src/DuckdbMigrator.ts
+++ b/packages/sql/duckdb/src/DuckdbMigrator.ts
@@ -1,0 +1,45 @@
+/**
+ * Runs database migrations for DuckDB projects that use Effect SQL.
+ *
+ * This module re-exports the shared migration loaders and errors, then provides
+ * `run` and `layer` helpers that apply pending migration files with the current
+ * `SqlClient`.
+ *
+ * @since 4.0.0
+ */
+import type * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Migrator from "effect/unstable/sql/Migrator"
+import type * as Client from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+
+/**
+ * @since 4.0.0
+ */
+export * from "effect/unstable/sql/Migrator"
+
+/**
+ * Runs SQL migrations using the configured `SqlClient`, returning the
+ * migrations that were applied.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const run: <R2 = never>(
+  options: Migrator.MigratorOptions<R2>
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R2
+> = Migrator.make({})
+
+/**
+ * Creates a layer that runs the configured SQL migrations during layer
+ * construction.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const layer = <R>(
+  options: Migrator.MigratorOptions<R>
+): Layer.Layer<never, Migrator.MigrationError | SqlError, Client.SqlClient | R> => Layer.effectDiscard(run(options))

--- a/packages/sql/duckdb/src/index.ts
+++ b/packages/sql/duckdb/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @since 4.0.0
+ */
+
+// @barrel: Auto-generated exports. Do not edit manually.
+
+/**
+ * @since 4.0.0
+ */
+export * as Duckdb from "./Duckdb.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as DuckdbClient from "./DuckdbClient.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as DuckdbMigrator from "./DuckdbMigrator.ts"

--- a/packages/sql/duckdb/test/Client.test.ts
+++ b/packages/sql/duckdb/test/Client.test.ts
@@ -1,0 +1,254 @@
+import * as Duckdb from "@duckdb/node-api"
+import { DuckdbClient } from "@effect/sql-duckdb"
+import { assert, describe, it, layer } from "@effect/vitest"
+import { Effect, Stream } from "effect"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+
+const ClientLayer = DuckdbClient.layer()
+
+const setup = (table: string) =>
+  Effect.gen(function*() {
+    const sql = yield* DuckdbClient.DuckdbClient
+    yield* sql.unsafe(`DROP TABLE IF EXISTS ${table}`)
+    yield* sql.unsafe(`CREATE TABLE ${table} (id INTEGER PRIMARY KEY, name VARCHAR)`)
+    return sql
+  })
+
+describe("DuckdbClient", () => {
+  layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("basic insert/select", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("basic_test")
+
+        yield* sql`INSERT INTO basic_test (id, name) VALUES (${1}, ${"hello"})`
+
+        const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM basic_test`
+        assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+
+        const values = yield* sql`SELECT id, name FROM basic_test`.values
+        assert.deepStrictEqual(values, [[1, "hello"]])
+
+        const raw = yield* sql`SELECT id, name FROM basic_test`.raw
+        assert.strictEqual((raw as Duckdb.DuckDBMaterializedResult).rowCount, 1)
+      }))
+
+    it.effect("compiler helpers", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+
+        const [insertQuery, insertParams] = sql`INSERT INTO people ${
+          sql.insert({ name: "Tim", age: 10 }).returning("*")
+        }`.compile()
+        assert.strictEqual(insertQuery, `INSERT INTO people ("name","age") VALUES (?,?) RETURNING *`)
+        assert.deepStrictEqual(insertParams, ["Tim", 10])
+
+        const [updateQuery, updateParams] = sql`UPDATE people SET ${sql.update({ name: "John" })}`.compile()
+        assert.strictEqual(updateQuery, `UPDATE people SET "name" = ?`)
+        assert.deepStrictEqual(updateParams, ["John"])
+
+        const [updateValuesQuery, updateValuesParams] = sql`UPDATE people SET name = data.name FROM ${
+          sql.updateValues([{ id: 1, name: "Tim" }, { id: 2, name: "John" }], "data")
+        } WHERE people.id = data.id`.compile()
+        assert.strictEqual(
+          updateValuesQuery,
+          `UPDATE people SET name = data.name FROM (values (?,?),(?,?)) AS data("id","name") WHERE people.id = data.id`
+        )
+        assert.deepStrictEqual(updateValuesParams, [1, "Tim", 2, "John"])
+
+        const [inQuery, inParams] = sql`SELECT * FROM ${sql("people")} WHERE id IN ${sql.in([1, 2, 3])}`.compile()
+        assert.strictEqual(inQuery, `SELECT * FROM "people" WHERE id IN (?,?,?)`)
+        assert.deepStrictEqual(inParams, [1, 2, 3])
+
+        assert.strictEqual(
+          sql.onDialect({
+            sqlite: () => "sqlite",
+            pg: () => "pg",
+            mysql: () => "mysql",
+            mssql: () => "mssql",
+            clickhouse: () => "clickhouse",
+            duckdb: () => "duckdb"
+          }),
+          "duckdb"
+        )
+      }))
+
+    it.effect("typed parameters and binary values", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        yield* sql`DROP TABLE IF EXISTS typed_test`
+        yield* sql`CREATE TABLE typed_test (id INTEGER, values INTEGER[], bytes BLOB)`
+
+        const bytes = Uint8Array.from([1, 2, 3])
+        yield* sql`INSERT INTO typed_test VALUES (${1}, ${sql.typed([1, 2, 3], Duckdb.LIST(Duckdb.INTEGER))}, ${bytes})`
+
+        const rows = yield* sql<{ id: number; values: ReadonlyArray<number>; bytes: Uint8Array }>`
+          SELECT id, values, bytes FROM typed_test
+        `
+        assert.strictEqual(rows[0].id, 1)
+        assert.deepStrictEqual(rows[0].values, [1, 2, 3])
+        assert.deepStrictEqual(rows[0].bytes, bytes)
+      }))
+
+    it.effect("streams rows", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        const rows = yield* sql<{ value: number }>`SELECT range::INTEGER AS value FROM range(3)`.stream.pipe(
+          Stream.runCollect
+        )
+        assert.deepStrictEqual(rows, [{ value: 0 }, { value: 1 }, { value: 2 }])
+      }))
+
+    it.effect("streaming is isolated from concurrent queries on the connection", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        // > 2048 rows so the result spans multiple DuckDB chunks.
+        yield* sql`CREATE OR REPLACE TABLE stream_iso AS SELECT range::INTEGER AS value FROM range(3000)`
+
+        let seen = 0
+        let sum = 0
+        // Run another query on the connection for every streamed row. With a
+        // shared connection this either truncated the stream silently or
+        // deadlocked; the dedicated stream connection makes it safe.
+        yield* sql<{ value: number }>`SELECT value FROM stream_iso ORDER BY value`.stream.pipe(
+          Stream.runForEach((row) =>
+            Effect.gen(function*() {
+              const echoed = yield* sql<{ c: number }>`SELECT ${row.value}::INTEGER AS c`
+              seen++
+              sum += echoed[0].c
+            })
+          )
+        )
+
+        assert.strictEqual(seen, 3000)
+        assert.strictEqual(sum, (2999 * 3000) / 2)
+      }))
+
+    it.effect("binding an empty array fails with a clear, actionable error", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        const error = yield* Effect.flip(sql`SELECT ${[]} AS value`)
+        assert.match(String((error.reason as any).cause?.message ?? (error.reason as any).cause), /empty array/i)
+      }))
+
+    it.effect("appender, scalar function, and table names", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        yield* sql`DROP TABLE IF EXISTS appender_test`
+        yield* sql`CREATE TABLE appender_test (id INTEGER, name VARCHAR)`
+
+        yield* Effect.scoped(
+          Effect.gen(function*() {
+            const appender = yield* sql.createAppender("appender_test")
+            yield* Effect.sync(() => {
+              appender.appendInteger(1)
+              appender.appendVarchar("duck")
+              appender.endRow()
+            })
+          })
+        )
+
+        const scalarFunction = Duckdb.DuckDBScalarFunction.create({
+          name: "effect_add_one",
+          parameterTypes: [Duckdb.INTEGER],
+          returnType: Duckdb.INTEGER,
+          mainFunction: (_info, input, output) => {
+            const inputVector = input.getColumnVector(0)
+            for (let i = 0; i < input.rowCount; i++) {
+              output.setItem(i, (inputVector.getItem(i) as number) + 1)
+            }
+            output.flush()
+          }
+        })
+        yield* sql.registerScalarFunction(scalarFunction)
+
+        const rows = yield* sql<{ id: number; name: string; id2: number }>`
+          SELECT id, name, effect_add_one(id) AS id2 FROM appender_test
+        `
+        assert.deepStrictEqual(rows, [{ id: 1, name: "duck", id2: 2 }])
+
+        const names = yield* sql.getTableNames("SELECT * FROM appender_test")
+        assert.deepStrictEqual(names, ["appender_test"])
+      }))
+
+    it.effect("scoped prepared statements", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        const rows = yield* Effect.scoped(
+          Effect.gen(function*() {
+            const prepared = yield* sql.prepare("SELECT $1::INTEGER AS value")
+            prepared.bind([42])
+            const reader = yield* Effect.tryPromise(() => prepared.runAndReadAll())
+            return reader.getRowObjectsJS()
+          })
+        )
+        assert.deepStrictEqual(rows, [{ value: 42 }])
+      }))
+
+    it.effect("classifies syntax and unique constraint errors", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("errors_test")
+
+        const syntax = yield* Effect.flip(sql.unsafe("SELEC 1"))
+        assert.strictEqual(syntax.reason._tag, "SqlSyntaxError")
+
+        yield* sql`INSERT INTO errors_test (id, name) VALUES (${1}, ${"one"})`
+        const duplicate = yield* Effect.flip(sql`INSERT INTO errors_test (id, name) VALUES (${1}, ${"two"})`)
+        assert.strictEqual(duplicate.reason._tag, "UniqueViolation")
+      }))
+  })
+
+  layer(DuckdbClient.layer({ resultMode: "json" }), { timeout: "30 seconds" })((it) => {
+    it.effect("json result mode", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        const rows = yield* sql<{ value: string }>`SELECT 9223372036854775807::BIGINT AS value`
+        assert.deepStrictEqual(rows, [{ value: "9223372036854775807" }])
+      }))
+  })
+
+  layer(
+    DuckdbClient.layer({
+      transformQueryNames: (name) => name.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`),
+      transformResultNames: (name) => name.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase())
+    }),
+    { timeout: "30 seconds" }
+  )((it) => {
+    it.effect("name transforms", () =>
+      Effect.gen(function*() {
+        const sql = yield* DuckdbClient.DuckdbClient
+        yield* sql`CREATE TABLE ${sql("peopleTest")} (${sql("firstName")} VARCHAR)`
+        yield* sql`INSERT INTO ${sql("peopleTest")} (${sql("firstName")}) VALUES (${"Tim"})`
+
+        const rows = yield* sql<{ firstName: string }>`SELECT ${sql("firstName")} FROM ${sql("peopleTest")}`
+        assert.deepStrictEqual(rows, [{ firstName: "Tim" }])
+      }))
+  })
+
+  describe("constructors", () => {
+    it.effect("fromInstance and fromConnection", () =>
+      Effect.gen(function*() {
+        const instance = yield* Effect.acquireRelease(
+          Effect.tryPromise(() => Duckdb.DuckDBInstance.create()),
+          (instance) => Effect.sync(() => instance.closeSync())
+        )
+
+        const fromInstance = yield* DuckdbClient.fromInstance({ liveInstance: instance })
+        const rows1 = yield* fromInstance<{ value: number }>`SELECT 1 AS value`
+        assert.deepStrictEqual(rows1, [{ value: 1 }])
+
+        const connection = yield* Effect.acquireRelease(
+          Effect.tryPromise(() => instance.connect()),
+          (connection) => Effect.sync(() => connection.closeSync())
+        )
+        const fromConnection = yield* DuckdbClient.fromConnection({
+          liveConnection: connection,
+          liveInstance: instance
+        })
+        const rows2 = yield* fromConnection<{ value: number }>`SELECT 2 AS value`
+        assert.deepStrictEqual(rows2, [{ value: 2 }])
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(Reactivity.layer)
+      ))
+  })
+})

--- a/packages/sql/duckdb/test/Migrator.test.ts
+++ b/packages/sql/duckdb/test/Migrator.test.ts
@@ -1,0 +1,31 @@
+import { DuckdbClient, DuckdbMigrator } from "@effect/sql-duckdb"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql/SqlClient"
+
+const ClientLayer = DuckdbClient.layer()
+
+describe("DuckdbMigrator", () => {
+  layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("runs migrations", () =>
+      Effect.gen(function*() {
+        const completed = yield* DuckdbMigrator.run({
+          loader: DuckdbMigrator.fromRecord({
+            "1_create": Effect.gen(function*() {
+              const sql = yield* SqlClient
+              yield* sql`CREATE TABLE migrated (id INTEGER PRIMARY KEY, name VARCHAR)`
+            }),
+            "2_insert": Effect.gen(function*() {
+              const sql = yield* SqlClient
+              yield* sql`INSERT INTO migrated VALUES (${1}, ${"duck"})`
+            })
+          })
+        })
+        assert.deepStrictEqual(completed, [[1, "create"], [2, "insert"]])
+
+        const sql = yield* DuckdbClient.DuckdbClient
+        const rows = yield* sql<{ id: number; name: string }>`SELECT * FROM migrated`
+        assert.deepStrictEqual(rows, [{ id: 1, name: "duck" }])
+      }))
+  })
+})

--- a/packages/sql/duckdb/test/Transaction.test.ts
+++ b/packages/sql/duckdb/test/Transaction.test.ts
@@ -1,0 +1,68 @@
+import { DuckdbClient } from "@effect/sql-duckdb"
+import { assert, describe, layer } from "@effect/vitest"
+import { Effect } from "effect"
+
+const ClientLayer = DuckdbClient.layer()
+
+const setup = (table: string) =>
+  Effect.gen(function*() {
+    const sql = yield* DuckdbClient.DuckdbClient
+    yield* sql.unsafe(`DROP TABLE IF EXISTS ${table}`)
+    yield* sql.unsafe(`CREATE TABLE ${table} (id INTEGER, name VARCHAR)`)
+    return sql
+  })
+
+describe("DuckdbClient transactions", () => {
+  layer(ClientLayer, { timeout: "30 seconds" })((it) => {
+    it.effect("withTransaction commit", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_commit")
+        yield* sql.withTransaction(sql.unsafe(`INSERT INTO tx_commit VALUES (1, 'hello')`))
+        const rows = yield* sql.unsafe<{ name: string }>(`SELECT name FROM tx_commit`)
+        assert.deepStrictEqual(rows, [{ name: "hello" }])
+      }))
+
+    it.effect("withTransaction rollback", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_rollback")
+        yield* sql.unsafe(`INSERT INTO tx_rollback VALUES (1, 'hello')`).pipe(
+          Effect.andThen(Effect.fail("boom")),
+          sql.withTransaction,
+          Effect.ignore
+        )
+        const rows = yield* sql.unsafe(`SELECT * FROM tx_rollback`)
+        assert.deepStrictEqual(rows, [])
+      }))
+
+    it.effect("nested transaction commits both", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_nested_commit")
+        const first = sql.unsafe(`INSERT INTO tx_nested_commit VALUES (1, 'hello')`)
+        const second = sql.unsafe(`INSERT INTO tx_nested_commit VALUES (2, 'world')`)
+        yield* first.pipe(Effect.andThen(() => second.pipe(sql.withTransaction)), sql.withTransaction)
+        const rows = yield* sql.unsafe<{ total: number }>(
+          `SELECT count(*)::INTEGER AS total FROM tx_nested_commit`
+        )
+        assert.strictEqual(rows.at(0)?.total, 2)
+      }))
+
+    it.effect("nested transaction failure rolls back the outer transaction", () =>
+      Effect.gen(function*() {
+        const sql = yield* setup("tx_nested_rollback")
+        yield* sql.unsafe(`INSERT INTO tx_nested_rollback VALUES (1, 'hello')`).pipe(
+          Effect.andThen(() =>
+            sql.unsafe(`INSERT INTO tx_nested_rollback VALUES (2, 'world')`).pipe(
+              Effect.andThen(Effect.fail("boom")),
+              sql.withTransaction,
+              Effect.ignore
+            )
+          ),
+          sql.withTransaction
+        )
+        const rows = yield* sql.unsafe<{ total: number }>(
+          `SELECT count(*)::INTEGER AS total FROM tx_nested_rollback`
+        )
+        assert.strictEqual(rows.at(0)?.total, 0)
+      }))
+  })
+})

--- a/packages/sql/duckdb/tsconfig.json
+++ b/packages/sql/duckdb/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" }
+  ]
+}

--- a/packages/sql/duckdb/vitest.config.ts
+++ b/packages/sql/duckdb/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/packages/sql/pg/test/Client.test.ts
+++ b/packages/sql/pg/test/Client.test.ts
@@ -208,7 +208,8 @@ it.layer(PgContainer.layerClient, { timeout: "30 seconds" })("PgClient", (it) =>
           pg: () => "B",
           mysql: () => "C",
           mssql: () => "D",
-          clickhouse: () => "E"
+          clickhouse: () => "E",
+          duckdb: () => "F"
         }),
         "B"
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         version: 4.22.1(core-js@3.47.0)(rolldown@1.0.0)(rollup@4.60.3)(vite@7.3.3(@types/node@25.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.27.2)(rollup@4.60.3)
+        version: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0)(rollup@4.60.3)
@@ -202,6 +202,9 @@ importers:
       '@effect/sql-d1':
         specifier: workspace:*
         version: link:../packages/sql/d1
+      '@effect/sql-duckdb':
+        specifier: workspace:*
+        version: link:../packages/sql/duckdb
       '@effect/sql-libsql':
         specifier: workspace:*
         version: link:../packages/sql/libsql
@@ -551,6 +554,16 @@ importers:
         specifier: ^4.20260507.1
         version: 4.20260507.1
 
+  packages/sql/duckdb:
+    dependencies:
+      '@duckdb/node-api':
+        specifier: ^1.5.4-r.1
+        version: 1.5.4-r.1
+    devDependencies:
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+
   packages/sql/libsql:
     dependencies:
       '@libsql/client':
@@ -749,7 +762,7 @@ importers:
         version: 4.60.3
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.27.2)(rollup@4.60.3)
+        version: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0)(rollup@4.60.3)
@@ -929,6 +942,9 @@ importers:
       '@effect/sql-d1':
         specifier: workspace:*
         version: link:../packages/sql/d1
+      '@effect/sql-duckdb':
+        specifier: workspace:*
+        version: link:../packages/sql/duckdb
       '@effect/sql-libsql':
         specifier: workspace:*
         version: link:../packages/sql/libsql
@@ -1602,36 +1618,43 @@ packages:
     resolution: {integrity: sha512-VhM7p70VFuNqxZMdiv1e+nMboPj/hMFlTIBWrRaX7+6VThs9mJr9+94wrUeXgfnfsyaEKSbRFa/dru1PINoSNw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-arm64-musl@0.54.0':
     resolution: {integrity: sha512-QS1A74Lv60/L9oemHCzbHgOLbV2smSJG5IxS5fjf8ZWetyUt918WDzIHBilz/+uiB+OlW2UVTsm952UG0YOrLw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-loong64-glibc@0.54.0':
     resolution: {integrity: sha512-8Myka2/0KbhuZnEKL6jagPXTgDKVpd/tfXDRa0oibUBgaqOSku6iRMzHGa/PhqHL+s14Gcp+/cIHz0zU3Tkgug==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-loong64-musl@0.54.0':
     resolution: {integrity: sha512-/AN3xCuMhC4PK7Pbj7/4zBuhFGr4m0OHV/5uGTfzpkKX/3+AXoyKl7PbT2VlNMGXAK0kuRThfjtx23gIwlWk7Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/linux-riscv64-glibc@0.54.0':
     resolution: {integrity: sha512-Aw2vXzzwFDpPbXh6ajsSabVCkCc66C3hCyMKprR/IxYvFtjYX80nh1ox0c7iaw6c4HacHMRLGw7FUSXvomPaEQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-glibc@0.54.0':
     resolution: {integrity: sha512-zZqj3wQELOX8n6QfT2uuWoMf64Wv0lMXNyam3btm+PKkg0P6a54TPL09Bs9XsViOdxgTcamsiQ7HlErt/LEjIA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-musl@0.54.0':
     resolution: {integrity: sha512-it6Qdt06dyW2adbAXpOCb7/KQLxlm4i1UphUAWqWsZk4t3EYetyAza9J0g3Vu9itIWSEIo9MnccgANckQJ6+qw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/win32-arm64@0.54.0':
     resolution: {integrity: sha512-F5kjV/6I9YtNOTDWHUpTqM2HHHS510BPL7z4NJuU0nDnaVeks7GwNEltGr56CcsG8XQYhkiAsqZytPu6AhA2hQ==}
@@ -1642,6 +1665,56 @@ packages:
     resolution: {integrity: sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg==}
     cpu: [x64]
     os: [win32]
+
+  '@duckdb/node-api@1.5.4-r.1':
+    resolution: {integrity: sha512-3PYk/4//svuYmb9RYVM71cCoNa6ngoYWwrMhJaqbm010txzIMWbJCbxrFeqDl+krdIug+Hc/MNCeS0gHsTXSIw==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.4-r.1':
+    resolution: {integrity: sha512-fl8EC5xdmI7VAI7bX4W6D7lOGNtxyLvSxGjOY8Ov7viVEKwIcBXXKlMPgh3sw+PiVlwZhKlknuCI8BL5xXpSDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.5.4-r.1':
+    resolution: {integrity: sha512-E8bECZ6abJqunPqVR1NA0Zho7qxanfDWWFuJrKMsU1NCUqyGLyhXqZwsRHAx7J6jrM+lhQ7wOZj1x/N4OVml3A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.4-r.1':
+    resolution: {integrity: sha512-96Pyk5Syy18S5DSN0CKkOQ7/CsyVGRML8ewox1qpFDjYvPH1VsULlQoIRwbpw7mkFEy17wuWmbwzb7oKu/nGMw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@duckdb/node-bindings-linux-arm64@1.5.4-r.1':
+    resolution: {integrity: sha512-4EsB+cgRqOE++mdPQ2ZoGJCg4ylmuqdbLDtmo3L19B+C5OzGmrhxlKD4o75eGEtfO52M+w+TdL0qhy0H5XvaKQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@duckdb/node-bindings-linux-x64-musl@1.5.4-r.1':
+    resolution: {integrity: sha512-tWgnttlKfWTktyv+m9YbxaedKBon5wmUoJ9DaIbE3D98KhhUaqmJhnjzso9O8hp6WUeRmwXR//hpT/X6Ft9nYA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@duckdb/node-bindings-linux-x64@1.5.4-r.1':
+    resolution: {integrity: sha512-IldapRydno5kf4VkPCe8yK+j4pCg+j6Qs46UmLnKex/mtIdJa7ifhMYRkvdc5KIAFEC0eEL5c830QeuwcUROyg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@duckdb/node-bindings-win32-arm64@1.5.4-r.1':
+    resolution: {integrity: sha512-77apmuNo51bPZzv8xjdeCp+hlU6JLwMPtS1CMViy83ONTsah+CGnpBx1lCnEqPL5Va0meufZyjSdZCVCijLdDA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.4-r.1':
+    resolution: {integrity: sha512-Wme7dScBGqjn2PUJ+RLFiFAblW1qQRBraX7SJc4uKtftZiUJJWZapEUh+doGfb68Qxvw8JhlMBSdaUsSUDJYsw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.5.4-r.1':
+    resolution: {integrity: sha512-v834OZZKQ59yAvh8GOEmM+R1foPNgdMGL0VTBgHywgblgQNyq11HvWgT4QGJIUFfo/cQ9WFyf1MFhK0+hV1aiA==}
 
   '@edge-runtime/primitives@6.0.0':
     resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
@@ -2095,89 +2168,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2527,21 +2616,25 @@ packages:
     resolution: {integrity: sha512-j4QzfCM8ks+OyM+KKYWDiBEQsm5RCW50H1Wz16wUyoFsobJ+X5qqcJxq6HvkE07m8euYmZelyB0WqsiDoz1v8g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-arm64-musl@1.42.0':
     resolution: {integrity: sha512-g5b1Uw7zo6yw4Ymzyd1etKzAY7xAaGA3scwB8tAp3QzuY7CYdfTwlhiLKSAKbd7T/JBgxOXAGNcLDorJyVTXcg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/linux-x64-gnu@1.42.0':
     resolution: {integrity: sha512-HnD99GD9qAbpV4q9iQil7mXZUJFpoBdDavfcC2CgGLPlawfcV5COzQPNwOgvPVkr7C0cBx6uNCq3S6r9IIiEIg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/linux-x64-musl@1.42.0':
     resolution: {integrity: sha512-8NTe8A78HHFn+nBi+8qMwIjgv9oIBh+9zqCPNLH56ah4vKOPvbePLI6NIv9qSkmzrBuu8SB+FJ2TH/G05UzbNA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/win32-arm64@1.42.0':
     resolution: {integrity: sha512-lAPS2YAuu+qFqoTNPFcNsxXjwSV0M+dOgAzzVTAN7Yo2ifj+oLOx0GsntWoM78PvQWI7Q827ZxqtU2ImBmDapA==}
@@ -2700,36 +2793,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -2857,131 +2956,157 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -4993,24 +5118,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -7954,6 +8083,47 @@ snapshots:
 
   '@dprint/win32-x64@0.54.0':
     optional: true
+
+  '@duckdb/node-api@1.5.4-r.1':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.4-r.1
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64-musl@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64-musl@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.5.4-r.1':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.4-r.1':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.5.4-r.1
+      '@duckdb/node-bindings-darwin-x64': 1.5.4-r.1
+      '@duckdb/node-bindings-linux-arm64': 1.5.4-r.1
+      '@duckdb/node-bindings-linux-arm64-musl': 1.5.4-r.1
+      '@duckdb/node-bindings-linux-x64': 1.5.4-r.1
+      '@duckdb/node-bindings-linux-x64-musl': 1.5.4-r.1
+      '@duckdb/node-bindings-win32-arm64': 1.5.4-r.1
+      '@duckdb/node-bindings-win32-x64': 1.5.4-r.1
 
   '@edge-runtime/primitives@6.0.0':
     optional: true
@@ -12431,11 +12601,11 @@ snapshots:
     transitivePeerDependencies:
       - core-js
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.27.2)(rollup@4.60.3):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.3):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.60.3
       unplugin-utils: 0.2.5
@@ -13118,7 +13288,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,6 +9,7 @@
     "@effect/platform-node": "workspace:*",
     "@effect/sql-clickhouse": "workspace:*",
     "@effect/sql-d1": "workspace:*",
+    "@effect/sql-duckdb": "workspace:*",
     "@effect/sql-libsql": "workspace:*",
     "@effect/sql-mysql2": "workspace:*",
     "@effect/sql-mssql": "workspace:*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,6 +65,8 @@
       "@effect/sql-clickhouse/*": ["./packages/sql/clickhouse/src/*.ts"],
       "@effect/sql-d1": ["./packages/sql/d1/src/index.ts"],
       "@effect/sql-d1/*": ["./packages/sql/d1/src/*.ts"],
+      "@effect/sql-duckdb": ["./packages/sql/duckdb/src/index.ts"],
+      "@effect/sql-duckdb/*": ["./packages/sql/duckdb/src/*.ts"],
       "@effect/sql-libsql": ["./packages/sql/libsql/src/index.ts"],
       "@effect/sql-libsql/*": ["./packages/sql/libsql/src/*.ts"],
       "@effect/sql-mssql": ["./packages/sql/mssql/src/index.ts"],

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -19,6 +19,7 @@
     { "path": "packages/platform-node-shared" },
     { "path": "packages/sql/clickhouse" },
     { "path": "packages/sql/d1" },
+    { "path": "packages/sql/duckdb" },
     { "path": "packages/sql/libsql" },
     { "path": "packages/sql/mysql2" },
     { "path": "packages/sql/mssql" },


### PR DESCRIPTION
## What

Adds a new `@effect/sql-duckdb` package — an Effect SQL adapter for [DuckDB](https://duckdb.org), backed by [`@duckdb/node-api`](https://www.npmjs.com/package/@duckdb/node-api) — and registers the `duckdb` dialect in the core SQL statement compiler.

It follows the existing `packages/sql/*` adapter conventions (compare `sqlite-node` / `libsql` / `pg`): a dialect-specific `DuckdbClient` service plus the generic `SqlClient`, a `DuckdbMigrator`, and `layer` / `layerConfig` / `layerFrom` constructors.

## Features

- Three constructors: `make` (managed instance), `fromInstance`, and `fromConnection`, with optional process-local instance caching (`cache: true`) and read-only mode.
- Configurable result conversion: `js` (default), `native`, or `json`.
- DuckDB-specific helpers exposed on `DuckdbClient`: typed parameters (`sql.typed`), appenders, prepared statements, scalar-function registration, query `interrupt`/`progress`, and `getTableNames`.
- Error classification mapping DuckDB messages to the shared `SqlError` reasons (unique/constraint/syntax/serialization/lock/timeout).

## Design notes

- **Transactions**: DuckDB has no SQL savepoints (and rejects nested `BEGIN`), so nested transactions are modeled by marking the whole outer transaction for rollback when a nested scope fails.
- **Streaming**: outside a transaction, `.stream` runs on a **dedicated connection** that is closed when the stream finishes or is interrupted. A DuckDB streaming result is bound to its connection and is silently truncated if another statement runs on that connection before it is fully consumed; using a dedicated connection isolates it from concurrent queries (including per-row queries during consumption). Inside a transaction — or when no instance is available to open a connection — the result is materialized up front to preserve transactional visibility.

## Core change

`Statement.ts` gains `"duckdb"` in the `Dialect` union and as a key on `onDialect` / `onDialectOrElse`; the existing `pg` `onDialect` test is updated accordingly.

## Testing

`pnpm --filter @effect/sql-duckdb test` (in-memory DuckDB, no container required) covers basic queries, compiler helpers, typed/binary params, streaming (including isolation from concurrent connection use), JSON result mode, name transforms, appender/scalar-function/table-names, prepared statements, error classification, the constructor variants, transactions (commit/rollback/nested), and migrations.

A changeset is included.