### PR TITLE
Fix Memory_20250818 missing requiresHandler flag

### DIFF
--- a/.changeset/fix-anthropic-memory-tool-requires-handler.md
+++ b/.changeset/fix-anthropic-memory-tool-requires-handler.md
@@ -1,0 +1,5 @@
+---
+"@effect/ai-anthropic": patch
+---
+
+Fix `Memory_20250818` provider-defined tool missing `requiresHandler: true`. Like the other client-executed tools (`TextEditor_20250728`, `Bash_2025*`, `ComputerUse_2025*`), the memory tool requires the application to implement its execution (view/create/str_replace/insert/delete/rename over `/memories/*`). Without this flag, `Tool.HandlersFor` excluded it from the required handlers, making it impossible to type-check a handler for `Memory_20250818` in `Toolkit.toLayer`.

--- a/packages/ai/anthropic/src/AnthropicTool.ts
+++ b/packages/ai/anthropic/src/AnthropicTool.ts
@@ -1616,6 +1616,7 @@ export const Memory_20250818 = Tool.providerDefined({
   id: "anthropic.memory_20250818",
   customName: "AnthropicMemory",
   providerName: "memory",
+  requiresHandler: true,
   parameters: Memory_20250818_Commands,
   success: Schema.String
 })


### PR DESCRIPTION
## Summary
- `Memory_20250818` in `packages/ai/anthropic/src/AnthropicTool.ts` was missing `requiresHandler: true`, unlike its structurally identical siblings `TextEditor_20250728`, `Bash_2025*`, and `ComputerUse_2025*`, which all set it.
- Per Anthropic's docs, the memory tool is client-side: the application must implement `view`/`create`/`str_replace`/`insert`/`delete`/`rename` over `/memories/*`, the same execution model as the text-editor and bash tools.
- Because `Tool.HandlersFor<Tools>` maps `RequiresHandler<Tool> extends true ? Handler<...> : never`, the missing flag (defaulting to `false`) made it impossible to type-check a handler for `Memory_20250818` in `Toolkit.toLayer({...})` — the tool could be declared but never wired to real execution.
- Fix: add `requiresHandler: true` to the `Memory_20250818` definition, matching the other client-executed tools.

## Test plan
- [x] `pnpm lint-fix` — clean
- [x] `pnpm check:tsgo` — clean
- [x] Added a changeset (`patch` for `@effect/ai-anthropic`)