### PR TITLE
add `HttpApiBuilder.handler` utility

### DIFF
--- a/.changeset/dull-rings-study.md
+++ b/.changeset/dull-rings-study.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `HttpApiBuilder.handler` utility for enforcing handler function type without transformation into layer / other form.

--- a/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts
@@ -1029,3 +1029,22 @@ function getResponseEncode<E>(
         )
   }
 }
+
+type GroupsOf<Api extends HttpApi.Any> = Api extends HttpApi.HttpApi<any, infer Groups> ? Groups : never
+
+type EndpointsOf<Api extends HttpApi.Any, GroupName extends HttpApiGroup.Name<GroupsOf<Api>>> = HttpApiGroup.Endpoints<
+  HttpApiGroup.WithName<GroupsOf<Api>, GroupName>
+>
+
+export const handler = <
+  Api extends HttpApi.Any,
+  GroupName extends HttpApiGroup.Name<GroupsOf<Api>>,
+  EndpointName extends HttpApiEndpoint.Name<EndpointsOf<Api, GroupName>>,
+  R,
+>(
+  _api: Api,
+  _group: GroupName,
+  _endpoint: EndpointName,
+  f: HttpApiEndpoint.HandlerWithName<EndpointsOf<Api, GroupName>, EndpointName, never, R>,
+) => f
+


### PR DESCRIPTION
## Type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `HttpApiBuilder.handler`, a small type helper for validating an HTTP API endpoint handler function directly, without converting it into a `Layer` or another builder form.