### PR TITLE
Add Schedule.max api

### DIFF
--- a/.changeset/fresh-cycles-wait.md
+++ b/.changeset/fresh-cycles-wait.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove the `Schedule.both` APIs and add `Schedule.max` for combining schedules by their slowest delay.

--- a/ai-docs/src/06_schedule/10_schedules.ts
+++ b/ai-docs/src/06_schedule/10_schedules.ts
@@ -70,12 +70,13 @@ export const maxRetries = Schedule.recurs(5)
 export const spacedPolling = Schedule.spaced("30 seconds")
 export const exponentialBackoff = Schedule.exponential("200 millis")
 
-// `Schedule.both` continues only while both schedules continue.
-// It is useful for combining a delay pattern with a hard attempt cap.
-export const retryBackoffWithLimit = Schedule.both(
+// `Schedule.max` continues only while all schedules continue and outputs
+// the slowest delay. It is useful for combining a delay pattern with a hard
+// attempt cap.
+export const retryBackoffWithLimit = Schedule.max([
   Schedule.exponential("250 millis"),
   Schedule.recurs(6)
-)
+])
 
 // `Schedule.either` continues while either schedule continues.
 // It is useful for fallback behavior (e.g. stop only when both are exhausted).

--- a/cookbooks/schedule.md
+++ b/cookbooks/schedule.md
@@ -17,7 +17,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
 - Schedule output is policy output. Use `Schedule.passthrough`,
   `Schedule.delays`, `Schedule.map`, or `Schedule.reduce` when the output shape
   matters.
-- `Schedule.both` continues only while both schedules continue.
+- `Schedule.max` continues only while all schedules continue and outputs the slowest delay.
 - `Schedule.either` continues while either schedule can continue.
 - `Schedule.jittered` spreads callers out. It does not add a recurrence limit.
 - `Schedule.addDelay` adds extra delay based on schedule output.
@@ -35,7 +35,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
 | Replace or cap selected delay             | `Schedule.modifyDelay`                                                                                            |
 | Run phases in sequence                    | `Schedule.andThen`                                                                                                |
 | Preserve phase in output                  | `Schedule.andThenResult`                                                                                          |
-| Continue while both policies continue     | `Schedule.both`                                                                                                   |
+| Continue while all policies continue      | `Schedule.max`                                                                                                    |
 | Continue while either policy continues    | `Schedule.either`                                                                                                 |
 | Keep input or output history              | `Schedule.collectInputs`, `Schedule.collectOutputs`, or `Schedule.collectWhile`                                   |
 | Maintain a running aggregate              | `Schedule.reduce`                                                                                                 |
@@ -253,15 +253,15 @@ backoff, allows at most 5 recurrences, and also stops after about 20 seconds.
 ```ts
 import { Schedule } from "effect"
 
-const deploymentHookRetryBudget = Schedule.exponential("200 millis").pipe(
-  Schedule.jittered,
-  Schedule.both(Schedule.recurs(5)),
-  Schedule.both(Schedule.during("20 seconds"))
-)
+const deploymentHookRetryBudget = Schedule.max([
+  Schedule.exponential("200 millis").pipe(Schedule.jittered),
+  Schedule.recurs(5),
+  Schedule.during("20 seconds")
+])
 ```
 
-Explanation: the resulting output is nested because `Schedule.both` preserves
-both schedule outputs. Use `Schedule.map` when a smaller output is needed.
+Explanation: `Schedule.max` stops when any schedule stops and outputs the
+slowest selected delay for each recurrence.
 
 ### Continue While Either Probe Is Active
 
@@ -472,12 +472,13 @@ selected delay.
 ```ts
 import { Duration, Effect, Schedule } from "effect"
 
-const websocketReconnectDelays = Schedule.exponential("100 millis").pipe(
-  Schedule.jittered,
-  Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, Duration.seconds(5)))),
-  Schedule.both(Schedule.recurs(8)),
-  Schedule.delays
-)
+const websocketReconnectDelays = Schedule.max([
+  Schedule.exponential("100 millis").pipe(
+    Schedule.jittered,
+    Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, Duration.seconds(5))))
+  ),
+  Schedule.recurs(8)
+])
 ```
 
 Explanation: `Schedule.modifyDelay` receives the selected delay and returns the
@@ -610,13 +611,15 @@ const isRetryableGraphqlGatewayError = (
       error.status === 502 ||
       error.status === 503))
 
-const graphqlGatewayRetry = Schedule.exponential("100 millis").pipe(
-  Schedule.jittered,
-  Schedule.setInputType<GraphqlGatewayError>(),
-  Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, Duration.seconds(2)))),
-  Schedule.both(Schedule.recurs(6)),
-  Schedule.while(({ input }) => isRetryableGraphqlGatewayError(input)),
-  Schedule.delays
+const graphqlGatewayRetry = Schedule.max([
+  Schedule.exponential("100 millis").pipe(
+    Schedule.jittered,
+    Schedule.setInputType<GraphqlGatewayError>(),
+    Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, Duration.seconds(2))))
+  ),
+  Schedule.recurs(6)
+]).pipe(
+  Schedule.while(({ input }) => isRetryableGraphqlGatewayError(input))
 )
 ```
 
@@ -627,7 +630,7 @@ jitters the selected delay, outputs the latest status, continues only while the
 rollout is running, and stops after about 2 minutes.
 
 ```ts
