### PR TITLE
Fix AtomRegistry parent links for duplicate reads

### DIFF
--- a/.changeset/clean-atom-parent-links.md
+++ b/.changeset/clean-atom-parent-links.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix AtomRegistry parent-child tracking when an atom reads the same parent more than once.

--- a/packages/effect/src/unstable/reactivity/AtomRegistry.ts
+++ b/packages/effect/src/unstable/reactivity/AtomRegistry.ts
@@ -634,9 +634,12 @@ class NodeImpl<A> {
         const parents = this.previousParents
         this.previousParents = undefined
         for (let i = 0; i < parents.length; i++) {
-          parents[i].removeChild(this)
-          if (parents[i].canBeRemoved) {
-            this.registry.scheduleNodeRemoval(parents[i])
+          const parent = parents[i]
+          if (this.parents.indexOf(parent) === -1) {
+            parent.removeChild(this)
+            if (parent.canBeRemoved) {
+              this.registry.scheduleNodeRemoval(parent)
+            }
           }
         }
       }
@@ -706,14 +709,19 @@ class NodeImpl<A> {
   }
 
   addParent(parent: NodeImpl<any>): void {
-    this.parents.push(parent)
+    if (this.parents.indexOf(parent) === -1) {
+      this.parents.push(parent)
+    }
     if (this.previousParents !== undefined) {
-      const index = this.previousParents.indexOf(parent)
-      if (index !== -1) {
+      let index = this.previousParents.indexOf(parent)
+      while (index !== -1) {
         this.previousParents[index] = this.previousParents[this.previousParents.length - 1]
-        if (this.previousParents.pop() === undefined) {
+        this.previousParents.pop()
+        if (this.previousParents.length === 0) {
           this.previousParents = undefined
+          break
         }
+        index = this.previousParents.indexOf(parent)
       }
     }
 

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -350,6 +350,39 @@ describe.sequential("Atom", () => {
     expect(rebuilds).toEqual(2)
   })
 
+  it("keeps parent child links when a parent is read more than once", () => {
+    const flag = Atom.make(true)
+    const base = Atom.make(0)
+    const derived = Atom.make((get) => {
+      const value = get(base)
+      if (get(flag)) {
+        get(base)
+      }
+      return value
+    })
+    const registry = AtomRegistry.make()
+    const unsubscribe = registry.subscribe(derived, () => {
+    }, { immediate: true })
+    const nodes = registry.getNodes()
+    const baseNode = nodes.get(base)
+    const derivedNode = nodes.get(derived)
+
+    assert(baseNode !== undefined)
+    assert(derivedNode !== undefined)
+    assert.strictEqual(baseNode.children.includes(derivedNode), true)
+    assert.strictEqual(derivedNode.parents.filter((parent) => parent === baseNode).length, 1)
+
+    registry.set(flag, false)
+
+    assert.strictEqual(baseNode.children.includes(derivedNode), true)
+    assert.strictEqual(derivedNode.parents.includes(baseNode), true)
+
+    registry.set(base, 1)
+
+    assert.strictEqual(registry.get(derived), 1)
+    unsubscribe()
+  })
+
   it("refresh derived before mount resolves base effect", async () => {
     const baseAtom = Atom.make(
       Effect.succeed("value").pipe(Effect.delay(100))


### PR DESCRIPTION
## Summary

Fixes an `AtomRegistry` dependency graph bug where an atom can stop being invalidated by a parent atom after recomputation.

## Problem

`AtomRegistry` tracks dependencies bidirectionally:

- a child atom stores its `parents`
- a parent atom stores its `children`

Those links must stay consistent. In some cases, the child still had a parent in `child.parents`, but the parent no longer had the child in `parent.children`. Once that happens, future updates to the parent do not invalidate the child, so the child keeps returning stale data.

## When It Happens

The bug can happen when a derived atom reads the same parent more than once during one evaluation, then later recomputes and reads that parent fewer times.

Example shape:

```ts
const derived = Atom.make((get) => {
  const value = get(base)

  if (get(flag)) {
    get(base)
  }

  return value
})