### PR TITLE
fix(PersistedQueue): Fix Redis-backed PersistedQueue script handling

### DIFF
--- a/.changeset/fix-redis-persisted-queue.md
+++ b/.changeset/fix-redis-persisted-queue.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix Redis-backed `PersistedQueue` reset and failed-item handling.

--- a/packages/effect/src/unstable/persistence/PersistedQueue.ts
+++ b/packages/effect/src/unstable/persistence/PersistedQueue.ts
@@ -613,7 +613,9 @@ local key_pending = KEYS[2]
 local prefix = ARGV[1]
 
 local entries = redis.call("HGETALL", key_pending)
-for id, payload in pairs(entries) do
+for i = 1, #entries, 2 do
+  local id = entries[i]
+  local payload = entries[i + 1]
   local lock_key = prefix .. id .. ":lock"
   local exists = redis.call("EXISTS", lock_key)
   if exists == 0 then
@@ -673,7 +675,7 @@ redis.call("DEL", key_lock)
 redis.call("HDEL", key_pending, id)
 redis.call("RPUSH", key_failed, payload)
 `,
-    numberOfKeys: 2
+    numberOfKeys: 3
   }
 )
 

--- a/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
+++ b/packages/effect/test/unstable/persistence/PersistedQueueTest.ts
@@ -99,6 +99,69 @@ export const suite = (name: string, layer: Layer.Layer<PersistedQueue.PersistedQ
 
         assert.isUndefined(fiber.pollUnsafe())
       }))
+
+    it.effect("does not redeliver in-flight elements", () =>
+      Effect.gen(function*() {
+        const queue = yield* PersistedQueue.make({
+          name: "test-queue-reset",
+          schema: Item
+        })
+
+        yield* queue.offer({ n: 42n })
+
+        const taken = Latch.makeUnsafe()
+        const release = Latch.makeUnsafe()
+        const fiber = yield* queue.take(() => Effect.andThen(taken.open, release.await)).pipe(Effect.forkScoped)
+        yield* taken.await
+
+        const fiber2 = yield* queue.take((val) => Effect.succeed(val)).pipe(Effect.forkScoped)
+
+        // allow any periodic reset in the store to run while the element is
+        // still being processed
+        yield* TestClock.adjust(1000)
+        yield* Effect.sleep(1000).pipe(
+          TestClock.withLive
+        )
+
+        assert.isUndefined(fiber2.pollUnsafe())
+
+        // after a successful take the element should not be delivered again
+        yield* release.open
+        yield* Fiber.join(fiber)
+        yield* TestClock.adjust(1000)
+        yield* Effect.sleep(1000).pipe(
+          TestClock.withLive
+        )
+
+        assert.isUndefined(fiber2.pollUnsafe())
+
+        yield* Fiber.interrupt(fiber2)
+      }))
+
+    it.effect("stops delivering when maxAttempts is exhausted", () =>
+      Effect.gen(function*() {
+        const queue = yield* PersistedQueue.make({
+          name: "test-queue-exhausted",
+          schema: Item
+        })
+
+        yield* queue.offer({ n: 42n })
+
+        const error = yield* queue
+          .take(() => Effect.fail("boom"), { maxAttempts: 1 })
+          .pipe(Effect.flip)
+
+        assert.strictEqual(error, "boom")
+
+        const fiber = yield* queue.take((val) => Effect.succeed(val), { maxAttempts: 1 }).pipe(Effect.forkScoped)
+
+        yield* TestClock.adjust(1000)
+        yield* Effect.sleep(1000).pipe(
+          TestClock.withLive
+        )
+
+        assert.isUndefined(fiber.pollUnsafe())
+      }))
   })
 
 const Item = Schema.Struct({

--- a/packages/platform-node/test/NodeRedis.test.ts
+++ b/packages/platform-node/test/NodeRedis.test.ts
@@ -1,6 +1,7 @@
 import { NodeRedis } from "@effect/platform-node"
+import { assert, it } from "@effect/vitest"
 import { RedisContainer } from "@testcontainers/redis"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
 import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
 import { PersistedQueue, Persistence } from "effect/unstable/persistence"
@@ -27,5 +28,57 @@ PersistedCacheTest.suite(
 
 PersistedQueueTest.suite(
   "NodeRedis",
-  PersistedQueue.layerStoreRedis().pipe(Layer.provide(RedisLayer))
+  // short intervals so the periodic reset runs while the suite's takes are
+  // in flight
+  PersistedQueue.layerStoreRedis({
+    pollInterval: "50 millis",
+    lockRefreshInterval: "100 millis"
+  }).pipe(Layer.provide(RedisLayer))
 )
+
+const PersistedQueueRedisLayer = Layer.mergeAll(
+  RedisLayer,
+  PersistedQueue.layer.pipe(
+    Layer.provideMerge(
+      PersistedQueue.layerStoreRedis().pipe(Layer.provide(RedisLayer))
+    )
+  )
+)
+
+it.layer(PersistedQueueRedisLayer, { timeout: "30 seconds" })(
+  "PersistedQueue (NodeRedis)",
+  (it) => {
+    // The shared PersistedQueue suite can only assert that exhausted elements
+    // are no longer delivered, which is also true if they are silently
+    // dropped. There is no public API for reading failed elements, so
+    // verifying they are preserved in the dead-letter list requires
+    // inspecting Redis directly.
+    it.effect("moves exhausted elements to the failed list", () =>
+      Effect.gen(function*() {
+        const redis = yield* NodeRedis.NodeRedis
+        const queueName = "test-redis-failed"
+
+        const queue = yield* PersistedQueue.make({
+          name: queueName,
+          schema: RedisItem
+        })
+        const id = yield* queue.offer({ n: 42 })
+        const error = yield* queue.take(() => Effect.fail("boom"), { maxAttempts: 1 }).pipe(Effect.flip)
+        assert.strictEqual(error, "boom")
+
+        const failed = yield* redis.use((client) => client.lrange(`effectq:${queueName}:failed`, 0, -1))
+        assert.strictEqual(failed.length, 1)
+        const failedItem = JSON.parse(failed[0])
+        assert.strictEqual(failedItem.id, id)
+        assert.deepStrictEqual(failedItem.element, { n: 42 })
+        assert.strictEqual(failedItem.attempts, 1)
+
+        const pending = yield* redis.use((client) => client.hlen(`effectq:${queueName}:pending`))
+        assert.strictEqual(pending, 0)
+      }))
+  }
+)
+
+const RedisItem = Schema.Struct({
+  n: Schema.Number
+})


### PR DESCRIPTION
## Summary

- Fix Redis-backed `PersistedQueue` reset handling so `HGETALL` results are read as field/value pairs from Redis' flat array response.
- Fix the failed-item Redis script key count so exhausted queue items can be moved to the failed queue instead of failing with a missing `KEYS[3]`.
- Add NodeRedis/Testcontainers regression coverage for locked pending reset behavior and exhausted failed-item handling.

## Why

`DurableQueue` workers rely on `PersistedQueue.layerStoreRedis` for durable handoff. Two Redis script bugs could break that path:

- `resetQueueRedis` treated `HGETALL` as if Lua yielded key/value pairs directly, causing locked pending items to be requeued incorrectly as both the item id and payload.
- `failedRedis` declared only two keys even though the script reads `KEYS[3]`, so exhausted items errored before reaching the failed list.

## Validation

- `pnpm lint-fix`
- `pnpm test packages/platform-node/test/NodeRedis.test.ts packages/effect/test/unstable/workflow/DurableQueue.test.ts`
- `pnpm check:tsgo`

_This PR was raised with the help of Codex ( GPT-5.5-xhigh )_