-import { Schedule } from "effect"
+import { Duration, Schedule } from "effect"
 
 type RolloutStatus = {
   readonly state: "running" | "succeeded" | "failed"
@@ -637,9 +640,10 @@ const rolloutStatusWatcher = Schedule.fixed("1 second").pipe(
   Schedule.setInputType<RolloutStatus>(),
   Schedule.passthrough,
   Schedule.jittered,
-  Schedule.both(Schedule.during("2 minutes")),
-  Schedule.while(({ input }) => input.state === "running"),
-  Schedule.map(([status]) => status)
+  Schedule.while(({ input, elapsed }) =>
+    input.state === "running" &&
+    Duration.isLessThanOrEqualTo(Duration.millis(elapsed), Duration.minutes(2))
+  )
 )
 ```
 
@@ -658,22 +662,24 @@ type PushProviderResponse = {
   readonly retryAfter: Duration.Duration | undefined
 }
 
-const pushNotificationProviderRetry = Schedule.exponential("1 second").pipe(
-  Schedule.setInputType<PushProviderResponse>(),
-  Schedule.passthrough,
-  Schedule.modifyDelay((response, delay) =>
-    Effect.succeed(
-      Duration.min(
-        response.retryAfter === undefined
-          ? delay
-          : Duration.max(delay, response.retryAfter),
-        Duration.minutes(1)
+const pushNotificationProviderRetry = Schedule.max([
+  Schedule.exponential("1 second").pipe(
+    Schedule.setInputType<PushProviderResponse>(),
+    Schedule.passthrough,
+    Schedule.modifyDelay((response, delay) =>
+      Effect.succeed(
+        Duration.min(
+          response.retryAfter === undefined
+            ? delay
+            : Duration.max(delay, response.retryAfter),
+          Duration.minutes(1)
+        )
       )
     )
   ),
-  Schedule.both(Schedule.recurs(6)),
-  Schedule.while(({ input }) => input.status === 429 || input.status === 500 || input.status === 503),
-  Schedule.delays
+  Schedule.recurs(6)
+]).pipe(
+  Schedule.while(({ input }) => input.status === 429 || input.status === 500 || input.status === 503)
 )
 ```
 
@@ -684,7 +690,7 @@ another 5 seconds for `slow_down`, output the latest input, continue only for
 `authorization_pending` and `slow_down`, and stop after about 15 minutes.
 
 ```ts
-import { Effect, Schedule } from "effect"
+import { Duration, Effect, Schedule } from "effect"
 
 type OAuthDeviceCodeStatus = {
   readonly error:
@@ -698,9 +704,10 @@ const oauthDeviceCodePolling = Schedule.spaced("5 seconds").pipe(
   Schedule.setInputType<OAuthDeviceCodeStatus>(),
   Schedule.passthrough,
   Schedule.addDelay((status) => Effect.succeed(status.error === "slow_down" ? "5 seconds" : "0 millis")),
-  Schedule.both(Schedule.during("15 minutes")),
-  Schedule.while(({ input }) => input.error === "authorization_pending" || input.error === "slow_down"),
-  Schedule.map(([status]) => status)
+  Schedule.while(({ input, elapsed }) =>
+    (input.error === "authorization_pending" || input.error === "slow_down") &&
+    Duration.isLessThanOrEqualTo(Duration.millis(elapsed), Duration.minutes(15))
+  )
 )
 ```
 

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -219,6 +219,38 @@ export declare namespace Schedule {
   }
 }
 
+/**
+ * Extracts the output type from a `Schedule`.
+ *
+ * @category type extractors
+ * @since 4.0.0
+ */
+export type Output<S> = S extends Schedule<infer Output, any, any, any> ? Output : never
+
+/**
+ * Extracts the input type from a `Schedule`.
+ *
+ * @category type extractors
+ * @since 4.0.0
+ */
+export type Input<S> = S extends Schedule<any, infer Input, any, any> ? Input : never
+
+/**
+ * Extracts the error type from a `Schedule`.
+ *
+ * @category type extractors
+ * @since 4.0.0
+ */
+export type Error<S> = S extends Schedule<any, any, infer Error, any> ? Error : never
+
+/**
+ * Extracts the service requirements from a `Schedule`.
+ *
+ * @category type extractors
+ * @since 4.0.0
+ */
+export type Env<S> = S extends Schedule<any, any, any, infer Env> ? Env : never
+
 const ScheduleProto = {
   [TypeId]: {
     _Out: identity,
@@ -741,51 +773,34 @@ export const andThenResult: {
     }
   })))
 
-type ScheduleInput<S> = S extends Schedule<any, infer Input, any, any> ? Input : never
-
-type ScheduleError<S> = S extends Schedule<any, any, infer Error, any> ? Error : never
-
-type ScheduleEnv<S> = S extends Schedule<any, any, any, infer Env> ? Env : never
-
 type NonEmptySchedules = readonly [
   Schedule<any, any, any, any>,
   ...ReadonlyArray<Schedule<any, any, any, any>>
 ]
 
 type SchedulesInput<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = UnionToIntersection<
