### PR TITLE
feat(sql-tursodatabase): add @effect/sql-tursodatabase driver for the Rust Turso engine

### DIFF
--- a/.changeset/add-sql-tursodatabase.md
+++ b/.changeset/add-sql-tursodatabase.md
@@ -1,0 +1,7 @@
+---
+"@effect/sql-tursodatabase": minor
+---
+
+Add `@effect/sql-tursodatabase`, an `@effect/sql` driver for the in-process Rust Turso engine (`@tursodatabase/database`).
+
+Provides `TursoClient` (a `SqlClient` exposing queries as `Effect`, the connection as a composable `Layer`, and typed `SqlError`s via Effect SQL's SQLite error classification) alongside `TursoMigrator`. Mirrors the existing `@effect/sql-libsql` and `@effect/sql-sqlite-node` drivers, including transaction support with savepoints and `SafeIntegers`. Streaming queries are not implemented.

--- a/packages/sql/tursodatabase/LICENSE
+++ b/packages/sql/tursodatabase/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sql/tursodatabase/README.md
+++ b/packages/sql/tursodatabase/README.md
@@ -1,0 +1,7 @@
+# `@effect/sql-tursodatabase`
+
+An `@effect/sql` implementation using the in-process Rust Turso engine (`@tursodatabase/database`).
+
+## Documentation
+
+- **API Reference**: [View the full documentation](https://effect-ts.github.io/effect/docs/sql-tursodatabase).

--- a/packages/sql/tursodatabase/docgen.json
+++ b/packages/sql/tursodatabase/docgen.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../node_modules/@effect/docgen/schema.json",
+  "srcLink": "https://github.com/Effect-TS/effect/tree/main/packages/sql/tursodatabase/src/",
+  "exclude": ["src/internal/**/*.ts"],
+  "tscExecutable": "tsgo",
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "module": "ES2022",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "rewriteRelativeImportExtensions": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "effect": ["../../../effect/src/index.js"],
+      "effect/*": ["../../../effect/src/*.js"]
+    },
+    "plugins": [
+      { "name": "@effect/language-service", "includeSuggestionsInTsc": false }
+    ]
+  }
+}

--- a/packages/sql/tursodatabase/package.json
+++ b/packages/sql/tursodatabase/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@effect/sql-tursodatabase",
+  "version": "4.0.0-beta.90",
+  "type": "module",
+  "license": "MIT",
+  "description": "A Turso toolkit for Effect",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect-smol.git",
+    "directory": "packages/sql/tursodatabase"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect-smol/issues"
+  },
+  "tags": [
+    "typescript",
+    "sql",
+    "turso",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "sql",
+    "turso",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "codegen": "effect-utils codegen",
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "build:tsgo": "tsgo -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "devDependencies": {
+    "effect": "workspace:^"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^"
+  },
+  "dependencies": {
+    "@tursodatabase/database": "^0.6.1",
+    "@tursodatabase/database-common": "^0.6.1"
+  }
+}

