### PR TITLE
feat(@effect/ai-anthropic): support custom auth header and extra headers in AnthropicClient

### DIFF
--- a/.changeset/anthropic-client-custom-auth-header.md
+++ b/.changeset/anthropic-client-custom-auth-header.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": minor
+---
+
+Add `apiKeyHeader`, `apiKeyScheme`, and `headers` options to `AnthropicClient.make`/`layer`/`layerConfig`, allowing the API key header name (e.g. `authorization`), its auth scheme prefix (e.g. `Bearer`/`OAuth`), and arbitrary extra request headers to be customized. Useful when targeting a gateway or proxy in front of Anthropic's API that expects different authentication conventions.

--- a/packages/ai/anthropic/src/AnthropicClient.ts
+++ b/packages/ai/anthropic/src/AnthropicClient.ts
@@ -166,6 +166,28 @@ export type Options = {
   readonly apiKey?: Redacted.Redacted<string> | undefined
 
   /**
+   * The name of the HTTP header used to send the `apiKey`.
+   *
+   * **Details**
+   *
+   * Override this when targeting a gateway or proxy in front of Anthropic's API (or an Anthropic-compatible API)
+   * that authenticates requests using a different header, such as `"authorization"`.
+   *
+   * @default "x-api-key"
+   */
+  readonly apiKeyHeader?: string | undefined
+
+  /**
+   * The authentication scheme prefix to prepend to the `apiKey` value before it is sent in the `apiKeyHeader`.
+   *
+   * **Details**
+   *
+   * Set this when `apiKeyHeader` is changed to `"authorization"` and the downstream service expects a scheme
+   * prefix, e.g. `"Bearer"` to produce an `authorization: Bearer <apiKey>` header.
+   */
+  readonly apiKeyScheme?: string | undefined
+
+  /**
    * The base URL for the Anthropic API. Override this to use a proxy or a different API-compatible endpoint.
    *
    * @default "https://api.anthropic.com"
@@ -178,6 +200,16 @@ export type Options = {
    * @default "2023-06-01"
    */
   readonly apiVersion?: string | undefined
+
+  /**
+   * Additional HTTP headers to send with every request made by this client.
+   *
+   * **Details**
+   *
+   * Merged in after all standard headers (`apiKeyHeader`, `anthropic-version`, `accept`), so these values take
+   * precedence and may be used to override them if needed.
+   */
+  readonly headers?: Headers.Input | undefined
 
   /**
    * Optional transformer for the underlying HTTP client, such as middleware, logging, or custom request/response
@@ -218,6 +250,7 @@ export const make = Effect.fnUntraced(
   function*(options: Options): Effect.fn.Return<Service, never, HttpClient.HttpClient> {
     const baseClient = yield* HttpClient.HttpClient
     const apiVersion = options.apiVersion ?? "2023-06-01"
+    const apiKeyHeader = options.apiKeyHeader ?? RedactedAnthropicHeaders.AnthropicApiKey
 
     const httpClient = baseClient.pipe(
       HttpClient.mapRequest((request) =>
@@ -225,12 +258,17 @@ export const make = Effect.fnUntraced(
           HttpClientRequest.prependUrl(options.apiUrl ?? "https://api.anthropic.com"),
           Predicate.isNotUndefined(options.apiKey)
             ? HttpClientRequest.setHeader(
-              RedactedAnthropicHeaders.AnthropicApiKey,
-              Redacted.value(options.apiKey)
+              apiKeyHeader,
+              Predicate.isNotUndefined(options.apiKeyScheme)
+                ? `${options.apiKeyScheme} ${Redacted.value(options.apiKey)}`
+                : Redacted.value(options.apiKey)
             )
             : identity,
           HttpClientRequest.setHeader("anthropic-version", apiVersion),
-          HttpClientRequest.acceptJson
+          HttpClientRequest.acceptJson,
+          Predicate.isNotUndefined(options.headers)
+            ? HttpClientRequest.setHeaders(options.headers)
+            : identity
         )
       ),
       Predicate.isNotUndefined(options.transformClient)
@@ -340,10 +378,12 @@ export const make = Effect.fnUntraced(
       createMessageStream
     })
   },
-  Effect.updateService(
-    Headers.CurrentRedactedNames,
-    Array.appendAll(Object.values(RedactedAnthropicHeaders))
-  )
+  (effect, options: Options) =>
+    Effect.updateService(
+      effect,
+      Headers.CurrentRedactedNames,
+      Array.append(options.apiKeyHeader ?? RedactedAnthropicHeaders.AnthropicApiKey)
+    )
 )
 
 // =============================================================================
@@ -391,6 +431,28 @@ export const layerConfig = (options?: {
   readonly apiKey?: Config.Config<Redacted.Redacted<string> | undefined> | undefined
 
   /**
+   * The name of the HTTP header used to send the `apiKey`.
+   *
+   * **Details**
+   *
+   * Override this when targeting a gateway or proxy in front of Anthropic's API (or an Anthropic-compatible API)
+   * that authenticates requests using a different header, such as `"authorization"`.
+   *
+   * @default "x-api-key"
+   */
+  readonly apiKeyHeader?: Config.Config<string> | undefined
+
+  /**
+   * The authentication scheme prefix to prepend to the `apiKey` value before it is sent in the `apiKeyHeader`.
+   *
+   * **Details**
+   *
+   * Set this when `apiKeyHeader` is changed to `"authorization"` and the downstream service expects a scheme
+   * prefix, e.g. `"Bearer"` to produce an `authorization: Bearer <apiKey>` header.
+   */
+  readonly apiKeyScheme?: Config.Config<string> | undefined
+
+  /**
    * The base URL for the Anthropic API. Override this to use a proxy or a different API-compatible endpoint.
    *
    * @default "https://api.anthropic.com"
@@ -405,6 +467,16 @@ export const layerConfig = (options?: {
   readonly apiVersion?: Config.Config<string> | undefined
 
   /**
+   * Additional HTTP headers to send with every request made by this client.
+   *
+   * **Details**
+   *
+   * Merged in after all standard headers (`apiKeyHeader`, `anthropic-version`, `accept`), so these values take
+   * precedence and may be used to override them if needed.
+   */
+  readonly headers?: Config.Config<Record<string, string>> | undefined
+
+  /**
    * Optional transformer for the underlying HTTP client, such as middleware, logging, or custom request/response
    * handling.
    */
@@ -416,16 +488,28 @@ export const layerConfig = (options?: {
       const apiKey = Predicate.isNotUndefined(options?.apiKey)
         ? yield* options.apiKey :
         undefined
+      const apiKeyHeader = Predicate.isNotUndefined(options?.apiKeyHeader)
+        ? yield* options.apiKeyHeader :
+        undefined
+      const apiKeyScheme = Predicate.isNotUndefined(options?.apiKeyScheme)
+        ? yield* options.apiKeyScheme :
+        undefined
       const apiUrl = Predicate.isNotUndefined(options?.apiUrl)
         ? yield* options.apiUrl :
         undefined
       const apiVersion = Predicate.isNotUndefined(options?.apiVersion)
         ? yield* options.apiVersion :
         undefined
+      const headers = Predicate.isNotUndefined(options?.headers)
+        ? yield* options.headers :
+        undefined
       return yield* make({
         apiKey,
+        apiKeyHeader,
+        apiKeyScheme,
         apiUrl,
         apiVersion,
+        headers,
         transformClient: options?.transformClient
       })
     })


### PR DESCRIPTION
## Summary
- Add `apiKeyHeader` option to `AnthropicClient.make`/`layer`/`layerConfig` — customize the header name used to send the API key (default `"x-api-key"`)
- Add `apiKeyScheme` option — prepend an auth scheme prefix (e.g. `Bearer`, `OAuth`) to the API key value
- Add `headers` option — merge arbitrary extra HTTP headers into every request

Useful when routing Anthropic requests through a gateway/proxy that expects different auth conventions (e.g. `authorization: Bearer <token>` instead of `x-api-key: <token>`).

This is a port of [Effect-TS/effect#6300](https://github.com/Effect-TS/effect/pull/6300), opened against the v3 `effect` repo, since v3 is currently in feature freeze per maintainer guidance in effect#6224.

## Test plan
- [x] `pnpm lint-fix`
- [x] `tsc -b` (package typecheck)
- [x] `pnpm docgen`
- [x] Manual verification via scratchpad script with a mocked `HttpClient` confirming `authorization: Bearer <key>` and custom header appear in outgoing requests, and that the dynamic header name is correctly redacted in logs