-  ScheduleInput<Schedules[number]>
+  Input<Schedules[number]>
 >
 
-type SchedulesError<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = ScheduleError<Schedules[number]>
+type SchedulesError<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = Error<Schedules[number]>
 
-type SchedulesEnv<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = ScheduleEnv<Schedules[number]>
+type SchedulesEnv<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = Env<Schedules[number]>
 
-const maxDuration = <Input, Error, Env, Input2, Error2, Env2>(
-  self: Schedule<Duration.Duration, Input, Error, Env>,
-  other: Schedule<Duration.Duration, Input2, Error2, Env2>
-): Schedule<Duration.Duration, Input & Input2, Error | Error2, Env | Env2> =>
-  fromStep(effect.map(
-    effect.zip(toStep(self), toStep(other)),
-    ([stepLeft, stepRight]) => (now, input) =>
-      Pull.matchEffect(stepLeft(now, input as Input), {
-        onSuccess: (leftResult) =>
-          stepRight(now, input as Input2).pipe(
-            effect.map((rightResult) => {
-              const duration = Duration.max(leftResult[0], rightResult[0])
-              return [duration, duration] as [Duration.Duration, Duration.Duration]
-            }),
-            Pull.catchDone((rightDone) => Cause.done(Duration.max(leftResult[0], rightDone as Duration.Duration)))
-          ),
-        onDone: (leftDone) =>
-          stepRight(now, input as Input2).pipe(
-            effect.flatMap((rightResult) => Cause.done(Duration.max(leftDone as Duration.Duration, rightResult[0]))),
-            Pull.catchDone((rightDone) =>
-              Cause.done(Duration.max(leftDone as Duration.Duration, rightDone as Duration.Duration))
-            )
-          ),
-        onFailure: effect.failCause
-      })
-  ))
+type MaxStepResult = {
+  readonly _tag: "Continue"
+  readonly duration: Duration.Duration
+} | {
+  readonly _tag: "Done"
+  readonly duration: Duration.Duration
+}
+
+const maxDuration = (durations: ReadonlyArray<Duration.Duration>): Duration.Duration => {
+  let max = durations[0]!
+  for (let i = 1; i < durations.length; i++) {
+    max = Duration.max(max, durations[i]!)
+  }
+  return max
+}
 
 /**
  * Combines schedules by recurring while all schedules want to recur, using the
@@ -836,12 +851,33 @@ const maxDuration = <Input, Error, Env, Input2, Error2, Env2>(
 export const max = <const Schedules extends NonEmptySchedules>(
   schedules: Schedules
 ): Schedule<Duration.Duration, SchedulesInput<Schedules>, SchedulesError<Schedules>, SchedulesEnv<Schedules>> => {
-  const [head, ...tail] = schedules
-  let schedule: Schedule<Duration.Duration, any, any, any> = delays(head)
-  for (const current of tail) {
-    schedule = maxDuration(schedule, delays(current))
-  }
-  return schedule
+  return fromStep(effect.map(
+    effect.all(schedules.map((schedule) => toStep(delays(schedule)))),
+    (steps) => (now, input) =>
+      effect.flatMap(
+        effect.all(steps.map((step) =>
+          Pull.matchEffect(step(now, input as never), {
+            onSuccess: (result) =>
+              effect.succeed<MaxStepResult>({
+                _tag: "Continue",
+                duration: result[0]
+              }),
+            onDone: (duration) =>
+              effect.succeed<MaxStepResult>({
+                _tag: "Done",
+                duration
+              }),
+            onFailure: effect.failCause
+          })
+        )),
+        (results) => {
+          const duration = maxDuration(results.map((result) => result.duration))
+          return results.some((result) => result._tag === "Done") ?
+            Cause.done(duration) :
+            effect.succeed([duration, duration] as [Duration.Duration, Duration.Duration])
+        }
+      )
+  ))
 }
 
 /**

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -22,7 +22,7 @@ import { type Pipeable, pipeArguments } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 import * as Pull from "./Pull.ts"
 import * as Result from "./Result.ts"
-import type { Contravariant, Covariant, Mutable } from "./Types.ts"
+import type { Contravariant, Covariant, Mutable, UnionToIntersection } from "./Types.ts"
 
 const TypeId = "~effect/Schedule"
 
@@ -41,9 +41,10 @@ const randomNext: Effect<number> = random.Random.useSync((random) => random.next
  * }> {}
  *
  * // Basic retry schedule - retry up to 3 times with exponential backoff
- * const retrySchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.both(Schedule.recurs(3))
- * )
+ * const retrySchedule = Schedule.max([
+ *   Schedule.exponential("100 millis"),
+ *   Schedule.recurs(3)
+ * ])
  *
  * // Basic repeat schedule - repeat every 30 seconds forever
  * const repeatSchedule: Schedule.Schedule<number, unknown, never> = Schedule
@@ -740,287 +741,108 @@ export const andThenResult: {
     }
   })))
 
-/**
- * Combines two `Schedule`s by recurring if both of the two schedules want
- * to recur, using the maximum of the two durations between recurrences and
- * outputting a tuple of the outputs of both schedules.
- *
- * **When to use**
- *
- * Use when the combined schedule should continue only while both schedules still recur.
- *
- * **Example** (Combining time and attempt limits)
- *
- * ```ts
- * import { Console, Data, Effect, Schedule } from "effect"
- *
- * class RetryAttemptError extends Data.TaggedError("RetryAttemptError")<{ readonly message: string }> {}
- *
- * // Both schedules must want to continue for the combined schedule to continue
- * const timeLimit = Schedule.spaced("1 second").pipe(Schedule.take(5)) // max 5 times
- * const attemptLimit = Schedule.recurs(3) // max 3 attempts
- *
- * // Continues only while BOTH schedules want to continue (intersection/AND logic)
- * const bothSchedule = Schedule.both(timeLimit, attemptLimit)
- * // Outputs: [time_result, attempt_count] tuple
- *
- * const program = Effect.gen(function*() {
- *   const results = yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task completed"
- *     }),
- *     bothSchedule.pipe(
- *       Schedule.tapOutput(([timeResult, attemptResult]) =>
- *         Console.log(`Time: ${timeResult}, Attempts: ${attemptResult}`)
- *       )
- *     )
- *   )
- *
- *   yield* Console.log("Completed all executions")
- * })
- *
- * // Both with different delay strategies - uses maximum delay
- * const fastSchedule = Schedule.fixed("500 millis").pipe(Schedule.take(4))
- * const slowSchedule = Schedule.spaced("2 seconds").pipe(Schedule.take(6))
- *
- * // Will use the slower (maximum) delay and stop when first schedule exhausts
- * const conservativeSchedule = Schedule.both(fastSchedule, slowSchedule)
- *
- * const retryProgram = Effect.gen(function*() {
- *   let attempt = 0
- *
- *   const result = yield* Effect.retry(
- *     Effect.gen(function*() {
- *       attempt++
- *       yield* Console.log(`Retry attempt ${attempt}`)
- *
- *       if (attempt < 3) {
- *         return yield* Effect.fail(new RetryAttemptError({ message: `Attempt ${attempt} failed` }))
- *       }
- *
- *       return `Success on attempt ${attempt}`
- *     }),
- *     conservativeSchedule
- *   )
- *
- *   yield* Console.log(`Final result: ${result}`)
- * })
- *
- * // Both provides intersection semantics (AND logic)
- * // Compare with either which provides union semantics (OR logic)
- * ```
- *
- * @see {@link either} for continuing while either schedule still recurs
- *
- * @category combining
- * @since 2.0.0
- */
-export const both: {
-  <Output2, Input2, Error2, Env2, Output>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2> =>
-  bothWith(self, other, (left, right) => [left, right]))
+type ScheduleInput<S> = S extends Schedule<any, infer Input, any, any> ? Input : never
 
