### PR TITLE
EFF-897 Move UrlParams.makeUrl to Url.make

### DIFF
--- a/.changeset/quiet-turtles-smile.md
+++ b/.changeset/quiet-turtles-smile.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Move `UrlParams.makeUrl` to `Url.make`.
+Move `UrlParams.makeUrl` to `Url.make` and return `Url.UrlError` for URL construction failures.

--- a/.changeset/quiet-turtles-smile.md
+++ b/.changeset/quiet-turtles-smile.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Move `UrlParams.makeUrl` to `Url.make`.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -40,7 +40,7 @@ import * as HttpClientResponse from "./HttpClientResponse.ts"
 import * as HttpIncomingMessage from "./HttpIncomingMessage.ts"
 import * as HttpMethod from "./HttpMethod.ts"
 import * as TraceContext from "./HttpTraceContext.ts"
-import * as UrlParams from "./UrlParams.ts"
+import * as Url from "./Url.ts"
 
 const TypeId = "~effect/http/HttpClient"
 
@@ -637,7 +637,7 @@ export const make = (
       Effect.withFiber((fiber) => {
         const scopedController = scopedRequests.get(request)
         const controller = scopedController ?? new AbortController()
-        const urlResult = UrlParams.makeUrl(request.url, request.urlParams, Option.getOrUndefined(request.hash))
+        const urlResult = Url.make(request.url, request.urlParams, Option.getOrUndefined(request.hash))
         if (Result.isFailure(urlResult)) {
           return Effect.fail(
             new Error.HttpClientError({

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -28,6 +28,7 @@ import * as Stream from "../../Stream.ts"
 import * as Headers from "./Headers.ts"
 import * as HttpBody from "./HttpBody.ts"
 import { hasBody, type HttpMethod } from "./HttpMethod.ts"
+import * as Url from "./Url.ts"
 import * as UrlParams from "./UrlParams.ts"
 
 const TypeId = "~effect/http/HttpClientRequest"
@@ -853,7 +854,7 @@ export const bodyFile: {
  * @since 4.0.0
  */
 export function toUrl(self: HttpClientRequest): Option.Option<URL> {
-  const r = UrlParams.makeUrl(self.url, self.urlParams, Option.getOrUndefined(self.hash))
+  const r = Url.make(self.url, self.urlParams, Option.getOrUndefined(self.hash))
   if (Result.isSuccess(r)) {
     return Option.some(r.success)
   }
@@ -904,7 +905,7 @@ export const toWebResult = (self: HttpClientRequest, options?: {
   readonly signal?: AbortSignal | undefined
   readonly context?: Context.Context<never> | undefined
 }): Result.Result<Request, UrlParams.UrlParamsError> => {
-  const url = UrlParams.makeUrl(self.url, self.urlParams, Option.getOrUndefined(self.hash))
+  const url = Url.make(self.url, self.urlParams, Option.getOrUndefined(self.hash))
   if (Result.isFailure(url)) {
     return Result.fail(url.failure)
   }

--- a/packages/effect/src/unstable/http/HttpClientRequest.ts
+++ b/packages/effect/src/unstable/http/HttpClientRequest.ts
@@ -904,7 +904,7 @@ const parseContentLength = (contentLength: string | null): number | undefined =>
 export const toWebResult = (self: HttpClientRequest, options?: {
   readonly signal?: AbortSignal | undefined
   readonly context?: Context.Context<never> | undefined
-}): Result.Result<Request, UrlParams.UrlParamsError> => {
+}): Result.Result<Request, Url.UrlError> => {
   const url = Url.make(self.url, self.urlParams, Option.getOrUndefined(self.hash))
   if (Result.isFailure(url)) {
     return Result.fail(url.failure)
@@ -945,7 +945,7 @@ export const toWebResult = (self: HttpClientRequest, options?: {
   }
   return Result.try({
     try: () => new Request(url.success, requestInit),
-    catch: (cause) => new UrlParams.UrlParamsError({ cause })
+    catch: (cause) => new Url.UrlError({ cause })
   })
 }
 
@@ -953,14 +953,14 @@ const isReadableStream = (u: unknown): u is ReadableStream<Uint8Array> =>
   typeof ReadableStream !== "undefined" && u instanceof ReadableStream
 
 /**
- * Converts an `HttpClientRequest` to a Web `Request`, failing with `UrlParamsError` when the request URL is invalid.
+ * Converts an `HttpClientRequest` to a Web `Request`, failing with `UrlError` when the request URL is invalid.
  *
  * @category converting
  * @since 4.0.0
  */
 export const toWeb = (self: HttpClientRequest, options?: {
   readonly signal?: AbortSignal | undefined
-}): Effect.Effect<Request, UrlParams.UrlParamsError> =>
+}): Effect.Effect<Request, Url.UrlError> =>
   Effect.contextWith((context) =>
     Effect.fromResult(toWebResult(self, {
       context: context,

--- a/packages/effect/src/unstable/http/Url.ts
+++ b/packages/effect/src/unstable/http/Url.ts
@@ -9,18 +9,28 @@
  * @since 4.0.0
  */
 import * as Cause from "../../Cause.ts"
+import * as Data from "../../Data.ts"
 import { dual } from "../../Function.ts"
 import * as Redacted from "../../Redacted.ts"
 import * as Result from "../../Result.ts"
 import * as UrlParams from "./UrlParams.ts"
 
 /**
+ * Error returned when constructing a `URL` fails.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class UrlError extends Data.TaggedError("UrlError")<{
+  readonly cause: unknown
+}> {}
+
+/**
  * Creates a `URL` safely by appending `UrlParams` and an optional hash to a URL string.
  *
  * **Details**
  *
- * Returns a `Result` that fails with `UrlParamsError` if the URL cannot be
- * constructed.
+ * Returns a `Result` that fails with `UrlError` if the URL cannot be constructed.
  *
  * @category constructors
  * @since 4.0.0
@@ -29,7 +39,7 @@ export const make = (
   url: string,
   params: UrlParams.UrlParams,
   hash: string | undefined
-): Result.Result<URL, UrlParams.UrlParamsError> =>
+): Result.Result<URL, UrlError> =>
   Result.try({
     try: () => {
       const urlInstance = new URL(url, baseUrl())
@@ -44,7 +54,7 @@ export const make = (
       }
       return urlInstance
     },
-    catch: (cause) => new UrlParams.UrlParamsError({ cause })
+    catch: (cause) => new UrlError({ cause })
   })
 
 const baseUrl = (): string | undefined => {

--- a/packages/effect/src/unstable/http/Url.ts
+++ b/packages/effect/src/unstable/http/Url.ts
@@ -15,6 +15,51 @@ import * as Result from "../../Result.ts"
 import * as UrlParams from "./UrlParams.ts"
 
 /**
+ * Creates a `URL` safely by appending `UrlParams` and an optional hash to a URL string.
+ *
+ * **Details**
+ *
+ * Returns a `Result` that fails with `UrlParamsError` if the URL cannot be
+ * constructed.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (
+  url: string,
+  params: UrlParams.UrlParams,
+  hash: string | undefined
+): Result.Result<URL, UrlParams.UrlParamsError> =>
+  Result.try({
+    try: () => {
+      const urlInstance = new URL(url, baseUrl())
+      for (let i = 0; i < params.params.length; i++) {
+        const [key, value] = params.params[i]
+        if (value !== undefined) {
+          urlInstance.searchParams.append(key, value)
+        }
+      }
+      if (hash !== undefined) {
+        urlInstance.hash = hash
+      }
+      return urlInstance
+    },
+    catch: (cause) => new UrlParams.UrlParamsError({ cause })
+  })
+
+const baseUrl = (): string | undefined => {
+  if (
+    "location" in globalThis &&
+    globalThis.location !== undefined &&
+    globalThis.location.origin !== undefined &&
+    globalThis.location.pathname !== undefined
+  ) {
+    return location.origin + location.pathname
+  }
+  return undefined
+}
+
+/**
  * Parses a URL string safely into a `URL` object, returning a `Result` type for
  * error handling.
  *

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -9,7 +9,6 @@
  * @since 4.0.0
  */
 import * as Arr from "../../Array.ts"
-import * as Data from "../../Data.ts"
 import * as Effect from "../../Effect.ts"
 import * as Equal from "../../Equal.ts"
 import * as Equ from "../../Equivalence.ts"
@@ -444,16 +443,6 @@ export const remove: {
   (key: string): (self: UrlParams) => UrlParams
   (self: UrlParams, key: string): UrlParams
 } = dual(2, (self: UrlParams, key: string): UrlParams => transform(self, Arr.filter(([k]) => k !== key)))
-
-/**
- * Error returned when constructing a `URL` from `UrlParams` fails.
- *
- * @category errors
- * @since 4.0.0
- */
-export class UrlParamsError extends Data.TaggedError("UrlParamsError")<{
-  cause: unknown
-}> {}
 
 /**
  * Serializes `UrlParams` to a URL query string without a leading question mark.

--- a/packages/effect/src/unstable/http/UrlParams.ts
+++ b/packages/effect/src/unstable/http/UrlParams.ts
@@ -21,7 +21,6 @@ import * as Option from "../../Option.ts"
 import type { Pipeable } from "../../Pipeable.ts"
 import { hasProperty } from "../../Predicate.ts"
 import type { ReadonlyRecord } from "../../Record.ts"
-import * as Result from "../../Result.ts"
 import * as Schema from "../../Schema.ts"
 import * as SchemaIssue from "../../SchemaIssue.ts"
 import * as SchemaTransformation from "../../SchemaTransformation.ts"
@@ -457,57 +456,12 @@ export class UrlParamsError extends Data.TaggedError("UrlParamsError")<{
 }> {}
 
 /**
- * Creates a `URL` safely by appending `UrlParams` and an optional hash to a URL string.
- *
- * **Details**
- *
- * Returns a `Result` that fails with `UrlParamsError` if the URL cannot be
- * constructed.
- *
- * @category converting
- * @since 4.0.0
- */
-export const makeUrl = (
-  url: string,
-  params: UrlParams,
-  hash: string | undefined
-): Result.Result<URL, UrlParamsError> => {
-  try {
-    const urlInstance = new URL(url, baseUrl())
-    for (let i = 0; i < params.params.length; i++) {
-      const [key, value] = params.params[i]
-      if (value !== undefined) {
-        urlInstance.searchParams.append(key, value)
-      }
-    }
-    if (hash !== undefined) {
-      urlInstance.hash = hash
-    }
-    return Result.succeed(urlInstance)
-  } catch (e) {
-    return Result.fail(new UrlParamsError({ cause: e }))
-  }
-}
-
-/**
  * Serializes `UrlParams` to a URL query string without a leading question mark.
  *
  * @category converting
  * @since 4.0.0
  */
 export const toString = (self: UrlParams): string => new URLSearchParams(self.params as any).toString()
-
-const baseUrl = (): string | undefined => {
-  if (
-    "location" in globalThis &&
-    globalThis.location !== undefined &&
-    globalThis.location.origin !== undefined &&
-    globalThis.location.pathname !== undefined
-  ) {
-    return location.origin + location.pathname
-  }
-  return undefined
-}
 
 /**
  * Builds a `Record` containing all the key-value pairs in the given `UrlParams`

--- a/packages/effect/test/unstable/http/Url.test.ts
+++ b/packages/effect/test/unstable/http/Url.test.ts
@@ -36,7 +36,7 @@ describe("Url", () => {
       const result = Url.make("http://%", UrlParams.empty, undefined)
 
       assertTrue(Result.isFailure(result))
-      assertInstanceOf(result.failure, UrlParams.UrlParamsError)
+      assertInstanceOf(result.failure, Url.UrlError)
     })
   })
 

--- a/packages/effect/test/unstable/http/Url.test.ts
+++ b/packages/effect/test/unstable/http/Url.test.ts
@@ -1,8 +1,15 @@
 import { describe, it } from "@effect/vitest"
-import { Cause, Redacted } from "effect"
+import { Cause, Redacted, Result } from "effect"
 
 import { Url, UrlParams } from "effect/unstable/http"
-import { assertFailure, assertSuccess, assertTrue, deepStrictEqual, strictEqual } from "../../utils/assert.ts"
+import {
+  assertFailure,
+  assertInstanceOf,
+  assertSuccess,
+  assertTrue,
+  deepStrictEqual,
+  strictEqual
+} from "../../utils/assert.ts"
 
 describe("Url", () => {
   const testURL = new URL("https://example.com/test")
@@ -12,6 +19,26 @@ describe("Url", () => {
     assertTrue(updatedUrl.toString() !== testURL.toString())
     strictEqual(updatedUrl.toString(), expected)
   }
+
+  describe("make", () => {
+    it("appends query parameters and hash", () => {
+      assertSuccess(
+        Url.make(
+          "https://example.com/test?existing=true",
+          UrlParams.fromInput([["foo", "bar"], ["foo", "baz"]]),
+          "section"
+        ),
+        new URL("https://example.com/test?existing=true&foo=bar&foo=baz#section")
+      )
+    })
+
+    it("fails when the URL cannot be constructed", () => {
+      const result = Url.make("http://%", UrlParams.empty, undefined)
+
+      assertTrue(Result.isFailure(result))
+      assertInstanceOf(result.failure, UrlParams.UrlParamsError)
+    })
+  })
 
   describe("fromString", () => {
     it("parses absolute URLs", () => {


### PR DESCRIPTION
## Summary
- Move safe URL construction from `UrlParams.makeUrl` to `Url.make`.
- Add `Url.UrlError` for URL construction failures and remove the now-unused `UrlParams.UrlParamsError`.
- Update HTTP client request URL construction call sites and tests to use `Url.make` / `Url.UrlError`, plus a changeset.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/unstable/http/Url.test.ts`
- `pnpm check:tsgo`