--- a/packages/sql/tursodatabase/src/TursoClient.ts
+++ b/packages/sql/tursodatabase/src/TursoClient.ts
@@ -1,0 +1,300 @@
+/**
+ * Turso adapter for Effect SQL, backed by `@tursodatabase/database`.
+ *
+ * This module provides a {@link TursoClient} and the generic SQL client service
+ * for the in-process Rust Turso engine. It uses Effect SQL's SQLite compiler,
+ * supports a managed engine connection or a caller-owned live connection,
+ * classifies Turso and SQLite failures as `SqlError`s, and provides transaction
+ * support with savepoints. Streaming queries are not implemented by this driver.
+ *
+ * @since 4.0.0
+ */
+import { connect } from "@tursodatabase/database"
+import type { DatabaseOpts, DatabasePromise, StatementPromise } from "@tursodatabase/database-common"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import { identity } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import * as Stream from "effect/Stream"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Client from "effect/unstable/sql/SqlClient"
+import type { Connection } from "effect/unstable/sql/SqlConnection"
+import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
+import * as Statement from "effect/unstable/sql/Statement"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+
+const classifyError = (cause: unknown, message: string, operation: string) =>
+  classifySqliteError(cause, { message, operation })
+
+/**
+ * Runtime type identifier used to mark `TursoClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-tursodatabase/TursoClient"
+
+/**
+ * Type-level identifier used to mark `TursoClient` values.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-tursodatabase/TursoClient"
+
+/**
+ * Turso-backed SQL client service, extending `SqlClient` with its runtime type marker and client configuration.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface TursoClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId
+  readonly config: TursoClientConfig
+  readonly sdk: DatabasePromise
+}
+
+/**
+ * Service tag for the Turso client service.
+ *
+ * **When to use**
+ *
+ * Use to access or provide a Turso client through the Effect context.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const TursoClient = Context.Service<TursoClient>("@effect/sql-tursodatabase/TursoClient")
+
+/**
+ * Configuration for a Turso client, either by supplying connection options or an existing live connection.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type TursoClientConfig = TursoClientConfig.Full | TursoClientConfig.Live
+
+/**
+ * Namespace containing the configuration variants for `TursoClient`.
+ *
+ * @since 4.0.0
+ */
+export declare namespace TursoClientConfig {
+  /**
+   * Shared Turso client options for span attributes and query/result name transformations.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Base {
+    readonly spanAttributes?: Record<string, unknown> | undefined
+    readonly transformResultNames?: ((str: string) => string) | undefined
+    readonly transformQueryNames?: ((str: string) => string) | undefined
+  }
+
+  /**
+   * Connection-based Turso configuration used to open a managed engine connection.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Full extends Base, DatabaseOpts {
+    /**
+     * The database path.
+     *
+     * **Details**
+     *
+     * The in-process Turso engine opens a local database file by path, or an
+     * in-memory database with `":memory:"`. Unlike libSQL, the engine does not
+     * accept `file:`/`libsql:`/`http:` URLs — pass a filesystem path.
+     */
+    readonly url: string | URL
+  }
+
+  /**
+   * Configuration that uses an existing Turso connection. The supplied `liveClient` is caller-owned and is not closed by the Effect client.
+   *
+   * @category models
+   * @since 4.0.0
+   */
+  export interface Live extends Base {
+    readonly liveClient: DatabasePromise
+  }
+}
+
+/**
+ * Creates a scoped Turso SQL client with transaction support. When given connection options it opens and closes the engine connection; when given `liveClient`, the caller retains ownership.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (
+  options: TursoClientConfig
+): Effect.Effect<TursoClient, never, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.gen(function*() {
+    const compiler = Statement.makeCompilerSqlite(options.transformQueryNames)
+    const transformRows = options.transformResultNames ?
+      Statement.defaultTransforms(
+        options.transformResultNames
+      ).array :
+      undefined
+
+    const spanAttributes: Array<[string, unknown]> = [
+      ...(options.spanAttributes ? Object.entries(options.spanAttributes) : []),
+      [ATTR_DB_SYSTEM_NAME, "sqlite"]
+    ]
+
+    const db = "liveClient" in options
+      ? options.liveClient
+      : yield* Effect.acquireRelease(
+        Effect.promise(() => {
+          const { spanAttributes: _s, transformQueryNames: _q, transformResultNames: _r, url, ...opts } = options
+          return connect(url.toString(), opts as DatabaseOpts)
+        }),
+        (db) => Effect.promise(() => db.close())
+      )
+
+    // `@tursodatabase/database` types `prepare` as async, but some engine
+    // versions return the statement synchronously. Wrapping in an async thunk
+    // normalizes both shapes for `Effect.tryPromise`.
+    const prepare = (sql: string) =>
+      Effect.tryPromise({
+        try: async () => db.prepare(sql),
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to prepare statement", "prepare") })
+      })
+
+    const runStatement = (
+      statement: StatementPromise,
+      params: ReadonlyArray<unknown>,
+      raw: boolean
+    ) =>
+      Effect.withFiber<ReadonlyArray<any>, SqlError>((fiber) => {
+        if (Context.get(fiber.context, Client.SafeIntegers)) {
+          statement.safeIntegers(true)
+        }
+        return Effect.tryPromise({
+          try: async () => {
+            if (statement.reader) {
+              return await statement.all(...params)
+            }
+            const result = await statement.run(...params)
+            return raw ? result as unknown as ReadonlyArray<any> : []
+          },
+          catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+        })
+      })
+
+    const runValues = (
+      statement: StatementPromise,
+      params: ReadonlyArray<unknown>
+    ) =>
+      Effect.tryPromise({
+        try: async () => {
+          if (statement.reader) {
+            return await statement.raw(true).all(...params) as ReadonlyArray<ReadonlyArray<unknown>>
+          }
+          await statement.run(...params)
+          return []
+        },
+        catch: (cause) => new SqlError({ reason: classifyError(cause, "Failed to execute statement", "execute") })
+      })
+
+    const run = (sql: string, params: ReadonlyArray<unknown>, raw = false) =>
+      Effect.flatMap(prepare(sql), (statement) => runStatement(statement, params, raw))
+
+    const connection = identity<Connection>({
+      execute(sql, params, transformRows) {
+        return transformRows
+          ? Effect.map(run(sql, params), transformRows)
+          : run(sql, params)
+      },
+      executeRaw(sql, params) {
+        return run(sql, params, true)
+      },
+      executeValues(sql, params) {
+        return Effect.flatMap(prepare(sql), (statement) => runValues(statement, params))
+      },
+      executeValuesUnprepared(sql, params) {
+        return Effect.flatMap(prepare(sql), (statement) => runValues(statement, params))
+      },
+      executeUnprepared(sql, params, transformRows) {
+        return transformRows
+          ? Effect.map(run(sql, params), transformRows)
+          : run(sql, params)
+      },
+      executeStream(_sql, _params) {
+        return Stream.die("executeStream not implemented")
+      }
+    })
+
+    const semaphore = yield* Semaphore.make(1)
+
+    const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
+    const transactionAcquirer = Effect.uninterruptibleMask((restore) => {
+      const fiber = Fiber.getCurrent()!
+      const scope = Context.getUnsafe(fiber.context, Scope.Scope)
+      return Effect.as(
+        Effect.tap(
+          restore(semaphore.take(1)),
+          () => Scope.addFinalizer(scope, semaphore.release(1))
+        ),
+        connection
+      )
+    })
+
+    return Object.assign(
+      yield* Client.make({
+        acquirer,
+        compiler,
+        transactionAcquirer,
+        spanAttributes,
+        transformRows
+      }),
+      {
+        [TypeId]: TypeId as TypeId,
+        config: options,
+        sdk: db
+      }
+    )
+  })
+
+/**
+ * Creates a layer from a `Config`-wrapped Turso client configuration, providing both `TursoClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerConfig = (
+  config: Config.Wrap<TursoClientConfig>
+): Layer.Layer<TursoClient | Client.SqlClient, Config.ConfigError> =>
+  Layer.effectContext(
+    Config.unwrap(config).pipe(
+      Effect.flatMap(make),
+      Effect.map((client) =>
+        Context.make(TursoClient, client).pipe(
+          Context.add(Client.SqlClient, client)
+        )
+      )
+    )
+  ).pipe(Layer.provide(Reactivity.layer))
+
+/**
+ * Creates a layer from a concrete Turso client configuration, providing both `TursoClient` and `SqlClient`.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (
+  config: TursoClientConfig
+): Layer.Layer<TursoClient | Client.SqlClient> =>
+  Layer.effectContext(
+    Effect.map(make(config), (client) =>
+      Context.make(TursoClient, client).pipe(
+        Context.add(Client.SqlClient, client)
+      ))
+  ).pipe(Layer.provide(Reactivity.layer))

--- a/packages/sql/tursodatabase/src/TursoMigrator.ts
+++ b/packages/sql/tursodatabase/src/TursoMigrator.ts
@@ -1,0 +1,47 @@
+/**
+ * Runs database migrations for Turso projects that use Effect SQL.
+ *
+ * This module re-exports the shared migration loaders and errors, then provides
+ * `run` and `layer` helpers that apply pending migration files with the current
+ * `SqlClient`. Migration execution is handled by the shared SQL migrator.
+ *
+ * @since 4.0.0
+ */
+import type * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Migrator from "effect/unstable/sql/Migrator"
+import type * as Client from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+
+/**
+ * @since 4.0.0
+ */
+export * from "effect/unstable/sql/Migrator"
+
+/**
+ * Runs SQL migrations for a Turso database using the shared `Migrator` implementation and the current `SqlClient`.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const run: <R2 = never>(
+  options: Migrator.MigratorOptions<R2>
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R2
+> = Migrator.make({})
+
+/**
+ * Creates a layer that runs the configured Turso migrations during layer construction and provides no services.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const layer = <R>(
+  options: Migrator.MigratorOptions<R>
+): Layer.Layer<
+  never,
+  Migrator.MigrationError | SqlError,
+  Client.SqlClient | R
+> => Layer.effectDiscard(run(options))

--- a/packages/sql/tursodatabase/src/index.ts
+++ b/packages/sql/tursodatabase/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @since 4.0.0
+ */
+
+// @barrel: Auto-generated exports. Do not edit manually.
+
+/**
+ * @since 4.0.0
+ */
+export * as TursoClient from "./TursoClient.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as TursoMigrator from "./TursoMigrator.ts"

