### PR TITLE
feat(openapi-generator): generate binary responses as typed streams with typed errors

### DIFF
--- a/.changeset/openapi-generator-binary-stream-typed-errors.md
+++ b/.changeset/openapi-generator-binary-stream-typed-errors.md
@@ -1,0 +1,7 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Generate binary (e.g. `application/pdf`, `format: binary`) success responses as typed `*Stream` clients with typed OpenAPI error responses, instead of decoding them as JSON strings.
+
+Binary success responses are now detected by schema shape (`type: string` with `format`/`contentEncoding: binary`) and by binary media types (including `application/pdf`), not just `application/octet-stream`. An operation whose only success response is binary generates a single `${id}Stream` method whose error channel includes the operation's typed OpenAPI error responses plus `HttpClientError` / `SchemaError`; the redundant JSON method is no longer emitted for it. `binaryRequest` now matches on status so per-status error bodies decode into their typed variants.

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -493,9 +493,19 @@ const parseOpenApi = (
         }
         const representable: Array<ParsedOperation.ParsedOperationMediaTypeSchema> = []
 
+        const statusLower = parsedStatus.toLowerCase()
+        const statusMajorNumber = Number(parsedStatus[0])
+        const isSuccessStatus = !Number.isNaN(statusMajorNumber) && statusMajorNumber < 4
+
         let jsonSchemaName: string | undefined
         const jsonResponseSchema = content?.["application/json"]?.schema
