### PR TITLE
Isolate cluster entity handler context from the fiber that first wakes it

### DIFF
--- a/.changeset/fix-cluster-entity-context-bleed.md
+++ b/.changeset/fix-cluster-entity-context-bleed.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Isolate a cluster entity's handler context from the fiber that first wakes it, so a caller/request-scoped service (such as an in-flight SQL transaction) present on that fiber is no longer frozen into the entity's long-lived `RpcServer` and reused by every later request.

--- a/.changeset/fix-cluster-entity-context-bleed.md
+++ b/.changeset/fix-cluster-entity-context-bleed.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Isolate a cluster entity's handler context from the fiber that first wakes it, so a caller/request-scoped service (such as an in-flight SQL transaction) present on that fiber is no longer frozen into the entity's long-lived `RpcServer` and reused by every later request.
+Use registration context for cluster entities

--- a/.changeset/tasty-moments-post.md
+++ b/.changeset/tasty-moments-post.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+add Effect.setContext for fully replacing the fiber context

--- a/packages/effect/src/Effect.ts
+++ b/packages/effect/src/Effect.ts
@@ -5958,6 +5958,53 @@ export const provideContext: {
 } = internal.provideContext
 
 /**
+ * Runs an effect with the provided context as its complete environment.
+ *
+ * **When to use**
+ *
+ * Use when you already have a `Context` containing every service required by
+ * the effect and want the wrapped effect to run with exactly that context.
+ *
+ * **Gotchas**
+ *
+ * `setContext` replaces the current context for the wrapped effect. Services
+ * from an outer context are not inherited unless they are also present in the
+ * context passed to `setContext`.
+ *
+ * **Example** (Running with a complete context)
+ *
+ * ```ts
+ * import { Context, Effect } from "effect"
+ *
+ * class Config extends Context.Service<Config, {
+ *   readonly greeting: string
+ * }>()("Config") {}
+ *
+ * const program = Effect.gen(function*() {
+ *   const config = yield* Effect.service(Config)
+ *   return `${config.greeting}, World!`
+ * })
+ *
+ * const context = Context.make(Config, { greeting: "Hello" })
+ *
+ * const runnable = Effect.setContext(program, context)
+ *
+ * Effect.runPromise(runnable).then(console.log)
+ * // Output: "Hello, World!"
+ * ```
+ *
+ * @see {@link provideContext} for partially satisfying an effect's context requirements.
+ * @see {@link updateContext} for deriving the required context from the current one.
+ *
+ * @category environment
+ * @since 4.0.0
+ */
+export const setContext: {
+  <R>(context: Context.Context<R>): <A, E>(self: Effect<A, E, R>) => Effect<A, E>
+  <A, E, R>(self: Effect<A, E, R>, context: Context.Context<R>): Effect<A, E>
+} = internal.setContext
+
+/**
  * Accesses a service from the context.
  *
  * **Example** (Accessing a required service)

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -2082,6 +2082,25 @@ export const contextWith = <R, A, E, R2>(
 ): Effect.Effect<A, E, R | R2> => withFiber((fiber) => f(fiber.context as Context.Context<R>))
 
 /** @internal */
+export const setContext: {
+  <R>(
+    context: Context.Context<R>
+  ): <A, E>(
+    self: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A, E>
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    context: Context.Context<R>
+  ): Effect.Effect<A, E>
+} = dual(
+  2,
+  <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    context: Context.Context<R>
+  ): Effect.Effect<A, E> => updateContext(self, constant(context))
+)
+
+/** @internal */
 export const provideContext: {
   <XR>(
     context: Context.Context<XR>

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -644,11 +644,6 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       entityId: entityId as EntityId,
       shardId: makeShardId(entityId)
     })
-    // Build the handlers + RpcServer under the registration context (plus
-    // per-entity additions), not the ambient context of the acquiring fiber, so
-    // a caller-scoped service is not frozen into the entity server.
-    // `updateContext` sets rather than merges onto the ambient (as
-    // `entityManager` does).
     const scope = yield* Effect.scope
     const handlerContext = Context.mutate(entityEntry.context, (context) =>
       context.pipe(
@@ -657,7 +652,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
         Context.add(Scope, scope)
       ))
     const handlers = yield* entityEntry.build.pipe(
-      Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
+      Effect.setContext(handlerContext as Context.Context<any>)
     )
 
     // oxlint-disable-next-line prefer-const
