### PR TITLE
[docs][function-pipe]: Add the limit the pipe can support

### DIFF
--- a/.changeset/brave-lies-rule.md
+++ b/.changeset/brave-lies-rule.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add the limit for arguments in pipe

--- a/packages/effect/src/Function.ts
+++ b/packages/effect/src/Function.ts
@@ -669,6 +669,8 @@ export const untupled = <A extends ReadonlyArray<unknown>, B>(f: (a: A) => B): (
  * )
  *
  * console.log(result) // "11"
+ * 
+ * pipe currently support up to 20 functions
  * ```
  *
  * @category combinators


### PR DESCRIPTION
## Type
- ✅  Documentation Update

## Description

While going through the docs for pipe and using it for a specific use-case I was hit with an compilation error that I passed the max number of passed arguments, though it would be good to declare this explicitly 
