### PR TITLE
Allow cron fields like `5/15` to expand from the starting value through the field maximum.

### DIFF
--- a/.changeset/cron-single-value-step.md
+++ b/.changeset/cron-single-value-step.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Allow cron fields like `5/15` to expand from the starting value through the field maximum.

--- a/packages/effect/src/Cron.ts
+++ b/packages/effect/src/Cron.ts
@@ -1165,7 +1165,9 @@ const parseSegment = (
       }
 
       if (right === undefined) {
-        values.add(left)
+        for (let i = left; i <= (step === undefined ? left : options.max); i += step ?? 1) {
+          values.add(i)
+        }
       } else {
         if (!Number.isInteger(right)) {
           return Result.fail(new CronParseError({ message: `Expected a positive integer`, input }))

--- a/packages/effect/test/Cron.test.ts
+++ b/packages/effect/test/Cron.test.ts
@@ -64,6 +64,18 @@ describe("Cron", () => {
       }))
     )
 
+    // Starting at minute 5 and then every 15 minutes.
+    deepStrictEqual(
+      Cron.parse("5/15 * * * *"),
+      Result.succeed(Cron.make({
+        minutes: [5, 20, 35, 50],
+        hours: [],
+        days: [],
+        months: [],
+        weekdays: []
+      }))
+    )
+
     const withNamedTimeZone = Cron.parseUnsafe("23 0-20/2 * * *", "Europe/Berlin")
     assertTrue(Option.isSome(withNamedTimeZone.tz))
     deepStrictEqual(DateTime.zoneToString(withNamedTimeZone.tz.value), "Europe/Berlin")


### PR DESCRIPTION
https://github.com/Effect-TS/effect/issues/6301