@@ -668,8 +663,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
         return client.write(response)
       }
     }).pipe(
-      Effect.provide(handlers),
-      Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
+      Effect.setContext(Context.merge(handlerContext, handlers))
     )
 
     client = yield* RpcClient.makeNoSerialization(entity.protocol, {

--- a/packages/effect/src/unstable/cluster/Entity.ts
+++ b/packages/effect/src/unstable/cluster/Entity.ts
@@ -618,11 +618,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       Rpc.ServicesClient<Rpcs> | Rpc.ServicesServer<Rpcs> | Rpc.Middleware<Rpcs> | LR
     >
     readonly concurrency: number | "unbounded"
-    readonly build: Effect.Effect<
-      Context.Context<Rpc.ToHandler<Rpcs>>,
-      never,
-      Scope | CurrentAddress
-    >
+    readonly build: Effect.Effect<Context.Context<Rpc.ToHandler<Rpcs>>>
   }>()
   const sharding = shardingTag.of({
     ...({} as Sharding["Service"]),
@@ -631,13 +627,7 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
         entityMap.set(entity.type, {
           context: context as any,
           concurrency: options?.concurrency ?? 1,
-          build: entity.protocol.toHandlers(handlers as any).pipe(
-            Effect.provideContext(Context.mutate(context, (context) =>
-              context.pipe(
-                Context.add(CurrentRunnerAddress, runnerAddress),
-                Context.omit(Scope)
-              )))
-          ) as any
+          build: entity.protocol.toHandlers(handlers as any) as any
         })
         return Effect.void
       })
@@ -654,8 +644,20 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       entityId: entityId as EntityId,
       shardId: makeShardId(entityId)
     })
+    // Build the handlers + RpcServer under the registration context (plus
+    // per-entity additions), not the ambient context of the acquiring fiber, so
+    // a caller-scoped service is not frozen into the entity server.
+    // `updateContext` sets rather than merges onto the ambient (as
+    // `entityManager` does).
+    const scope = yield* Effect.scope
+    const handlerContext = Context.mutate(entityEntry.context, (context) =>
+      context.pipe(
+        Context.add(CurrentRunnerAddress, runnerAddress),
+        Context.add(CurrentAddress, address),
+        Context.add(Scope, scope)
+      ))
     const handlers = yield* entityEntry.build.pipe(
-      Effect.provideService(CurrentAddress, address)
+      Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
     )
 
     // oxlint-disable-next-line prefer-const
@@ -665,7 +667,10 @@ export const makeTestClient: <Type extends string, Rpcs extends Rpc.Any, LA, LE,
       onFromServer(response) {
         return client.write(response)
       }
