### PR TITLE
feat: add `Schema.DateFromMillis`

### DIFF
--- a/.changeset/calm-masks-count.md
+++ b/.changeset/calm-masks-count.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Add `Schema.DateFromMillis` and `SchemaTransformation.dateFromMillis` for decoding millisecond timestamps into `Date` values.

--- a/migration/schema.md
+++ b/migration/schema.md
@@ -29,6 +29,7 @@ This document maps v3 Schema APIs to their v4 equivalents. Simple renames and ar
 | `RedactedFromSelf`                              | `Redacted`                                                                    | rename            |
 | `Redacted`                                      | `RedactedFromValue`                                                           | rename            |
 | `EitherFromSelf`                                | `Result`                                                                      | rename            |
+| `DateFromNumber`                                | `DateFromMillis`                                                              | rename            |
 | `TaggedError`                                   | `TaggedErrorClass`                                                            | rename            |
 | `decodeUnknown`                                 | `decodeUnknownEffect`                                                         | rename            |
 | `decode`                                        | `decodeEffect`                                                                | rename            |

--- a/packages/effect/src/Schema.ts
+++ b/packages/effect/src/Schema.ts
@@ -10451,6 +10451,8 @@ const DateString = String.annotate({ expected: "a string in ISO 8601 format that
  * ```
  *
  * @see {@link DateValid} for accepting only valid Date instances
+ * @see {@link DateFromString} for decoding strings into Date instances
+ * @see {@link DateFromMillis} for decoding epoch milliseconds into Date instances
  *
  * @category Date
  * @since 4.0.0
@@ -10510,6 +10512,8 @@ export interface DateFromString extends decodeTo<Date, String> {
  *
  * Invalid date strings can decode to invalid `Date` instances.
  *
+ * @see {@link DateFromMillis} for decoding epoch milliseconds into Date instances
+ * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
  * @see {@link Date} for accepting Date instances directly
  * @see {@link DateValid} for rejecting invalid Date instances
  *
@@ -10517,6 +10521,47 @@ export interface DateFromString extends decodeTo<Date, String> {
  * @since 3.10.0
  */
 export const DateFromString: DateFromString = DateString.pipe(decodeTo(Date, SchemaTransformation.dateFromString))
+
+/**
+ * Type-level representation of {@link DateFromMillis}.
+ *
+ * @category Date
+ * @since 4.0.0
+ */
+export interface DateFromMillis extends decodeTo<Date, Number> {
+  readonly "Rebuild": DateFromMillis
+}
+
+/**
+ * Schema that decodes epoch milliseconds into a JavaScript `Date`.
+ *
+ * **When to use**
+ *
+ * Use to model numeric millisecond timestamps that decode to JavaScript `Date`
+ * objects and encode back to numbers.
+ *
+ * **Details**
+ *
+ * Decoding:
+ * A number of milliseconds since the Unix epoch is decoded as a `Date`.
+ *
+ * Encoding:
+ * A `Date` is encoded as its millisecond timestamp.
+ *
+ * **Gotchas**
+ *
+ * This schema accepts any number, including `NaN`, `Infinity`, and `-Infinity`.
+ * Those values decode to invalid `Date` instances.
+ *
+ * @see {@link DateFromString} for decoding string-encoded dates
+ * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
+ *
+ * @category Date
+ * @since 4.0.0
+ */
+export const DateFromMillis: DateFromMillis = Number.pipe(
+  decodeTo(Date, SchemaTransformation.dateFromMillis)
+)
 
 /**
  * Type-level representation of {@link DateValid}.
@@ -12064,6 +12109,10 @@ export interface DateTimeUtcFromString extends decodeTo<DateTimeUtc, String> {
  *
  * - A `DateTime.Utc` is encoded as a UTC ISO 8601 string.
  *
+ * @see {@link DateTimeUtcFromDate} for decoding JavaScript Date values into UTC values
+ * @see {@link DateTimeUtcFromMillis} for decoding epoch milliseconds into UTC values
+ * @see {@link DateFromString} for decoding strings into JavaScript Date instances
+ *
  * @category DateTime
  * @since 4.0.0
  */
@@ -12096,6 +12145,10 @@ export interface DateTimeUtcFromMillis extends decodeTo<instanceOf<DateTime.Utc>
  *
  * Encoding:
  * - A `DateTime.Utc` is encoded as a number of milliseconds since the Unix epoch.
+ *
+ * @see {@link DateTimeUtcFromDate} for decoding JavaScript Date values into UTC values
+ * @see {@link DateTimeUtcFromString} for decoding date-time strings into UTC values
+ * @see {@link DateFromMillis} for decoding epoch milliseconds into JavaScript Date instances
  *
  * @category DateTime
  * @since 4.0.0

--- a/packages/effect/src/SchemaTransformation.ts
+++ b/packages/effect/src/SchemaTransformation.ts
@@ -871,7 +871,7 @@ export const bigintFromString = new Transformation(
  * )
  * ```
  *
- * @see {@link numberFromString}
+ * @see {@link dateFromMillis}
  * @see {@link dateTimeUtcFromString}
  *
  * @category Coercions
@@ -880,6 +880,46 @@ export const bigintFromString = new Transformation(
 export const dateFromString: Transformation<globalThis.Date, string> = new Transformation(
   SchemaGetter.Date(),
   SchemaGetter.transform(formatDate)
+)
+
+/**
+ * Decodes epoch milliseconds into a `Date` and encodes a `Date` back to epoch
+ * milliseconds.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema transformation for numeric timestamps represented
+ * as milliseconds since the Unix epoch.
+ *
+ * **Details**
+ *
+ * Decoding creates a `Date` from the number like `new Date(ms)`. Encoding
+ * returns the `Date` timestamp like `date.getTime()`.
+ *
+ * **Gotchas**
+ *
+ * This transformation does not validate date validity. `NaN`, `Infinity`, and
+ * `-Infinity` decode to invalid `Date` instances.
+ *
+ * **Example** (Converting milliseconds to a Date)
+ *
+ * ```ts
+ * import { Schema, SchemaTransformation } from "effect"
+ *
+ * const schema = Schema.Number.pipe(
+ *   Schema.decodeTo(Schema.Date, SchemaTransformation.dateFromMillis)
+ * )
+ * ```
+ *
+ * @see {@link dateFromString}
+ * @see {@link SchemaGetter.dateTimeUtcFromInput}
+ *
+ * @category Coercions
+ * @since 4.0.0
+ */
+export const dateFromMillis: Transformation<globalThis.Date, number> = new Transformation(
+  SchemaGetter.Date(),
+  SchemaGetter.transform((date) => date.getTime())
 )
 
 /**
@@ -1762,8 +1802,8 @@ export const timeZoneFromString: Transformation<DateTime.TimeZone, string> = tra
  * UTC, and fails with `InvalidValue` when parsing fails. Encode uses
  * `DateTime.formatIso`.
  *
- * @see {@link dateTimeZonedFromString} for ISO strings that should preserve zoned date-time information
  * @see {@link dateFromString} for decoding into JavaScript `Date`
+ * @see {@link dateTimeZonedFromString} for ISO strings that should preserve zoned date-time information
  *
  * @category transforming
  * @since 4.0.0

--- a/packages/effect/test/schema/Schema.test.ts
+++ b/packages/effect/test/schema/Schema.test.ts
@@ -1954,6 +1954,28 @@ Expected a value with a size of at most 2, got Map([["a",1],["b",NaN],["c",3]])`
       await encoding.succeed(new Date("2021-01-01T00:00:00.000Z"), "2021-01-01T00:00:00.000Z")
     })
 
+    it("DateFromMillis", async () => {
+      const schema = Schema.DateFromMillis
+      const asserts = new TestSchema.Asserts(schema)
+      if (verifyGeneration) {
+        asserts.arbitrary().verifyGeneration()
+      }
+
+      const decoding = asserts.decoding()
+      await decoding.succeed(0, new Date(0))
+      assertTrue(Schema.decodeSync(schema)(NaN) instanceof Date)
+      assertTrue(Schema.decodeSync(schema)(Infinity) instanceof Date)
+      assertTrue(Schema.decodeSync(schema)(-Infinity) instanceof Date)
+      await decoding.fail(null, `Expected number, got null`)
+
+      const encoding = asserts.encoding()
+      await encoding.succeed(new Date(0), 0)
+      strictEqual(Schema.encodeSync(schema)(new Date("invalid")), NaN)
+      strictEqual(Schema.encodeSync(schema)(new Date(NaN)), NaN)
+      strictEqual(Schema.encodeSync(schema)(new Date(Infinity)), NaN)
+      strictEqual(Schema.encodeSync(schema)(new Date(-Infinity)), NaN)
+    })
+
     it("FiniteFromString", async () => {
       const schema = Schema.FiniteFromString
       const asserts = new TestSchema.Asserts(schema)


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Adds `SchemaTransformation.dateFromMillis` and `Schema.DateFromMillis` for decoding epoch millisecond numbers into native JavaScript `Date` values and encoding Dates back with `getTime()`.

Effect v3 has [`Schema.DateFromNumber`](https://github.com/Effect-TS/effect/blob/3e59443be029e99d2b457bb43f682feb5ebcd2e0/packages/effect/src/Schema.ts#L6865-L6873), but v4 currently only exposes the millisecond-number conversion for `DateTime.Utc` via `Schema.DateTimeUtcFromMillis`. Since v4 still supports native JavaScript `Date` schemas such as `Schema.Date` and `Schema.DateFromString`, this PR fills the corresponding millisecond timestamp gap for users who need to keep native `Date` values instead of migrating that field to `DateTime.Utc`.

The new schema follows the v3 behavior by accepting any number, including non-finite numbers, which decode to (potentially invalid) `Date` instances. It also documents the related native `Date` and `DateTime.Utc` alternatives with `@see` tags.

Includes schema tests for decode/encode behavior and a patch changeset.

Validation:

- `corepack pnpm lint-fix`
- `corepack pnpm test packages/effect/test/schema/Schema.test.ts`
- `corepack pnpm test-types packages/effect/typetest/schema/Schema.tst.ts`
- `corepack pnpm check:tsgo`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue: N/A
- Closes: N/A