-/**
- * Combines two `Schedule`s by recurring if both of the two schedules want
- * to recur, using the maximum of the two durations between recurrences and
- * outputting the result of the left schedule (i.e. `self`).
- *
- * **When to use**
- *
- * Use when two schedules must both allow recurrence and only the left schedule's
- * output is needed.
- *
- * **Example** (Combining schedules and keeping the left output)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine two schedules, keeping left output
- * const leftSchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("left-result"))
- * )
- * const rightSchedule = Schedule.spaced("50 millis")
- *
- * const combined = Schedule.bothLeft(leftSchedule, rightSchedule)
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-done"
- *     }),
- *     combined.pipe(Schedule.take(3))
- *   )
- * })
- * ```
- *
- * @category combining
- * @since 2.0.0
- */
-export const bothLeft: {
-  <Output2, Input2, Error2, Env2>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<Output, Input & Input2, Error | Error2, Env | Env2> => bothWith(self, other, (output) => output))
+type ScheduleError<S> = S extends Schedule<any, any, infer Error, any> ? Error : never
 
-/**
- * Combines two `Schedule`s by recurring if both of the two schedules want
- * to recur, using the maximum of the two durations between recurrences and
- * outputting the result of the right schedule (i.e. `other`).
- *
- * **When to use**
- *
- * Use when two schedules must both allow recurrence and only the right
- * schedule's output is needed.
- *
- * **Example** (Combining schedules and keeping the right output)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine two schedules, keeping right output
- * const leftSchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("left-result"))
- * )
- * const rightSchedule = Schedule.spaced("50 millis").pipe(
- *   Schedule.map(() => Effect.succeed("right-result"))
- * )
- *
- * const combined = Schedule.bothRight(leftSchedule, rightSchedule)
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-done"
- *     }),
- *     combined.pipe(Schedule.take(3))
- *   )
- * })
- * ```
- *
- * @category combining
- * @since 2.0.0
- */
-export const bothRight: {
-  <Output2, Input2, Error2, Env2>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<Output2, Input & Input2, Error | Error2, Env | Env2> => bothWith(self, other, (_, output) => output))
+type ScheduleEnv<S> = S extends Schedule<any, any, any, infer Env> ? Env : never
 
