### PR TITLE
Fix MCP string request ids

### DIFF
--- a/.changeset/fix-mcp-string-request-id.md
+++ b/.changeset/fix-mcp-string-request-id.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix MCP servers handling non-numeric JSON-RPC string request ids.

--- a/packages/effect/src/unstable/rpc/RpcMessage.ts
+++ b/packages/effect/src/unstable/rpc/RpcMessage.ts
@@ -49,7 +49,13 @@ export type RequestId = Branded<bigint, "~effect/rpc/RpcMessage/RequestId">
  * @since 4.0.0
  */
 export const RequestId = (id: bigint | string): RequestId =>
-  typeof id === "bigint" ? id as RequestId : BigInt(id) as RequestId
+  typeof id === "bigint"
+    ? id as RequestId
+    : isNumericRequestId(id)
+    ? BigInt(id) as RequestId
+    : id as unknown as RequestId
+
+const isNumericRequestId = (id: string) => id === "0" || /^-?[1-9]\d*$/.test(id)
 
 /**
  * The transport-encoded RPC request envelope, including the string request id,

--- a/packages/effect/src/unstable/rpc/RpcSerialization.ts
+++ b/packages/effect/src/unstable/rpc/RpcSerialization.ts
@@ -341,7 +341,7 @@ function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessag
         jsonrpc: "2.0",
         method: response.tag,
         params: response.payload,
-        id: response.id !== "" ? Number(response.id) : "",
+        id: encodeJsonRpcRequestId(response.id),
         headers: response.headers,
         traceId: response.traceId,
         spanId: response.spanId,
@@ -361,21 +361,21 @@ function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessag
       return {
         jsonrpc: "2.0",
         chunk: true,
-        id: Number(response.requestId),
+        id: encodeJsonRpcRequestId(response.requestId),
         result: response.values
       }
     case "Exit": {
       if (response.exit._tag === "Success") {
         return {
           jsonrpc: "2.0",
-          id: response.requestId !== "" ? Number(response.requestId) : undefined,
+          id: encodeJsonRpcResponseId(response.requestId),
           result: response.exit.value
         } as any
       }
       const error = response.exit.cause.find((failure) => failure._tag === "Fail")
       return {
         jsonrpc: "2.0",
-        id: response.requestId !== "" ? Number(response.requestId) : undefined,
+        id: encodeJsonRpcResponseId(response.requestId),
         error: response.exit._tag === "Failure" ?
           {
             _tag: "Cause",
@@ -403,6 +403,13 @@ function encodeJsonRpcMessage(response: RpcMessage.FromServerEncoded | RpcMessag
       return {} as never
   }
 }
+
+const isJsonRpcNumberId = (id: string) => id === "0" || /^-?[1-9]\d*$/.test(id)
+
+const encodeJsonRpcRequestId = (id: string): string | number => id !== "" && isJsonRpcNumberId(id) ? Number(id) : id
+
+const encodeJsonRpcResponseId = (id: string): string | number | undefined =>
+  id === "" ? undefined : encodeJsonRpcRequestId(id)
 
 const jsonRpcInternalError = -32603
 

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -79,4 +79,31 @@ describe("McpServer", () => {
 
       strictEqual(response.status, 404)
     }))
+
+  it.effect("accepts string JSON-RPC request ids", () =>
+    Effect.gen(function*() {
+      const { httpClient } = yield* makeTestClient
+
+      const response = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe({
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: {
+              name: "TestClient",
+              version: "1.0.0"
+            }
+          },
+          id: "14f40ee1b859ee70"
+        }),
+        httpClient.execute
+      )
+      const body = yield* response.json
+
+      strictEqual(response.status, 200)
+      strictEqual((body as any).id, "14f40ee1b859ee70")
+      strictEqual((body as any).result.protocolVersion, "2025-06-18")
+    }))
 })


### PR DESCRIPTION
## What changed

- Preserve non-numeric JSON-RPC string ids instead of forcing every RPC request id through `BigInt`.
- Preserve non-numeric ids when encoding JSON-RPC responses.
- Add an MCP HTTP regression using the reported id shape from #2303.
- Add a patch changeset for `effect`.

## Root cause

MCP accepts JSON-RPC request ids as strings or numbers, but the RPC bridge assumed string ids were numeric and converted them with `BigInt(...)`. Opaque ids such as `14f40ee1b859ee70` therefore failed before the tool call could complete.

Fixes #2303.

## Validation

- `pnpm test packages/effect/test/unstable/ai/McpServer.test.ts`
- `pnpm test packages/effect/test/rpc/RpcSerialization.test.ts`
- `pnpm check:tsgo`