--- a/packages/sql/tursodatabase/test/Client.test.ts
+++ b/packages/sql/tursodatabase/test/Client.test.ts
@@ -1,0 +1,95 @@
+import { TursoClient } from "@effect/sql-tursodatabase"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+
+const makeClient = TursoClient.make({
+  url: ":memory:"
+}).pipe(Effect.provide(Reactivity.layer))
+
+describe("Client", () => {
+  it.effect("should work", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      let response
+      response = yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`INSERT INTO test (name) VALUES ('hello')`
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [{ id: 1, name: "hello" }])
+      response = yield* sql`SELECT * FROM test`.values
+      assert.deepStrictEqual(response, [[1, "hello"]])
+      response = yield* sql`INSERT INTO test (name) VALUES ('world')`.pipe(sql.withTransaction)
+      assert.deepStrictEqual(response, [])
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [
+        { id: 1, name: "hello" },
+        { id: 2, name: "world" }
+      ])
+    }))
+
+  it.effect("should work with raw", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      let response
+      response = yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`.raw
+      assert.deepStrictEqual(response, { changes: 0, lastInsertRowid: 0 })
+      response = yield* sql`INSERT INTO test (name) VALUES ('hello')`.raw
+      assert.deepStrictEqual(response, { changes: 1, lastInsertRowid: 1 })
+      response = yield* sql`SELECT * FROM test`.raw
+      assert.deepStrictEqual(response, [{ id: 1, name: "hello" }])
+      response = yield* sql`INSERT INTO test (name) VALUES ('world')`.raw.pipe(sql.withTransaction)
+      assert.deepStrictEqual(response, { changes: 1, lastInsertRowid: 2 })
+      response = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(response, [
+        { id: 1, name: "hello" },
+        { id: 2, name: "world" }
+      ])
+    }))
+
+  it.effect("withTransaction", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql.withTransaction(sql`INSERT INTO test (name) VALUES ('hello')`)
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [{ id: 1, name: "hello" }])
+    }))
+
+  it.effect("withTransaction rollback", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      yield* sql`INSERT INTO test (name) VALUES ('hello')`.pipe(
+        Effect.andThen(Effect.fail("boom")),
+        sql.withTransaction,
+        Effect.ignore
+      )
+      const rows = yield* sql`SELECT * FROM test`
+      assert.deepStrictEqual(rows, [])
+    }))
+
+  it.effect("withTransaction nested", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const stmt = sql`INSERT INTO test (name) VALUES ('hello')`
+      yield* stmt.pipe(Effect.andThen(() => stmt.pipe(sql.withTransaction)), sql.withTransaction)
+      const rows = yield* sql<{ total_rows: number }>`select count(*) as total_rows FROM test`
+      assert.deepStrictEqual(rows.at(0)?.total_rows, 2)
+    }))
+
+  it.effect("withTransaction nested rollback", () =>
+    Effect.gen(function*() {
+      const sql = yield* makeClient
+      yield* sql`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`
+      const stmt = sql`INSERT INTO test (name) VALUES ('hello')`
+      yield* stmt.pipe(
+        Effect.andThen(() => stmt.pipe(Effect.andThen(Effect.fail("boom")), sql.withTransaction, Effect.ignore)),
+        sql.withTransaction
+      )
+      const rows = yield* sql<{ total_rows: number }>`select count(*) as total_rows FROM test`
+      assert.deepStrictEqual(rows.at(0)?.total_rows, 1)
+    }))
+})

--- a/packages/sql/tursodatabase/tsconfig.json
+++ b/packages/sql/tursodatabase/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" }
+  ]
+}

--- a/packages/sql/tursodatabase/vitest.config.ts
+++ b/packages/sql/tursodatabase/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         version: 4.22.1(core-js@3.47.0)(rolldown@1.0.0)(rollup@4.60.3)(vite@7.3.3(@types/node@25.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.27.2)(rollup@4.60.3)
+        version: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0)(rollup@4.60.3)
@@ -683,6 +683,19 @@ importers:
         specifier: workspace:^
         version: link:../../effect
 
+  packages/sql/tursodatabase:
+    dependencies:
+      '@tursodatabase/database':
+        specifier: ^0.6.1
+        version: 0.6.1
+      '@tursodatabase/database-common':
+        specifier: ^0.6.1
+        version: 0.6.1
+    devDependencies:
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+
   packages/tools/ai-codegen:
     dependencies:
       '@effect/openapi-generator':
@@ -749,7 +762,7 @@ importers:
         version: 4.60.3
       rollup-plugin-esbuild:
         specifier: ^6.2.1
-        version: 6.2.1(esbuild@0.27.2)(rollup@4.60.3)
+        version: 6.2.1(esbuild@0.27.7)(rollup@4.60.3)
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.0.0)(rollup@4.60.3)
@@ -1506,6 +1519,7 @@ packages:
 
   '@clickhouse/client-common@1.18.4':
     resolution: {integrity: sha512-kPPtv8yQmplNAxfrAJvwBJq5dd+IWRewEbXSpUvtyEJXlrB8lt/ZH63jUS81Nmd+lK5MRvpOFXPoN3iogkvg+A==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.18.4':
     resolution: {integrity: sha512-jjCrddI+e2OVXGh/MQY92K9r8Z/iwqaZtUXNI/MfZ/y9VGYwfbQsXRzp4Jv6w4Hgxvr4sLcz9YwIvkCBQ6X/mw==}
@@ -3161,6 +3175,32 @@ packages:
   '@ts-graphviz/core@2.0.7':
     resolution: {integrity: sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==}
     engines: {node: '>=18'}
+
+  '@tursodatabase/database-common@0.6.1':
+    resolution: {integrity: sha512-fkmkhgSUDg3MXkcziTG9Ime3AY5+YvvDN7VvUDEMNV7MP+XgwE/i5tU6eQP1EKa/zDkdSYPq8gPcmROmKmKL8Q==}
+
+  '@tursodatabase/database-darwin-arm64@0.6.1':
+    resolution: {integrity: sha512-2/nlqulI/kWlrh7vHMwF5fkuavGRWB83SIhzHZmoHSQovq0a28Z4+WAHerjh9yNs7DTj70U9PIsvAtRdh77l7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tursodatabase/database-linux-arm64-gnu@0.6.1':
+    resolution: {integrity: sha512-ixooF2xyxV84GYIYPLI5D9VEp+cX3WPBmXRyoCGw7+l9G66eOp8QppGF0dKFYhtp/AJ8YmOp+lemqBoCue9N8Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tursodatabase/database-linux-x64-gnu@0.6.1':
+    resolution: {integrity: sha512-cNZ3FS8XBn4X8zHSzd31nvEeBbR4hCDBGs2P3ViND1Egu5oDZ822a+hWxNxMgMPgUJf/aGBEAk5p+j11fAC/QQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@tursodatabase/database-win32-x64-msvc@0.6.1':
+    resolution: {integrity: sha512-3CASiW3BbeNT4qryxPKKZECGxaAtfUeM/Bjx1NWIxShCLLtRpnaEUt7WLOT2hz+sqU322H6fmMuaN9sYrcwBxw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tursodatabase/database@0.6.1':
+    resolution: {integrity: sha512-qg6LO1XHA9kc2s97crg0/nHiKFk3xTzylRuZPYggO0vA4hx2rp8fk0Je2vFGOkfVv+ZmzsXOIb+DBHmdrG+72A==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -6575,6 +6615,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -9174,6 +9215,29 @@ snapshots:
     dependencies:
       '@ts-graphviz/ast': 2.0.7
       '@ts-graphviz/common': 2.1.5
+
+  '@tursodatabase/database-common@0.6.1': {}
+
+  '@tursodatabase/database-darwin-arm64@0.6.1':
+    optional: true
+
+  '@tursodatabase/database-linux-arm64-gnu@0.6.1':
+    optional: true
+
+  '@tursodatabase/database-linux-x64-gnu@0.6.1':
+    optional: true
+
+  '@tursodatabase/database-win32-x64-msvc@0.6.1':
+    optional: true
+
+  '@tursodatabase/database@0.6.1':
+    dependencies:
+      '@tursodatabase/database-common': 0.6.1
+    optionalDependencies:
+      '@tursodatabase/database-darwin-arm64': 0.6.1
+      '@tursodatabase/database-linux-arm64-gnu': 0.6.1
+      '@tursodatabase/database-linux-x64-gnu': 0.6.1
+      '@tursodatabase/database-win32-x64-msvc': 0.6.1
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -12431,11 +12495,11 @@ snapshots:
     transitivePeerDependencies:
       - core-js
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.27.2)(rollup@4.60.3):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.3):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
       rollup: 4.60.3
       unplugin-utils: 0.2.5
@@ -13118,7 +13182,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,6 +85,8 @@
       "@effect/sql-sqlite-react-native/*": ["./packages/sql/sqlite-react-native/src/*.ts"],
       "@effect/sql-sqlite-wasm": ["./packages/sql/sqlite-wasm/src/index.ts"],
       "@effect/sql-sqlite-wasm/*": ["./packages/sql/sqlite-wasm/src/*.ts"],
+      "@effect/sql-tursodatabase": ["./packages/sql/tursodatabase/src/index.ts"],
+      "@effect/sql-tursodatabase/*": ["./packages/sql/tursodatabase/src/*.ts"],
       "@effect/ai-codegen": ["./packages/tools/ai-codegen/src/index.ts"],
       "@effect/ai-codegen/*": ["./packages/tools/ai-codegen/src/*.ts"],
       "@effect/ai-docgen": ["./packages/tools/ai-docgen/src/index.ts"],

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -29,6 +29,7 @@
     { "path": "packages/sql/sqlite-node" },
     { "path": "packages/sql/sqlite-react-native" },
     { "path": "packages/sql/sqlite-wasm" },
+    { "path": "packages/sql/tursodatabase" },
     { "path": "packages/tools/ai-codegen" },
     { "path": "packages/tools/bundle" },
     { "path": "packages/tools/openapi-generator" },


### PR DESCRIPTION
## What

Adds **`@effect/sql-tursodatabase`**, an `@effect/sql` driver for the in-process **Rust Turso engine** (`@tursodatabase/database`).

It mirrors the existing `@effect/sql-libsql` and `@effect/sql-sqlite-node` drivers:

- `TursoClient` — a `SqlClient` (queries as `Effect`, the connection as a composable `Layer` via `TursoClient.layer` / `layerConfig`, typed `SqlError` via Effect SQL's SQLite error classification).
- `TursoMigrator` — `run` / `layer` over the shared `Migrator`.
- Transaction support with savepoints, `SafeIntegers`, and OpenTelemetry span attributes, consistent with the other SQLite-family drivers.
- Streaming queries are not implemented (same as `sql-libsql` / `sql-sqlite-node`).

## Why

`@tursodatabase/database` is the in-process Rust SQLite-compatible engine (MVCC / `BEGIN CONCURRENT`, CDC). It is the only SQLite-family engine in the ecosystem without a first-party Effect SQL client. This package closes that gap so Effect users can adopt the Rust Turso engine without hand-rolling the `Effect.tryPromise` / tagged-error / `acquireRelease` seam.

It is also the upstream half of drizzle-team/drizzle-orm#5962 (which adds `drizzle-orm/effect-tursodatabase` on top of this client).

## Notes

- The engine's async API types `prepare` as returning a `Promise`, but some published versions return the statement synchronously; the client normalizes both shapes.
- The engine opens databases by filesystem path or `":memory:"` (it does not accept `file:` / `libsql:` / `http:` URLs, unlike libSQL) — documented on `TursoClientConfig.Full.url`.

## Test

`packages/sql/tursodatabase/test/Client.test.ts` runs against a real in-memory Turso engine (queries, raw results, `withTransaction` commit/rollback, nested savepoints) — 6/6 passing. `tsc -b`, `oxlint`, and `dprint` are clean. Changeset included.