-/**
- * Combines two `Schedule`s by recurring if both of the two schedules want
- * to recur, using the maximum of the two durations between recurrences and
- * outputting the result of the combination of both schedule outputs using the
- * specified `combine` function.
- *
- * **When to use**
- *
- * Use when two schedules must both allow recurrence and their outputs should be
- * combined into a custom value.
- *
- * **Example** (Combining schedule outputs)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine two schedules with custom output combination
- * const leftSchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("left"))
- * )
- * const rightSchedule = Schedule.spaced("50 millis").pipe(
- *   Schedule.map(() => Effect.succeed("right"))
- * )
- *
- * const combined = Schedule.bothWith(
- *   leftSchedule,
- *   rightSchedule,
- *   (left, right) => `${left}-${right}`
- * )
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-result"
- *     }),
- *     combined.pipe(Schedule.take(3))
- *   )
- * })
- * ```
- *
- * @category combining
- * @since 2.0.0
- */
-export const bothWith: {
-  <Output2, Input2, Error2, Env2, Output, Output3>(
-    other: Schedule<Output2, Input2, Error2, Env2>,
-    combine: (selfOutput: Output, otherOutput: Output2) => Output3
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output3, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2, Output3>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>,
-    combine: (selfOutput: Output, otherOutput: Output2) => Output3
-  ): Schedule<Output3, Input & Input2, Error | Error2, Env | Env2>
-} = dual(3, <Output, Input, Error, Env, Output2, Input2, Error2, Env2, Output3>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>,
-  combine: (selfOutput: Output, otherOutput: Output2) => Output3
-): Schedule<Output3, Input & Input2, Error | Error2, Env | Env2> =>
+type NonEmptySchedules = readonly [
+  Schedule<any, any, any, any>,
+  ...ReadonlyArray<Schedule<any, any, any, any>>
+]
+
+type SchedulesInput<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = UnionToIntersection<
+  ScheduleInput<Schedules[number]>
+>
+
+type SchedulesError<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = ScheduleError<Schedules[number]>
+
+type SchedulesEnv<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = ScheduleEnv<Schedules[number]>
+
+const maxDuration = <Input, Error, Env, Input2, Error2, Env2>(
+  self: Schedule<Duration.Duration, Input, Error, Env>,
+  other: Schedule<Duration.Duration, Input2, Error2, Env2>
+): Schedule<Duration.Duration, Input & Input2, Error | Error2, Env | Env2> =>
   fromStep(effect.map(
     effect.zip(toStep(self), toStep(other)),
     ([stepLeft, stepRight]) => (now, input) =>
       Pull.matchEffect(stepLeft(now, input as Input), {
         onSuccess: (leftResult) =>
           stepRight(now, input as Input2).pipe(
-            effect.map((rightResult) =>
-              [
-                combine(leftResult[0], rightResult[0]),
-                Duration.max(leftResult[1], rightResult[1])
-              ] as [Output3, Duration.Duration]
-            ),
-            Pull.catchDone((rightDone) => Cause.done(combine(leftResult[0], rightDone as Output2)))
+            effect.map((rightResult) => {
+              const duration = Duration.max(leftResult[0], rightResult[0])
+              return [duration, duration] as [Duration.Duration, Duration.Duration]
+            }),
+            Pull.catchDone((rightDone) => Cause.done(Duration.max(leftResult[0], rightDone as Duration.Duration)))
           ),
         onDone: (leftDone) =>
           stepRight(now, input as Input2).pipe(
-            effect.flatMap((rightResult) => Cause.done(combine(leftDone, rightResult[0]))),
-            Pull.catchDone((rightDone) => Cause.done(combine(leftDone, rightDone as Output2)))
+            effect.flatMap((rightResult) => Cause.done(Duration.max(leftDone as Duration.Duration, rightResult[0]))),
+            Pull.catchDone((rightDone) =>
+              Cause.done(Duration.max(leftDone as Duration.Duration, rightDone as Duration.Duration))
+            )
           ),
         onFailure: effect.failCause
       })
-  )))
+  ))
+
+/**
+ * Combines schedules by recurring while all schedules want to recur, using the
+ * maximum delay between recurrences and outputting that maximum delay.
+ *
+ * **When to use**
+ *
+ * Use when a combined policy should continue only while every schedule still
+ * recurs, and should wait for the slowest schedule between recurrences.
+ *
+ * **Example** (Combining retry schedules by their maximum delay)
+ *
+ * ```ts
+ * import { Console, Data, Effect, Schedule } from "effect"
+ *
+ * class RetryAttemptError extends Data.TaggedError("RetryAttemptError")<{ readonly message: string }> {}
+ *
+ * const retrySchedule = Schedule.max([
+ *   Schedule.fixed("5 seconds"),
+ *   Schedule.exponential("5 seconds"),
+ *   Schedule.spaced("10 seconds")
+ * ])
+ *
+ * const program = Effect.gen(function*() {
+ *   let attempt = 0
+ *
+ *   yield* Effect.retry(
+ *     Effect.gen(function*() {
+ *       attempt++
+ *       yield* Console.log(`Retry attempt ${attempt}`)
+ *       if (attempt < 3) {
+ *         return yield* Effect.fail(new RetryAttemptError({ message: `Attempt ${attempt} failed` }))
+ *       }
+ *       return "success"
+ *     }),
+ *     retrySchedule.pipe(
+ *       Schedule.tapOutput((duration) =>
+ *         Console.log(`Waiting for the slowest schedule: ${duration}`)
+ *       )
+ *     )
+ *   )
+ * })
+ * ```
+ *
+ * @category combining
+ * @since 4.0.0
+ */
+export const max = <const Schedules extends NonEmptySchedules>(
+  schedules: Schedules
+): Schedule<Duration.Duration, SchedulesInput<Schedules>, SchedulesError<Schedules>, SchedulesEnv<Schedules>> => {
+  const [head, ...tail] = schedules
+  let schedule: Schedule<Duration.Duration, any, any, any> = delays(head)
+  for (const current of tail) {
+    schedule = maxDuration(schedule, delays(current))
+  }
+  return schedule
+}
 
 /**
  * Returns a new `Schedule` that recurs on the specified `Cron` schedule and
@@ -1239,10 +1061,11 @@ export const duration = (durationInput: Duration.Input): Schedule<Duration.Durat
  * })
  *
  * // Combine with other schedules for time-bounded execution
- * const timeAndCountLimited = Schedule.spaced("1 second").pipe(
- *   Schedule.both(Schedule.during("10 seconds")), // Stop after 10 seconds OR
- *   Schedule.both(Schedule.recurs(15)) // 15 attempts, whichever comes first
- * )
+ * const timeAndCountLimited = Schedule.max([
+ *   Schedule.spaced("1 second"),
+ *   Schedule.during("10 seconds"), // Stop after 10 seconds OR
+ *   Schedule.recurs(15) // 15 attempts, whichever comes first
+ * ])
  *
  * // Burst execution within time window
  * const burstWindow = Schedule.during("3 seconds")
@@ -1262,9 +1085,10 @@ export const duration = (durationInput: Duration.Input): Schedule<Duration.Durat
  * })
  *
  * // Timed retry window - retry for up to 30 seconds
- * const timedRetry = Schedule.exponential("200 millis").pipe(
- *   Schedule.both(Schedule.during("30 seconds"))
- * )
+ * const timedRetry = Schedule.max([
+ *   Schedule.exponential("200 millis"),
+ *   Schedule.during("30 seconds")
+ * ])
  *
  * const retryProgram = Effect.gen(function*() {
  *   let attempt = 0
@@ -1370,10 +1194,10 @@ export const during = (duration: Duration.Input): Schedule<Duration.Duration> =>
  * })
  *
  * // Either provides union semantics (OR logic)
- * // Compare with both, which provides intersection semantics (AND logic)
+ * // Compare with max, which continues only while all schedules recur
  * ```
  *
- * @see {@link both} for continuing only while both schedules still recur
+ * @see {@link max} for continuing only while all schedules still recur
  *
  * @category combining
  * @since 2.0.0
@@ -1616,10 +1440,10 @@ export const eitherWith: {
  * const program = Effect.gen(function*() {
  *   yield* Effect.repeat(
  *     Console.log("Running task..."),
- *     Schedule.spaced("1 second").pipe(
- *       Schedule.both(Schedule.elapsed),
- *       Schedule.tapOutput(([count, duration]) =>
- *         Console.log(`Run ${count}, elapsed: ${Duration.toMillis(duration)}ms`)
+ *     Schedule.elapsed.pipe(
+ *       Schedule.addDelay(() => Effect.succeed("1 second")),
+ *       Schedule.tapOutput((duration) =>
+ *         Console.log(`Elapsed: ${Duration.toMillis(duration)}ms`)
  *       ),
  *       Schedule.take(5)
  *     )
@@ -1655,9 +1479,10 @@ export const elapsed: Schedule<Duration.Duration> = fromStepWithMetadata(
  * // Delays: 200ms, 300ms, 450ms, 675ms, 1012ms, ...
  *
  * // Retry with exponential backoff (limited to 5 attempts)
- * const retryPolicy = Schedule.exponential("50 millis").pipe(
- *   Schedule.both(Schedule.recurs(5))
- * )
+ * const retryPolicy = Schedule.max([
+ *   Schedule.exponential("50 millis"),
+ *   Schedule.recurs(5)
+ * ])
  *
  * const program = Effect.gen(function*() {
  *   let attempt = 0
@@ -1725,8 +1550,10 @@ export const exponential = (
  *
  *       return `Success on attempt ${attempt}`
  *     }),
- *     Schedule.fibonacci("50 millis").pipe(
- *       Schedule.both(Schedule.recurs(6)), // Maximum 6 retries
+ *     Schedule.max([
+ *       Schedule.fibonacci("50 millis"),
+ *       Schedule.recurs(6) // Maximum 6 retries
+ *     ]).pipe(
  *       Schedule.tapOutput((delay) => Console.log(`Next retry in ${delay}`))
  *     )
  *   )
@@ -2136,9 +1963,10 @@ export const passthrough = <Output, Input, Error, Env>(
  * })
  *
  * // Combining recurs with other schedules for sophisticated retry logic
- * const complexRetry = Schedule.exponential("100 millis").pipe(
- *   Schedule.both(Schedule.recurs(3)) // At most 3 retries
- * )
+ * const complexRetry = Schedule.max([
+ *   Schedule.exponential("100 millis"),
+ *   Schedule.recurs(3) // At most 3 retries
+ * ])
  *
  * // Allow ten recurrences after the initial run
  * const tenRecurrences = Effect.gen(function*() {
@@ -2197,9 +2025,10 @@ export const recurs = (times: number): Schedule<number> =>
  * )
  *
  * // Simple spaced schedule with limited repetitions
- * const limitedSpaced = Schedule.spaced("100 millis").pipe(
- *   Schedule.both(Schedule.recurs(5)) // at most 5 times
- * )
+ * const limitedSpaced = Schedule.max([
+ *   Schedule.spaced("100 millis"),
+ *   Schedule.recurs(5) // at most 5 times
+ * ])
  *
  * const program = Effect.gen(function*() {
  *   yield* Console.log("Starting spaced execution...")

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -8,6 +8,7 @@
  *
  * @since 2.0.0
  */