-    }).pipe(Effect.provide(handlers))
+    }).pipe(
+      Effect.provide(handlers),
+      Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
+    )
 
     client = yield* RpcClient.makeNoSerialization(entity.protocol, {
       supportsAck: true,

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -155,23 +155,18 @@ export const make = Effect.fnUntraced(function*<
       Effect.fnUntraced(function*(scope) {
         let isShuttingDown = false
 
-        // Build the handlers + RpcServer under the registration `context` (plus
-        // per-entity additions), not the ambient context of whichever fiber
-        // first wakes the entity (or triggers a defect rebuild), so a
-        // caller-scoped service is not frozen into this long-lived server.
-        // `updateContext` sets rather than merges onto the ambient.
         const handlerContext = Context.mutate(context, (context) =>
           context.pipe(
             Context.add(CurrentAddress, address),
             Context.add(CurrentRunnerAddress, options.runnerAddress),
             Context.add(KeepAliveLatch, keepAliveLatch),
-            Context.add(Scope.Scope, scope)
+            Context.add(Scope.Scope, scope),
+            Context.add(CurrentLogAnnotations, {})
           ))
 
         // Initiate the behavior for the entity
         const handlers = yield* (entity.protocol.toHandlers(buildHandlers as any).pipe(
-          Effect.provideService(CurrentLogAnnotations, {}),
-          Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>),
+          Effect.setContext(handlerContext as Context.Context<any>),
           Effect.sandbox,
           Effect.tapError((cause) => Effect.logError("Defect building entity handlers", cause)),
           Effect.retry(defectRetryPolicy)
@@ -287,8 +282,7 @@ export const make = Effect.fnUntraced(function*<
           }
         }).pipe(
           Scope.provide(scope),
-          Effect.provideContext(handlers),
-          Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
+          Effect.setContext(Context.merge(handlerContext, handlers))
         )
 
         yield* Scope.addFinalizer(

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -155,16 +155,23 @@ export const make = Effect.fnUntraced(function*<
       Effect.fnUntraced(function*(scope) {
         let isShuttingDown = false
 
+        // Build the handlers + RpcServer under the registration `context` (plus
+        // per-entity additions), not the ambient context of whichever fiber
+        // first wakes the entity (or triggers a defect rebuild), so a
+        // caller-scoped service is not frozen into this long-lived server.
+        // `updateContext` sets rather than merges onto the ambient.
+        const handlerContext = Context.mutate(context, (context) =>
+          context.pipe(
+            Context.add(CurrentAddress, address),
+            Context.add(CurrentRunnerAddress, options.runnerAddress),
+            Context.add(KeepAliveLatch, keepAliveLatch),
+            Context.add(Scope.Scope, scope)
+          ))
+
         // Initiate the behavior for the entity
         const handlers = yield* (entity.protocol.toHandlers(buildHandlers as any).pipe(
           Effect.provideService(CurrentLogAnnotations, {}),
-          Effect.provideContext(Context.mutate(context, (context) =>
-            context.pipe(
-              Context.add(CurrentAddress, address),
-              Context.add(CurrentRunnerAddress, options.runnerAddress),
-              Context.add(KeepAliveLatch, keepAliveLatch),
-              Context.add(Scope.Scope, scope)
-            ))),
+          Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>),
           Effect.sandbox,
           Effect.tapError((cause) => Effect.logError("Defect building entity handlers", cause)),
           Effect.retry(defectRetryPolicy)
@@ -280,7 +287,8 @@ export const make = Effect.fnUntraced(function*<
           }
         }).pipe(
           Scope.provide(scope),
-          Effect.provideContext(handlers)
+          Effect.provideContext(handlers),
+          Effect.updateContext((_: Context.Context<never>) => handlerContext as Context.Context<any>)
         )
 
         yield* Scope.addFinalizer(

--- a/packages/effect/test/cluster/Entity.test.ts
+++ b/packages/effect/test/cluster/Entity.test.ts
@@ -21,20 +21,12 @@ describe.concurrent("Entity", () => {
         assert.deepEqual(user, new User({ id: 1, name: "User 1" }))
       }).pipe(Effect.provide(TestShardingConfig)))
 
-    // The entity's handler server is built once, on whichever fiber first wakes
-    // it. If that fiber's ambient context is merged into the build, a caller's
-    // request-scoped service is frozen into the server and observed by every
-    // later, unrelated request. The build must be a pure function of the
-    // registration context, not of the acquiring fiber.
     it.effect("does not freeze the acquiring fiber's context into the entity server", () =>
       Effect.gen(function*() {
         const makeClient = yield* Entity.makeTestClient(ContextBleedEntity, ContextBleedLayer)
 
-        // Acquiring the client builds the entity; do so from a fiber that
-        // provides CallerId = "A".
         const client = yield* makeClient("1").pipe(Effect.provideService(CallerId, "A"))
 
-        // A later request that provides no CallerId must not observe "A".
         const observed = yield* client.ReadCaller()
         assert.strictEqual(observed, "none")
       }).pipe(Effect.provide(TestShardingConfig)))

--- a/packages/effect/test/cluster/Entity.test.ts
+++ b/packages/effect/test/cluster/Entity.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { type Cause, Effect, Queue, Schema, Stream } from "effect"
 import { Entity, ShardingConfig } from "effect/unstable/cluster"
 import { Rpc } from "effect/unstable/rpc/index"
-import { TestEntity, TestEntityLayer, User } from "./TestEntity.ts"
+import { CallerId, ContextBleedEntity, ContextBleedLayer, TestEntity, TestEntityLayer, User } from "./TestEntity.ts"
 
 const StreamEntity = Entity.make("StreamEntity", [
   Rpc.make("Watch", {
@@ -19,6 +19,24 @@ describe.concurrent("Entity", () => {
         const client = yield* makeClient("123")
         const user = yield* client.GetUser({ id: 1 })
         assert.deepEqual(user, new User({ id: 1, name: "User 1" }))
+      }).pipe(Effect.provide(TestShardingConfig)))
+
+    // The entity's handler server is built once, on whichever fiber first wakes
+    // it. If that fiber's ambient context is merged into the build, a caller's
+    // request-scoped service is frozen into the server and observed by every
+    // later, unrelated request. The build must be a pure function of the
+    // registration context, not of the acquiring fiber.
+    it.effect("does not freeze the acquiring fiber's context into the entity server", () =>
+      Effect.gen(function*() {
+        const makeClient = yield* Entity.makeTestClient(ContextBleedEntity, ContextBleedLayer)
+
+        // Acquiring the client builds the entity; do so from a fiber that
+        // provides CallerId = "A".
+        const client = yield* makeClient("1").pipe(Effect.provideService(CallerId, "A"))
+
+        // A later request that provides no CallerId must not observe "A".
+        const observed = yield* client.ReadCaller()
+        assert.strictEqual(observed, "none")
       }).pipe(Effect.provide(TestShardingConfig)))
   })
 

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -11,7 +11,15 @@ import {
   ShardingConfig,
   Snowflake
 } from "effect/unstable/cluster"
-import { TestEntity, TestEntityNoState, TestEntityState, User } from "./TestEntity.ts"
+import {
+  CallerId,
+  ContextBleedEntity,
+  ContextBleedLayer,
+  TestEntity,
+  TestEntityNoState,
+  TestEntityState,
+  User
+} from "./TestEntity.ts"
 
 describe.concurrent("Sharding", () => {
   it.effect("delivers volatile requests directly to the entity", () =>
@@ -22,6 +30,30 @@ describe.concurrent("Sharding", () => {
       const user = yield* client.GetUserVolatile({ id: 1 })
       expect(user).toEqual(new User({ id: 1, name: "User 1" }))
     }).pipe(Effect.provide(TestSharding)))
+
+  it.effect("does not freeze the first caller's context into the entity server", () =>
+    Effect.gen(function*() {
+      yield* TestClock.adjust(1)
+      const makeClient = yield* ContextBleedEntity.client
+      const client = makeClient("1")
+
+      // The first (volatile) request wakes and builds the entity inline on this
+      // fiber, which provides CallerId = "A".
+      const first = yield* client.ReadCaller().pipe(Effect.provideService(CallerId, "A"))
+      expect(first).toEqual("A")
+
+      // A later volatile request that provides no CallerId must not observe the
+      // "A" frozen into the server by the first request.
+      const second = yield* client.ReadCaller()
+      expect(second).toEqual("none")
+
+      // Neither must a later durable request. This is the scenario the bug
+      // actually harms: a persisted request (delivered on the storage-loop
+      // fiber) running against the scoped context of whoever first woke the
+      // entity.
+      const durable = yield* client.ReadCallerPersisted()
+      expect(durable).toEqual("none")
+    }).pipe(Effect.provide(ContextBleedSharding)))
 
   it.effect("persists durable requests until the entity replies", () =>
     Effect.gen(function*() {
@@ -576,3 +608,5 @@ const TestSharding = TestShardingWithoutStorage.pipe(
   Layer.provideMerge(MessageStorage.layerMemory),
   Layer.provide(TestShardingConfig)
 )
+
+const ContextBleedSharding = ContextBleedLayer.pipe(Layer.provideMerge(TestSharding))

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -37,20 +37,12 @@ describe.concurrent("Sharding", () => {
       const makeClient = yield* ContextBleedEntity.client
       const client = makeClient("1")
 
-      // The first (volatile) request wakes and builds the entity inline on this
-      // fiber, which provides CallerId = "A".
       const first = yield* client.ReadCaller().pipe(Effect.provideService(CallerId, "A"))
       expect(first).toEqual("A")
 
-      // A later volatile request that provides no CallerId must not observe the
-      // "A" frozen into the server by the first request.
       const second = yield* client.ReadCaller()
       expect(second).toEqual("none")
 
-      // Neither must a later durable request. This is the scenario the bug
-      // actually harms: a persisted request (delivered on the storage-loop
-      // fiber) running against the scoped context of whoever first woke the
-      // entity.
       const durable = yield* client.ReadCallerPersisted()
       expect(durable).toEqual("none")
     }).pipe(Effect.provide(ContextBleedSharding)))

--- a/packages/effect/test/cluster/TestEntity.ts
+++ b/packages/effect/test/cluster/TestEntity.ts
@@ -130,3 +130,27 @@ export const TestEntityNoState = TestEntity.toLayer(
 )
 
 export const TestEntityLayer = TestEntityNoState.pipe(Layer.provideMerge(TestEntityState.layer))
+
+// A marker service used to prove that a caller's request-scoped context does
+// not bleed into an entity's long-lived server. It is deliberately NOT provided
+// by the entity layer; the handler reads it best-effort via `serviceOption`, so
+// it stands in for a scoped service (e.g. a SQL transaction context) that only
+// happens to be present on whichever fiber first wakes the entity.
+export const CallerId = Context.Service<never, string>(
+  "effect/test/cluster/CallerId"
+)
+
+export const ContextBleedEntity = Entity.make("ContextBleedEntity", [
+  // Volatile: the first message builds the entity inline on the caller's fiber.
+  Rpc.make("ReadCaller", { success: Schema.String }).annotate(ClusterSchema.Persisted, false),
+  // Durable: delivered on the detached storage-loop fiber, so it can only see a
+  // caller's context if an earlier message froze it into the server.
+  Rpc.make("ReadCallerPersisted", { success: Schema.String }).annotate(ClusterSchema.Persisted, true)
+])
+
+const readCaller = () => Effect.map(Effect.serviceOption(CallerId), Option.getOrElse(() => "none"))
+
+export const ContextBleedLayer = ContextBleedEntity.toLayer({
+  ReadCaller: readCaller,
+  ReadCallerPersisted: readCaller
+})

--- a/packages/effect/test/cluster/TestEntity.ts
+++ b/packages/effect/test/cluster/TestEntity.ts
@@ -131,20 +131,12 @@ export const TestEntityNoState = TestEntity.toLayer(
 
 export const TestEntityLayer = TestEntityNoState.pipe(Layer.provideMerge(TestEntityState.layer))
 
-// A marker service used to prove that a caller's request-scoped context does
-// not bleed into an entity's long-lived server. It is deliberately NOT provided
-// by the entity layer; the handler reads it best-effort via `serviceOption`, so
-// it stands in for a scoped service (e.g. a SQL transaction context) that only
-// happens to be present on whichever fiber first wakes the entity.
 export const CallerId = Context.Service<never, string>(
   "effect/test/cluster/CallerId"
 )
 
 export const ContextBleedEntity = Entity.make("ContextBleedEntity", [
-  // Volatile: the first message builds the entity inline on the caller's fiber.
   Rpc.make("ReadCaller", { success: Schema.String }).annotate(ClusterSchema.Persisted, false),
-  // Durable: delivered on the detached storage-loop fiber, so it can only see a
-  // caller's context if an earlier message froze it into the server.
   Rpc.make("ReadCallerPersisted", { success: Schema.String }).annotate(ClusterSchema.Persisted, true)
 ])
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

A cluster entity's `RpcServer` is built once, lazily, inline on whichever fiber first delivers a message to it — and it captured that fiber's ambient context via `Effect.provideContext` (a merge, not a replace). So a caller/request-scoped service on that fiber — e.g. an in-flight SQL `TransactionContext` — got frozen into the long-lived server (`toHandlers` bakes it into each handler's `entry.context`, and the server captures it again) and reused by every later request, long after the caller's scope had closed. It triggers on a non-persisted first message (the default) or a defect rebuild, and once frozen it poisons every later request, durable ones included.

**Fix:** build the handlers and the server under exactly the registration context plus the per-entity additions, using `updateContext` (set) instead of `provideContext` (merge). Same change in `Entity.makeTestClient`. Sitting in the `writeRef` acquire body, it also covers defect rebuilds. (Alternative: isolate in `ResourceMap`'s lookup wrapper to fix all consumers at once — I didn't, as it's broader and misses the defect-rebuild path, which bypasses the wrapper.)

**Tests:** `ContextBleedEntity` (volatile + persisted RPCs) reads a marker service standing in for the transaction context. The first request wakes the entity providing `CallerId = "A"`; later requests provide nothing and must not see `"A"` — covered through real `Sharding` (volatile and durable) and `makeTestClient`. All fail on `main`, pass after the fix.