-        if (Predicate.isNotUndefined(jsonResponseSchema)) {
+        const jsonResponseSchemaResolved = Predicate.isNotUndefined(jsonResponseSchema)
+          ? resolveReference(jsonResponseSchema, resolveRef)
+          : undefined
+        if (
+          Predicate.isNotUndefined(jsonResponseSchema) &&
+          !isBinarySchema(jsonResponseSchemaResolved)
+        ) {
           jsonSchemaName = addSchema(`${schemaId}${status}`, jsonResponseSchema, op)
           if (isHttpApi) {
             representable.push({
@@ -584,6 +594,16 @@ const parseOpenApi = (
           op.defaultResponse = parsedResponse
         }
 
+        for (const [, mediaType] of Object.entries(content ?? {})) {
+          if (!Predicate.isObject(mediaType) || Predicate.isUndefined(mediaType.schema)) {
+            continue
+          }
+          if (isSuccessStatus && isBinarySchema(resolveReference(mediaType.schema, resolveRef))) {
+            op.binaryResponse = true
+            op.binaryResponseStatusCodes.add(statusLower)
+          }
+        }
+
         if (Predicate.isNotUndefined(jsonSchemaName)) {
           const schemaName = jsonSchemaName
 
@@ -592,8 +612,6 @@ const parseOpenApi = (
             continue
           }
 
-          const statusLower = parsedStatus.toLowerCase()
-          const statusMajorNumber = Number(parsedStatus[0])
           if (Number.isNaN(statusMajorNumber)) {
             continue
           }
@@ -613,9 +631,9 @@ const parseOpenApi = (
         }
 
         if (Predicate.isNotUndefined(content?.["application/octet-stream"])) {
-          const statusMajorNumber = Number(parsedStatus[0])
-          if (!Number.isNaN(statusMajorNumber) && statusMajorNumber < 4) {
+          if (isSuccessStatus) {
             op.binaryResponse = true
+            op.binaryResponseStatusCodes.add(statusLower)
           }
         }
 
@@ -864,7 +882,7 @@ const transformMultipartSchema = (
       return transformed
     }
 
-    if (isMultipartBinaryFile(value)) {
+    if (isBinarySchema(value)) {
       return { $ref: singleFileRef }
     }
 
@@ -896,7 +914,7 @@ const resolveSchemaReference = (ref: string, resolveRef: (ref: string) => unknow
   return current
 }
 
-const isMultipartBinaryFile = (value: unknown): value is JsonSchema.JsonSchema =>
+const isBinarySchema = (value: unknown): value is JsonSchema.JsonSchema =>
   Predicate.isObject(value) &&
   value.type === "string" &&
   (
@@ -909,7 +927,7 @@ const isMultipartBinaryFiles = (value: Record<string, unknown>, singleFileRef: s
     return false
   }
   const items = value.items
-  return isMultipartBinaryFile(items) || (Predicate.isObject(items) && items.$ref === singleFileRef)
+  return isBinarySchema(items) || (Predicate.isObject(items) && items.$ref === singleFileRef)
 }
 
 const isJsonMediaType = (contentType: string): boolean =>
@@ -920,6 +938,7 @@ const isTextMediaType = (contentType: string): boolean => contentType.startsWith
 
 const isBinaryMediaType = (contentType: string): boolean =>
   contentType === "application/octet-stream" ||
+  contentType === "application/pdf" ||
   (contentType.startsWith("application/") && (contentType.includes("binary") || contentType.endsWith("+octet-stream")))
 
 const getRequestMediaTypeEncoding = (

--- a/packages/tools/openapi-generator/src/OpenApiTransformer.ts
+++ b/packages/tools/openapi-generator/src/OpenApiTransformer.ts
@@ -60,6 +60,9 @@ const computeImportRequirements = (operations: ReadonlyArray<ParsedOperation>): 
 const requiresStreaming = (requirements: ImportRequirements): boolean =>
   requirements.eventStream || requirements.octetStream
 
+const hasNonBinaryMethod = (operation: ParsedOperation): boolean =>
+  operation.successSchemas.size > 0 || operation.voidSchemas.size > 0 || operation.binaryResponseStatusCodes.size === 0
+
 /**
  * Create the transformer used for schema-backed HttpClient output.
  *
@@ -80,7 +83,9 @@ export const makeTransformerSchema = () => {
   ) => {
     const methods: Array<string> = []
     for (const op of operations) {
-      methods.push(operationToMethod(name, op))
+      if (hasNonBinaryMethod(op)) {
+        methods.push(operationToMethod(name, op))
+      }
       if (op.sseSchema) {
         methods.push(operationToSseMethod(name, op))
       }
@@ -204,7 +209,16 @@ ${clientErrorSource(name)}`
     const jsdoc = Utils.toComment(operation.description)
     const methodKey = `readonly "${operation.id}Stream"`
     const parameters = args.join(", ")
-    const returnType = `Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`
+    const errors = ["HttpClientError.HttpClientError", "SchemaError"]
+    if (operation.errorSchemas.size > 0) {
+      Utils.spreadElementsInto(
+        Array.from(operation.errorSchemas.values()).map(
+          (schema) => `${_name}Error<"${schema}", typeof ${schema}.Type>`
+        ),
+        errors
+      )
+    }
+    const returnType = `Stream.Stream<Uint8Array, ${errors.join(" | ")}>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -216,7 +230,9 @@ ${clientErrorSource(name)}`
     const requirements = computeImportRequirements(operations)
     const implMethods: Array<string> = []
     for (const op of operations) {
-      implMethods.push(operationToImpl(op))
+      if (hasNonBinaryMethod(op)) {
+        implMethods.push(operationToImpl(op))
+      }
       if (op.sseSchema) {
         implMethods.push(operationToSseImpl(importName, op))
       }
@@ -411,7 +427,20 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
 
-    pipeline.push(`binaryRequest`)
+    const decodes: Array<string> = []
+    const singleSuccessCode = operation.binaryResponseStatusCodes.size === 1
+    operation.binaryResponseStatusCodes.forEach((status) => {
+      const statusCode = singleSuccessCode && status.startsWith("2") ? "2xx" : status
+      decodes.push(`"${statusCode}": (response) => Effect.succeed(response.stream)`)
+    })
+    operation.errorSchemas.forEach((schema, status) => {
+      decodes.push(`"${status}": decodeError("${schema}", ${schema})`)
+    })
+    decodes.push(`orElse: unexpectedStatus`)
+
+    pipeline.push(`binaryRequest(HttpClientResponse.matchStatus({
+      ${decodes.join(",\n      ")}
+    }))`)
 
     return (
       `"${operation.id}Stream": (${params}) => ` +
@@ -491,12 +520,14 @@ export const makeTransformerTs = () => {
   ) => {
     const methods: Array<string> = []
     for (const op of operations) {
-      methods.push(operationToMethod(name, op))
+      if (hasNonBinaryMethod(op)) {
+        methods.push(operationToMethod(name, op))
+      }
       if (op.sseSchema) {
         methods.push(operationToSseMethod(op))
       }
       if (op.binaryResponse) {
-        methods.push(operationToBinaryMethod(op))
+        methods.push(operationToBinaryMethod(name, op))
       }
     }
     return `export interface ${name} {
@@ -582,7 +613,7 @@ ${clientErrorSource(name)}`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
-  const operationToBinaryMethod = (operation: ParsedOperation) => {
+  const operationToBinaryMethod = (name: string, operation: ParsedOperation) => {
     const args: Array<string> = []
     if (operation.pathIds.length > 0) {
       Utils.spreadElementsInto(operation.pathIds.map((id) => `${id}: string`), args)
@@ -608,7 +639,13 @@ ${clientErrorSource(name)}`
     const jsdoc = Utils.toComment(operation.description)
     const methodKey = `readonly "${operation.id}Stream"`
     const parameters = args.join(", ")
-    const returnType = `Stream.Stream<Uint8Array, HttpClientError.HttpClientError>`
+    const errors = ["HttpClientError.HttpClientError"]
+    if (operation.errorSchemas.size > 0) {
+      for (const schema of operation.errorSchemas.values()) {
+        errors.push(`${name}Error<"${schema}", ${schema}>`)
+      }
+    }
+    const returnType = `Stream.Stream<Uint8Array, ${errors.join(" | ")}>`
     return `${jsdoc}${methodKey}: (${parameters}) => ${returnType}`
   }
 
@@ -620,7 +657,9 @@ ${clientErrorSource(name)}`
     const requirements = computeImportRequirements(operations)
     const implMethods: Array<string> = []
     for (const op of operations) {
-      implMethods.push(operationToImpl(op))
+      if (hasNonBinaryMethod(op)) {
+        implMethods.push(operationToImpl(op))
+      }
       if (op.sseSchema) {
         implMethods.push(operationToSseImpl(op))
       }
@@ -738,18 +777,18 @@ export const make = (
     }
 
     const successCodesRaw = Array.from(operation.successSchemas.keys())
+    const singleSuccessCode = successCodesRaw.length === 1 && successCodesRaw[0].startsWith("2")
     const successCodes = successCodesRaw
       .map((_) => JSON.stringify(_))
       .join(", ")
-    const singleSuccessCode = successCodesRaw.length === 1 && successCodesRaw[0].startsWith("2")
     const errorCodes = operation.errorSchemas.size > 0 &&
       Object.fromEntries(operation.errorSchemas.entries())
     const configAccessor = resolveConfigAccessor(operation, "options", "config")
-    pipeline.push(
-      `onRequest(${configAccessor})([${singleSuccessCode ? `"2xx"` : successCodes}]${
-        errorCodes ? `, ${JSON.stringify(errorCodes)}` : ""
-      })`
-    )
+    const onRequestArgs = [`[${singleSuccessCode ? `"2xx"` : successCodes}]`]
+    if (errorCodes) {
+      onRequestArgs.push(JSON.stringify(errorCodes))
+    }
+    pipeline.push(`onRequest(${configAccessor})(${onRequestArgs.join(", ")})`)
 
     return (
       `"${operation.id}": (${params}) => ` +
@@ -831,7 +870,20 @@ export const make = (
       pipeline.push(`HttpClientRequest.bodyJsonUnsafe(options.payload)`)
     }
 
-    pipeline.push(`binaryRequest`)
+    const decodes: Array<string> = []
+    const singleSuccessCode = operation.binaryResponseStatusCodes.size === 1
+    operation.binaryResponseStatusCodes.forEach((status) => {
+      const statusCode = singleSuccessCode && status.startsWith("2") ? "2xx" : status
+      decodes.push(`"${statusCode}": (response) => Effect.succeed(response.stream)`)
+    })
+    operation.errorSchemas.forEach((schema, status) => {
+      decodes.push(`"${status}": decodeError("${schema}")`)
+    })
+    decodes.push(`orElse: unexpectedStatus`)
+
+    pipeline.push(`binaryRequest(HttpClientResponse.matchStatus({
+      ${decodes.join(",\n      ")}
+    }))`)
 
     return (
       `"${operation.id}Stream": (${params}) => ` +
@@ -933,10 +985,14 @@ const sseRequestSource = (_importName: string) =>
         Stream.pipeThroughChannel(Sse.decodeDataSchema(schema))
       )`
 
-const binaryRequestSource =
-  `const binaryRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<Uint8Array, HttpClientError.HttpClientError> =>
-    HttpClient.filterStatusOk(httpClient).execute(request).pipe(
-      Effect.map((response) => response.stream),
+const binaryRequestSource = `const binaryRequest = <E>(
+    f: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<Stream.Stream<Uint8Array, HttpClientError.HttpClientError>, E>
+  ) =>
+  (
+    request: HttpClientRequest.HttpClientRequest
+  ): Stream.Stream<Uint8Array, E | HttpClientError.HttpClientError> =>
+    httpClient.execute(request).pipe(
+      Effect.flatMap(f),
       Stream.unwrap
     )`
 
@@ -952,10 +1008,14 @@ const sseRequestSourceTs =
       Stream.map((line) => JSON.parse(line.slice(6)))
     )`
 
-const binaryRequestSourceTs =
-  `const binaryRequest = (request: HttpClientRequest.HttpClientRequest): Stream.Stream<Uint8Array, HttpClientError.HttpClientError> =>
-    HttpClient.filterStatusOk(httpClient).execute(request).pipe(
-      Effect.map((response) => response.stream),
+const binaryRequestSourceTs = `const binaryRequest = <E>(
+    f: (response: HttpClientResponse.HttpClientResponse) => Effect.Effect<Stream.Stream<Uint8Array, HttpClientError.HttpClientError>, E>
+  ) =>
+  (
+    request: HttpClientRequest.HttpClientRequest
+  ): Stream.Stream<Uint8Array, E | HttpClientError.HttpClientError> =>
+    httpClient.execute(request).pipe(
+      Effect.flatMap(f),
       Stream.unwrap
     )`
 

--- a/packages/tools/openapi-generator/src/ParsedOperation.ts
+++ b/packages/tools/openapi-generator/src/ParsedOperation.ts
@@ -221,8 +221,9 @@ export interface ParsedOperation {
   readonly voidSchemas: ReadonlySet<string>
   // SSE streaming response schema (text/event-stream)
   readonly sseSchema?: string
-  // Binary stream response (application/octet-stream)
+  // Binary success response
   readonly binaryResponse: boolean
+  readonly binaryResponseStatusCodes: ReadonlySet<string>
 }
 
 /**
@@ -273,5 +274,6 @@ export const makeDeepMutable = (options: {
   errorSchemas: new Map(),
   voidSchemas: new Set(),
   paramsOptional: true,
-  binaryResponse: false
+  binaryResponse: false,
+  binaryResponseStatusCodes: new Set()
 })

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -35,7 +35,11 @@ function assertTypeOnly(spec: OpenAPISpec, expected: string) {
   )
 }
 
-function assertRuntimeIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string>) {
+function assertRuntimeIncludes(
+  spec: OpenAPISpec,
+  includes: ReadonlyArray<string>,
+  excludes: ReadonlyArray<string> = []
+) {
   return Effect.gen(function*() {
     const generator = yield* OpenApiGenerator.OpenApiGenerator
 
@@ -46,6 +50,9 @@ function assertRuntimeIncludes(spec: OpenAPISpec, includes: ReadonlyArray<string
 
     for (const expected of includes) {
       assert.include(result, expected)
+    }
+    for (const excluded of excludes) {
+      assert.notInclude(result, excluded)
     }
   }).pipe(
     Effect.provide(OpenApiGenerator.layerTransformerSchema)
@@ -522,6 +529,82 @@ export const TestClientError = <Tag extends string, E>(
           `"streamEventsSse": () => HttpClientRequest.get(\`/events\`).pipe(`,
           `sseRequest(StreamEvents200Sse)`,
           `schema: Schema.ConstraintDecoder<Type, DecodingServices>`
+        ]
+      ))
+
+    it.effect("binary response schema generates typed stream with typed errors", () =>
+      assertRuntimeIncludes(
+        {
+          openapi: "3.1.0",
+          info: {
+            title: "Test API",
+            version: "1.0.0"
+          },
+          paths: {
+            "/invoice/{id}": {
+              get: {
+                operationId: "getInvoice",
+                parameters: [
+                  {
+                    name: "id",
+                    in: "path",
+                    schema: {
+                      type: "string"
+                    },
+                    required: true
+                  }
+                ],
+                responses: {
+                  200: {
+                    description: "Invoice PDF",
+                    content: {
+                      "application/pdf": {
+                        schema: {
+                          type: "string",
+                          format: "binary"
+                        }
+                      }
+                    }
+                  },
+                  400: {
+                    description: "Bad request",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            code: { type: "string" },
+                            message: { type: "string" }
+                          },
+                          required: ["code", "message"],
+                          additionalProperties: false
+                        }
+                      }
+                    }
+                  }
+                },
+                tags: ["Invoices"],
+                security: []
+              }
+            }
+          },
+          components: {
+            schemas: {},
+            securitySchemes: {}
+          },
+          security: [],
+          tags: []
+        },
+        [
+          `readonly "getInvoiceStream": (id: string) => Stream.Stream<Uint8Array, HttpClientError.HttpClientError | SchemaError | TestClientError<"GetInvoice400", typeof GetInvoice400.Type>>`,
+          `"getInvoiceStream": (id) => HttpClientRequest.get(\`/invoice/\${id}\`).pipe(`,
+          `binaryRequest(HttpClientResponse.matchStatus({`,
+          `"2xx": (response) => Effect.succeed(response.stream)`,
+          `"400": decodeError("GetInvoice400", GetInvoice400)`
+        ],
+        [
+          `readonly "getInvoice":`,
+          `schemaBodyJson(GetInvoice200)`
         ]
       ))
 


### PR DESCRIPTION
## What

The OpenAPI generator emitted binary success responses (e.g. `application/pdf`, `type: string` + `format: binary`) as JSON-string clients, so a PDF/download endpoint decoded its body as a JSON string and lost its typed error responses.

This teaches the generator to treat binary success responses as streams:

- **Detection by schema shape**, not just media type: `type: string` with `format: binary` (or `contentEncoding: binary`), and binary media types including `application/pdf` — not only `application/octet-stream`.
- **Typed error channel on the stream method.** An operation whose only success response is binary now generates a single `${id}Stream` method returning `Stream.Stream<Uint8Array, HttpClientError | SchemaError | <typed OpenAPI error responses>>`. `binaryRequest` matches on status (`HttpClientResponse.matchStatus`) so per-status error bodies decode into their typed variants.
- **No redundant JSON method** is emitted for a binary-only operation (previously both a JSON method and the stream method were produced).
- Tracked on `ParsedOperation` via a new `binaryResponseStatusCodes` set; `binaryResponse` semantics generalized from "octet-stream only" to "binary success response".

Applies to both the schema-backed HttpClient transformer and the type-only transformer.

## Test

Added a generator test: a `GET` returning `application/pdf` (200, `format: binary`) with a `400` JSON error produces a typed `getInvoiceStream` (error channel includes the `400` variant), emits `binaryRequest(HttpClientResponse.matchStatus({ "2xx": ..., "400": decodeError(...) }))`, and does **not** emit a JSON `getInvoice` method / `schemaBodyJson`.

All 69 `@effect/openapi-generator` tests pass; `tspc -b` and `dprint check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)