+import type { NonEmptyReadonlyArray } from "./Array.ts"
 import * as Cause from "./Cause.ts"
 import * as Context from "./Context.ts"
 import * as Cron from "./Cron.ts"
@@ -773,35 +774,6 @@ export const andThenResult: {
     }
   })))
 
-type NonEmptySchedules = readonly [
-  Schedule<any, any, any, any>,
-  ...ReadonlyArray<Schedule<any, any, any, any>>
-]
-
-type SchedulesInput<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = UnionToIntersection<
-  Input<Schedules[number]>
->
-
-type SchedulesError<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = Error<Schedules[number]>
-
-type SchedulesEnv<Schedules extends ReadonlyArray<Schedule<any, any, any, any>>> = Env<Schedules[number]>
-
-type MaxStepResult = {
-  readonly _tag: "Continue"
-  readonly duration: Duration.Duration
-} | {
-  readonly _tag: "Done"
-  readonly duration: Duration.Duration
-}
-
-const maxDuration = (durations: ReadonlyArray<Duration.Duration>): Duration.Duration => {
-  let max = durations[0]!
-  for (let i = 1; i < durations.length; i++) {
-    max = Duration.max(max, durations[i]!)
-  }
-  return max
-}
-
 /**
  * Combines schedules by recurring while all schedules want to recur, using the
  * maximum delay between recurrences and outputting that maximum delay.
@@ -848,36 +820,48 @@ const maxDuration = (durations: ReadonlyArray<Duration.Duration>): Duration.Dura
  * @category combining
  * @since 4.0.0
  */
