### PR TITLE
Fix workflow entity client collision

### DIFF
--- a/.changeset/fix-workflow-entity-client-collision.md
+++ b/.changeset/fix-workflow-entity-client-collision.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix ClusterWorkflowEngine partial workflow clients colliding with full workflow clients.

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -10,8 +10,10 @@ import * as Context from "../../Context.ts"
 import * as DateTime from "../../DateTime.ts"
 import * as Duration from "../../Duration.ts"
 import * as Effect from "../../Effect.ts"
+import * as Equal from "../../Equal.ts"
 import * as Exit from "../../Exit.ts"
 import * as Fiber from "../../Fiber.ts"
+import * as Hash from "../../Hash.ts"
 import * as Latch from "../../Latch.ts"
 import * as Layer from "../../Layer.ts"
 import * as Option from "../../Option.ts"
@@ -345,9 +347,10 @@ export const make = Effect.gen(function*() {
 
   const engine = WorkflowEngine.makeUnsafe({
     register: (workflow, execute) =>
-      Effect.suspend(() =>
-        sharding.registerEntity(
-          ensureEntity(workflow),
+      Effect.suspend(() => {
+        const entity = ensureEntity(workflow)
+        const registerEntity = sharding.registerEntity(
+          entity,
           Effect.gen(function*() {
             const address = yield* Entity.CurrentAddress
             const executionId = address.entityId
@@ -436,8 +439,11 @@ export const make = Effect.gen(function*() {
               resume: () => ensureSuccess(resume(workflow, executionId))
             }
           })
+        )
+        return RcMap.invalidate(clientsPartial, workflow._tag).pipe(
+          Effect.andThen(registerEntity)
         ) as Effect.Effect<void, never, Scope.Scope>
-      ),
+      }),
 
     execute: (workflow, { discard, executionId, parent, payload }) => {
       ensureEntity(workflow)
@@ -708,12 +714,20 @@ const makeWorkflowEntity = (workflow: Workflow.Any) =>
     ActivityRpc
   ]).annotateMerge(workflow.annotations)
 
-const makePartialWorkflowEntity = (workflowName: string) =>
-  Entity.make(`Workflow/${workflowName}`, [
+const makePartialWorkflowEntity = (workflowName: string) => {
+  const entity = Entity.make(`Workflow/${workflowName}`, [
     DeferredRpc,
     ResumeRpc,
     ActivityRpc
   ])
+  const hash = Hash.combine(Hash.string("partial"))(Hash.string(entity.type))
+  // Partial and full entities share the persisted address but need distinct client proxies.
+  Object.defineProperties(entity, {
+    [Equal.symbol]: { value: (that: Equal.Equal) => that === entity },
+    [Hash.symbol]: { value: () => hash }
+  })
+  return entity
+}
 
 const activityPrimaryKey = (activity: string, attempt: number) => `${activity}/${attempt}`
 

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -279,6 +279,39 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       assert.strictEqual(envelope.address.shardId.group, "workflow")
     }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
 
+  it.effect("routes activities to the workflow shard group after a partial client is cached", () =>
+    Effect.gen(function*() {
+      const driver = yield* MessageStorage.MemoryDriver
+      const engine = yield* WorkflowEngine
+      const payload = { id: "partial-client-before-execute" }
+      const executionId = yield* ShardedDeferredWorkflow.executionId(payload)
+      const token = DurableDeferred.tokenFromExecutionId(ShardedDeferred, {
+        workflow: ShardedDeferredWorkflow,
+        executionId
+      })
+
+      yield* DurableDeferred.done(ShardedDeferred, {
+        token,
+        exit: Exit.void
+      })
+
+      yield* engine.register(ShardedDeferredWorkflow, () =>
+        Activity.make({
+          name: "ShardedActivity",
+          execute: Effect.void
+        }))
+
+      const journalLength = driver.journal.length
+      assert.strictEqual(yield* ShardedDeferredWorkflow.execute(payload), undefined)
+      const envelope = driver.journal.slice(journalLength).find((envelope) =>
+        envelope._tag === "Request" &&
+        envelope.address.entityType === "Workflow/ShardedDeferredWorkflow" &&
+        envelope.tag === "activity"
+      )
+      assert(envelope)
+      assert.strictEqual(envelope.address.shardId.group, "workflow")
+    }).pipe(Effect.scoped, Effect.provide(TestWorkflowEngine)))
+
   it.effect("SuspendOnFailure", () =>
     Effect.gen(function*() {
       const flags = yield* Flags


### PR DESCRIPTION
## What changed

- Keep partial workflow entities routed to the persisted `Workflow/${name}` address.
- Give partial workflow entities distinct client-cache identity from the full workflow entity so Sharding does not reuse a proxy missing `run`.
- Add the deferred-first-then-execute regression from #2520.
- Add a patch changeset for `effect`.

## Root cause

`ClusterWorkflowEngine` builds both a full workflow entity and a partial workflow entity for deferred/resume/activity operations. Both used the same entity type, so the sharding client `ResourceMap` could cache the partial proxy first and later return it for `Workflow.execute`, where `run` does not exist.

Fixes #2520.

## Validation

- `pnpm test packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `pnpm check:tsgo`