-export const max = <const Schedules extends NonEmptySchedules>(
+export const max = <
+  const Schedules extends NonEmptyReadonlyArray<
+    Schedule<any, any, any, any>
+  >
+>(
   schedules: Schedules
-): Schedule<Duration.Duration, SchedulesInput<Schedules>, SchedulesError<Schedules>, SchedulesEnv<Schedules>> => {
-  return fromStep(effect.map(
-    effect.all(schedules.map((schedule) => toStep(delays(schedule)))),
+): Schedule<
+  Duration.Duration,
+  UnionToIntersection<
+    Input<Schedules[number]>
+  >,
+  Error<Schedules[number]>,
+  Env<Schedules[number]>
+> =>
+  fromStep(effect.map(
+    effect.all(schedules.map(toStep)),
     (steps) => (now, input) =>
       effect.flatMap(
-        effect.all(steps.map((step) =>
+        effect.forEach(steps, (step) =>
           Pull.matchEffect(step(now, input as never), {
-            onSuccess: (result) =>
-              effect.succeed<MaxStepResult>({
-                _tag: "Continue",
-                duration: result[0]
-              }),
-            onDone: (duration) =>
-              effect.succeed<MaxStepResult>({
-                _tag: "Done",
-                duration
-              }),
+            onSuccess: (result) => effect.succeed(result[1]),
+            onDone: () => effect.undefined,
             onFailure: effect.failCause
-          })
-        )),
+          })),
         (results) => {
-          const duration = maxDuration(results.map((result) => result.duration))
-          return results.some((result) => result._tag === "Done") ?
-            Cause.done(duration) :
-            effect.succeed([duration, duration] as [Duration.Duration, Duration.Duration])
+          const duration = maxDuration(results)
+          if (duration === undefined) {
+            return Cause.done(Duration.zero)
+          }
+          return effect.succeed([duration, duration] as [Duration.Duration, Duration.Duration])
         }
       )
   ))
+
+const maxDuration = (results: ReadonlyArray<Duration.Duration | undefined>): Duration.Duration | undefined => {
+  let max = results[0]
+  for (let i = 1; i < results.length; i++) {
+    max = results[i] && max && Duration.max(max, results[i]!)
+    if (max === undefined) break
+  }
+
+  return max
 }
 
 /**

--- a/packages/effect/src/Stream.ts
+++ b/packages/effect/src/Stream.ts
@@ -1471,7 +1471,7 @@ export const fromAsyncIterable = <A, E>(
  *
  * const program = Effect.gen(function*() {
  *   const schedule = Schedule.spaced("50 millis").pipe(
- *     Schedule.both(Schedule.recurs(2))
+ *     Schedule.take(3)
  *   )
  *   const stream = Stream.fromSchedule(schedule)
  *   const values = yield* Stream.runCollect(stream)

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -4,6 +4,38 @@ import { constant, constUndefined } from "effect/Function"
 import { TestClock } from "effect/testing"
 
 describe("Schedule", () => {
+  describe("combining", () => {
+    it.effect("max - outputs the slowest schedule duration", () =>
+      Effect.gen(function*() {
+        const schedule = Schedule.max([
+          Schedule.fixed("5 seconds"),
+          Schedule.exponential("5 seconds"),
+          Schedule.spaced("10 seconds")
+        ])
+        const inputs = Array.makeBy(3, constUndefined)
+        const outputs = yield* runDelays(schedule, inputs)
+        assert.deepStrictEqual(outputs, [
+          Duration.seconds(10),
+          Duration.seconds(10),
+          Duration.seconds(20)
+        ])
+      }))
+
+    it.effect("max - stops when any schedule completes", () =>
+      Effect.gen(function*() {
+        const schedule = Schedule.max([
+          Schedule.duration("1 second"),
+          Schedule.spaced("5 seconds")
+        ])
+        const inputs = Array.makeBy(3, constUndefined)
+        const outputs = yield* runDelays(schedule, inputs)
+        assert.deepStrictEqual(outputs, [
+          Duration.seconds(5),
+          Duration.seconds(5)
+        ])
+      }))
+  })
+
   describe("sequencing", () => {
     it.effect("tap - provides full metadata", () =>
       Effect.gen(function*() {

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -31,7 +31,7 @@ describe("Schedule", () => {
         const outputs = yield* runDelays(schedule, inputs)
         assert.deepStrictEqual(outputs, [
           Duration.seconds(5),
-          Duration.seconds(5)
+          Duration.zero
         ])
       }))
   })

--- a/packages/effect/typetest/Schedule.tst.ts
+++ b/packages/effect/typetest/Schedule.tst.ts
@@ -20,6 +20,14 @@ describe("Schedule", () => {
     expect(schedule).type.toBe<Schedule.Schedule<number, string, "error" | "tapError", "service" | "tapService">>()
   })
 
+  it("type extractors", () => {
+    type TestSchedule = Schedule.Schedule<number, string, "error", "service">
+    expect<Schedule.Output<TestSchedule>>().type.toBe<number>()
+    expect<Schedule.Input<TestSchedule>>().type.toBe<string>()
+    expect<Schedule.Error<TestSchedule>>().type.toBe<"error">()
+    expect<Schedule.Env<TestSchedule>>().type.toBe<"service">()
+  })
+
   it("max", () => {
     const first = hole<Schedule.Schedule<number, { readonly first: string }, "firstError", "firstService">>()
     const second = hole<Schedule.Schedule<boolean, { readonly second: number }, "secondError", "secondService">>()

--- a/packages/effect/typetest/Schedule.tst.ts
+++ b/packages/effect/typetest/Schedule.tst.ts
@@ -1,4 +1,5 @@
 import { type Effect, hole } from "effect"
+import type * as Duration from "effect/Duration"
 import * as Schedule from "effect/Schedule"
 import { describe, expect, it } from "tstyche"
 
@@ -17,5 +18,19 @@ describe("Schedule", () => {
       return hole<Effect.Effect<void, "tapError", "tapService">>()
     })
     expect(schedule).type.toBe<Schedule.Schedule<number, string, "error" | "tapError", "service" | "tapService">>()
+  })
+
+  it("max", () => {
+    const first = hole<Schedule.Schedule<number, { readonly first: string }, "firstError", "firstService">>()
+    const second = hole<Schedule.Schedule<boolean, { readonly second: number }, "secondError", "secondService">>()
+    const schedule = Schedule.max([first, second])
+    expect(schedule).type.toBe<
+      Schedule.Schedule<
+        Duration.Duration,
+        { readonly first: string } & { readonly second: number },
+        "firstError" | "secondError",
+        "firstService" | "secondService"
+      >
+    >()
   })
 })


### PR DESCRIPTION
## Summary
- Remove the public `Schedule.both`, `Schedule.bothLeft`, `Schedule.bothRight`, and `Schedule.bothWith` APIs.
- Add `Schedule.max([...])`, which continues while all schedules recur and outputs the slowest selected duration.
- Rework `Schedule.max` to step all supplied schedules via `effect.all` instead of chaining pairwise intermediary schedules.
- Export schedule type extractors: `Schedule.Output`, `Schedule.Input`, `Schedule.Error`, and `Schedule.Env`.
- Update schedule docs/examples, tests, typetests, and add a changeset.

## Validation
- `pnpm lint-fix`
- `pnpm test packages/effect/test/Schedule.test.ts`
- `pnpm test-types Schedule.tst.ts`
- `pnpm check:tsgo`
- `cd packages/effect && pnpm docgen`