### PR TITLE
EFF-907 Remove Schedule.either APIs

### DIFF
--- a/.changeset/remove-schedule-either.md
+++ b/.changeset/remove-schedule-either.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Remove Schedule.either APIs and add Schedule.min for combining schedules by the fastest delay.

--- a/ai-docs/src/06_schedule/10_schedules.ts
+++ b/ai-docs/src/06_schedule/10_schedules.ts
@@ -7,9 +7,11 @@ import { Duration, Effect, Random, Schedule, Schema } from "effect"
 
 // Production pattern: capped exponential backoff with jitter and max attempts.
 // Delays start at 250ms, grow exponentially with jitter, and are capped at 10s.
-export const productionRetrySchedule = Schedule.exponential("250 millis").pipe(
+export const productionRetrySchedule = Schedule.min([
+  Schedule.exponential("250 millis"),
   // Cap the delay at 10 seconds to avoid excessively long waits.
-  Schedule.either(Schedule.spaced("10 seconds")),
+  Schedule.spaced("10 seconds")
+]).pipe(
   Schedule.jittered,
   Schedule.setInputType<HttpError>(),
   Schedule.while(({ input }) => input.retryable)
@@ -77,12 +79,12 @@ export const retryBackoffWithLimit = Schedule.both(
   Schedule.recurs(6)
 )
 
-// `Schedule.either` continues while either schedule continues.
-// It is useful for fallback behavior (e.g. stop only when both are exhausted).
-export const keepTryingUntilBothStop = Schedule.either(
-  Schedule.spaced("2 seconds"),
-  Schedule.recurs(3)
-)
+// `Schedule.min` continues while any schedule continues and uses the fastest
+// active delay as both its output and the delay before the next recurrence.
+export const fastestRetryCadence = Schedule.min([
+  Schedule.exponential("500 millis"),
+  Schedule.spaced("2 seconds")
+])
 
 // Use `Schedule.while` to continue only for retryable failures.
 // This lets non-retryable errors fail fast, even if attempts remain.

--- a/cookbooks/schedule.md
+++ b/cookbooks/schedule.md
@@ -18,7 +18,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
   `Schedule.delays`, `Schedule.map`, or `Schedule.reduce` when the output shape
   matters.
 - `Schedule.both` continues only while both schedules continue.
-- `Schedule.either` continues while either schedule can continue.
+- `Schedule.min` continues while any schedule can continue, using the fastest active delay.
 - `Schedule.jittered` spreads callers out. It does not add a recurrence limit.
 - `Schedule.addDelay` adds extra delay based on schedule output.
 - `Schedule.modifyDelay` replaces or adjusts the selected delay.
@@ -36,7 +36,7 @@ This cookbook intentionally defines schedules only. It does not apply them with
 | Run phases in sequence                    | `Schedule.andThen`                                                                                                |
 | Preserve phase in output                  | `Schedule.andThenResult`                                                                                          |
 | Continue while both policies continue     | `Schedule.both`                                                                                                   |
-| Continue while either policy continues    | `Schedule.either`                                                                                                 |
+| Continue while any policy continues       | `Schedule.min`                                                                                                    |
 | Keep input or output history              | `Schedule.collectInputs`, `Schedule.collectOutputs`, or `Schedule.collectWhile`                                   |
 | Maintain a running aggregate              | `Schedule.reduce`                                                                                                 |
 | Observe decisions without changing output | `Schedule.tap`, `Schedule.tapInput`, or `Schedule.tapOutput`                                                      |
@@ -263,7 +263,7 @@ const deploymentHookRetryBudget = Schedule.exponential("200 millis").pipe(
 Explanation: the resulting output is nested because `Schedule.both` preserves
 both schedule outputs. Use `Schedule.map` when a smaller output is needed.
 
-### Continue While Either Probe Is Active
+### Continue While Any Probe Is Active
 
 Goal: Create a service readiness policy that continues while either 2 immediate
 warmup probes or a slower 500 millisecond probe schedule still wants to recur.
@@ -271,14 +271,16 @@ warmup probes or a slower 500 millisecond probe schedule still wants to recur.
 ```ts
 import { Schedule } from "effect"
 
-const readinessWarmupOrSlowProbe = Schedule.recurs(2).pipe(
-  Schedule.either(Schedule.spaced("500 millis").pipe(Schedule.take(5)))
-)
+const readinessWarmupOrSlowProbe = Schedule.min([
+  Schedule.recurs(2),
+  Schedule.spaced("500 millis").pipe(Schedule.take(5))
+])
 ```
 
-Explanation: `Schedule.either` keeps recurring while at least one side can
-continue. Its output preserves both sides, so map the result if callers should
-see a smaller shape.
+Explanation: `Schedule.min` keeps recurring while at least one schedule can
+continue. Its output is the fastest active delay, which is `Duration.zero`
+while the immediate warmup probes are active and then 500 milliseconds while
+only the slower probe schedule remains.
 
 ### Warm Up Fast, Then Settle Into Maintenance
 

--- a/packages/effect/src/Schedule.ts
+++ b/packages/effect/src/Schedule.ts
@@ -23,7 +23,7 @@ import { type Pipeable, pipeArguments } from "./Pipeable.ts"
 import { hasProperty } from "./Predicate.ts"
 import * as Pull from "./Pull.ts"
 import * as Result from "./Result.ts"
-import type { Contravariant, Covariant, Mutable } from "./Types.ts"
+import type { Contravariant, Covariant, Mutable, UnionToIntersection } from "./Types.ts"
 
 const TypeId = "~effect/Schedule"
 
@@ -857,10 +857,10 @@ export const andThenResult: {
  * })
  *
  * // Both provides intersection semantics (AND logic)
- * // Compare with either which provides union semantics (OR logic)
+ * // Compare with Schedule.min, which provides union semantics (OR logic)
  * ```
  *
- * @see {@link either} for continuing while either schedule still recurs
+ * @see {@link min} for continuing while any schedule still recurs
  *
  * @category combining
  * @since 2.0.0
@@ -1629,304 +1629,75 @@ export const during = (duration: Duration.Input): Schedule<Duration.Duration> =>
     ({ output }) => effect.succeed(Duration.isLessThanOrEqualTo(output, Duration.fromInputUnsafe(duration)))
   )
 
+type ScheduleInput<T> = T extends Schedule<any, infer Input, any, any> ? Input : never
+
+type ScheduleError<T> = T extends Schedule<any, any, infer Error, any> ? Error : never
+
+type ScheduleEnv<T> = T extends Schedule<any, any, any, infer Env> ? Env : never
+
+const minimumDuration = (durations: ReadonlyArray<Duration.Duration | undefined>): Duration.Duration | undefined => {
+  let min: Duration.Duration | undefined
+  for (const duration of durations) {
+    if (duration !== undefined) {
+      min = min === undefined ? duration : Duration.min(min, duration)
+    }
+  }
+  return min
+}
+
 /**
- * Combines two `Schedule`s by recurring if either of the two schedules wants
- * to recur, using the minimum of the two durations between recurrences and
- * outputting a tuple of the outputs of both schedules.
+ * Combines multiple schedules by recurring while any schedule wants to recur,
+ * using the minimum delay between recurrences.
  *
  * **When to use**
  *
- * Use when the combined schedule should continue while at least one schedule still recurs.
+ * Use when several timing policies are available and recurrence should follow
+ * the fastest active schedule. The output of the combined schedule is the
+ * fastest computed delay.
  *
- * **Example** (Combining schedules with either semantics)
+ * **Example** (Combining schedules by the fastest delay)
  *
  * ```ts
- * import { Console, Data, Effect, Schedule } from "effect"
+ * import { Schedule } from "effect"
  *
- * class RetryAttemptError extends Data.TaggedError("RetryAttemptError")<{ readonly message: string }> {}
- *
- * // Either continues as long as at least one schedule wants to continue
- * const timeBasedSchedule = Schedule.spaced("2 seconds").pipe(Schedule.take(3))
- * const countBasedSchedule = Schedule.recurs(5)
- *
- * // Continues until both schedules are exhausted (either still wants to recur)
- * const eitherSchedule = Schedule.either(timeBasedSchedule, countBasedSchedule)
- * // Outputs: [time_result, count_result] tuple
- *
- * const program = Effect.gen(function*() {
- *   const results = yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task completed"
- *     }),
- *     eitherSchedule.pipe(
- *       Schedule.tapOutput(([timeResult, countResult]) =>
- *         Console.log(`Time: ${timeResult}, Count: ${countResult}`)
- *       )
- *     )
- *   )
- *
- *   yield* Console.log(`Total executions: ${results.length}`)
- * })
- *
- * // Either with different delay strategies
- * const aggressiveRetry = Schedule.exponential("100 millis").pipe(
- *   Schedule.take(3)
- * )
- * const fallbackRetry = Schedule.fixed("5 seconds").pipe(Schedule.take(2))
- *
- * // Will use the more aggressive retry until it's exhausted, then fallback
- * const combinedRetry = Schedule.either(aggressiveRetry, fallbackRetry)
- *
- * const retryProgram = Effect.gen(function*() {
- *   let attempt = 0
- *
- *   const result = yield* Effect.retry(
- *     Effect.gen(function*() {
- *       attempt++
- *       yield* Console.log(`Retry attempt ${attempt}`)
- *
- *       if (attempt < 6) {
- *         return yield* Effect.fail(new RetryAttemptError({ message: `Attempt ${attempt} failed` }))
- *       }
- *
- *       return `Success on attempt ${attempt}`
- *     }),
- *     combinedRetry
- *   )
- *
- *   yield* Console.log(`Final result: ${result}`)
- * })
- *
- * // Either provides union semantics (OR logic)
- * // Compare with both, which provides intersection semantics (AND logic)
+ * const schedule = Schedule.min([
+ *   Schedule.fixed("5 seconds"),
+ *   Schedule.exponential("5 seconds"),
+ *   Schedule.spaced("10 seconds")
+ * ])
  * ```
  *
  * @see {@link both} for continuing only while both schedules still recur
  *
  * @category combining
- * @since 2.0.0
- */
-export const either: {
-  <Output2, Input2, Error2, Env2>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<[Output, Output2], Input & Input2, Error | Error2, Env | Env2> =>
-  eitherWith(self, other, (left, right) => [left, right]))
-
-/**
- * Combines two `Schedule`s by recurring if either of the two schedules wants
- * to recur, using the minimum of the two durations between recurrences and
- * outputting the result of the left schedule (i.e. `self`).
- *
- * **When to use**
- *
- * Use when either schedule may keep recurrence going and only the left
- * schedule's output is needed.
- *
- * **Example** (Combining either schedules and keeping the left output)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine two schedules with either semantics, keeping left output
- * const primarySchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("primary-result")),
- *   Schedule.take(2)
- * )
- * const backupSchedule = Schedule.spaced("500 millis").pipe(
- *   Schedule.map(() => Effect.succeed("backup-result"))
- * )
- *
- * const combined = Schedule.eitherLeft(primarySchedule, backupSchedule)
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-done"
- *     }),
- *     combined.pipe(Schedule.take(5))
- *   )
- * })
- * ```
- *
- * @category combining
  * @since 4.0.0
  */
-export const eitherLeft: {
-  <Output2, Input2, Error2, Env2>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<Output, Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<Output, Input & Input2, Error | Error2, Env | Env2> => eitherWith(self, other, (output) => output))
-
-/**
- * Combines two `Schedule`s by recurring if either of the two schedules wants
- * to recur, using the minimum of the two durations between recurrences and
- * outputting the result of the right schedule (i.e. `other`).
- *
- * **When to use**
- *
- * Use when either schedule may keep recurrence going and only the right
- * schedule's output is needed.
- *
- * **Example** (Combining either schedules and keeping the right output)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine two schedules with either semantics, keeping right output
- * const primarySchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("primary-result")),
- *   Schedule.take(2)
- * )
- * const backupSchedule = Schedule.spaced("500 millis").pipe(
- *   Schedule.map(() => Effect.succeed("backup-result"))
- * )
- *
- * const combined = Schedule.eitherRight(primarySchedule, backupSchedule)
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-done"
- *     }),
- *     combined.pipe(Schedule.take(5))
- *   )
- * })
- * ```
- *
- * @category combining
- * @since 4.0.0
- */
-export const eitherRight: {
-  <Output2, Input2, Error2, Env2>(
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): <Output, Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output2, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>
-  ): Schedule<Output2, Input & Input2, Error | Error2, Env | Env2>
-} = dual(2, <Output, Input, Error, Env, Output2, Input2, Error2, Env2>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>
-): Schedule<Output2, Input & Input2, Error | Error2, Env | Env2> => eitherWith(self, other, (_, output) => output))
-
-/**
- * Combines two `Schedule`s by recurring if either of the two schedules wants
- * to recur, using the minimum of the two durations between recurrences and
- * outputting the result of the combination of both schedule outputs using the
- * specified `combine` function.
- *
- * **When to use**
- *
- * Use when either schedule may keep recurrence going and their outputs should be
- * combined into a custom value.
- *
- * **Example** (Combining either schedule outputs)
- *
- * ```ts
- * import { Console, Effect, Schedule } from "effect"
- *
- * // Combine schedules with either semantics and custom combination
- * const primarySchedule = Schedule.exponential("100 millis").pipe(
- *   Schedule.map(() => Effect.succeed("primary")),
- *   Schedule.take(2)
- * )
- * const fallbackSchedule = Schedule.spaced("500 millis").pipe(
- *   Schedule.map(() => Effect.succeed("fallback"))
- * )
- *
- * const combined = Schedule.eitherWith(
- *   primarySchedule,
- *   fallbackSchedule,
- *   (primary, fallback) => `${primary}+${fallback}`
- * )
- *
- * const program = Effect.gen(function*() {
- *   yield* Effect.repeat(
- *     Effect.gen(function*() {
- *       yield* Console.log("Task executed")
- *       return "task-result"
- *     }),
- *     combined.pipe(Schedule.take(5))
- *   )
- * })
- * ```
- *
- * @category combining
- * @since 2.0.0
- */
-export const eitherWith: {
-  <Output2, Input2, Error2, Env2, Output, Output3>(
-    other: Schedule<Output2, Input2, Error2, Env2>,
-    combine: (selfOutput: Output, otherOutput: Output2) => Output3
-  ): <Input, Error, Env>(
-    self: Schedule<Output, Input, Error, Env>
-  ) => Schedule<Output3, Input & Input2, Error | Error2, Env | Env2>
-  <Output, Input, Error, Env, Output2, Input2, Error2, Env2, Output3>(
-    self: Schedule<Output, Input, Error, Env>,
-    other: Schedule<Output2, Input2, Error2, Env2>,
-    combine: (selfOutput: Output, otherOutput: Output2) => Output3
-  ): Schedule<Output3, Input & Input2, Error | Error2, Env | Env2>
-} = dual(3, <Output, Input, Error, Env, Output2, Input2, Error2, Env2, Output3>(
-  self: Schedule<Output, Input, Error, Env>,
-  other: Schedule<Output2, Input2, Error2, Env2>,
-  combine: (selfOutput: Output, otherOutput: Output2) => Output3
-): Schedule<Output3, Input & Input2, Error | Error2, Env | Env2> =>
+export const min = <const Schedules extends ReadonlyArray<Schedule<any, any, any, any>>>(
+  schedules: Schedules
+): Schedule<
+  Duration.Duration,
+  UnionToIntersection<ScheduleInput<Schedules[number]>>,
+  ScheduleError<Schedules[number]>,
+  ScheduleEnv<Schedules[number]>
+> =>
   fromStep(effect.map(
-    effect.zip(toStep(self), toStep(other)),
-    ([stepLeft, stepRight]) => (now, input) =>
-      Pull.matchEffect(stepLeft(now, input as Input), {
-        onSuccess: (leftResult) =>
-          stepRight(now, input as Input2).pipe(
-            effect.map((rightResult) =>
-              [combine(leftResult[0], rightResult[0]), Duration.min(leftResult[1], rightResult[1])] as [
-                Output3,
-                Duration.Duration
-              ]
-            ),
-            Pull.catchDone((rightDone) =>
-              effect.succeed<[Output3, Duration.Duration]>([
-                combine(leftResult[0], rightDone as Output2),
-                leftResult[1]
-              ])
-            )
-          ),
-        onFailure: effect.failCause,
-        onDone: (leftDone) =>
-          stepRight(now, input as Input2).pipe(
-            effect.map((rightResult) =>
-              [combine(leftDone, rightResult[0]), rightResult[1]] as [
-                Output3,
-                Duration.Duration
-              ]
-            ),
-            Pull.catchDone((rightDone) => Cause.done(combine(leftDone, rightDone as Output2)))
-          )
-      })
-  )))
+    effect.forEach(schedules, toStep),
+    (steps) => (now: number, input: unknown) =>
+      effect.flatMap(
+        effect.forEach(steps, (step) =>
+          Pull.matchEffect(step(now, input as any), {
+            onSuccess: ([, duration]) => effect.succeed(duration),
+            onFailure: effect.failCause,
+            onDone: () => effect.succeed(undefined)
+          })),
+        (durations) => {
+          const duration = minimumDuration(durations)
+          return duration === undefined
+            ? Cause.done(Duration.zero)
+            : effect.succeed([duration, duration] as [Duration.Duration, Duration.Duration])
+        }
+      )
+  ) as any) as any
 
 /**
  * Schedule that always recurs and returns the total elapsed duration since the

--- a/packages/effect/src/unstable/cluster/ClusterCron.ts
+++ b/packages/effect/src/unstable/cluster/ClusterCron.ts
@@ -147,9 +147,10 @@ export const make = <E, R>(options: {
   return Layer.merge(InitialRun, EntityLayer)
 }
 
-const retryPolicy = Schedule.exponential(200, 1.5).pipe(
-  Schedule.either(Schedule.spaced("1 minute"))
-)
+const retryPolicy = Schedule.min([
+  Schedule.exponential(200, 1.5),
+  Schedule.spaced("1 minute")
+])
 
 class CronPayload extends Schema.Class<CronPayload>("effect/cluster/ClusterCron/CronPayload")({
   dateTime: Schema.DateTimeUtc

--- a/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
+++ b/packages/effect/src/unstable/cluster/ClusterWorkflowEngine.ts
@@ -626,9 +626,10 @@ export const make = Effect.gen(function*() {
   return engine
 })
 
-const retryPolicy = Schedule.exponential(200, 1.5).pipe(
-  Schedule.either(Schedule.spaced("1 minute"))
-)
+const retryPolicy = Schedule.min([
+  Schedule.exponential(200, 1.5),
+  Schedule.spaced("1 minute")
+])
 
 const ensureSuccess = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -611,9 +611,10 @@ export const make = Effect.fnUntraced(function*<
   })
 })
 
-const defaultRetryPolicy = Schedule.exponential(500, 1.5).pipe(
-  Schedule.either(Schedule.spaced("10 seconds"))
-)
+const defaultRetryPolicy = Schedule.min([
+  Schedule.exponential(500, 1.5),
+  Schedule.spaced("10 seconds")
+])
 
 const makeMessageDecode = <Type extends string, Rpcs extends Rpc.Any>(
   entity: Entity<Type, Rpcs>,

--- a/packages/effect/src/unstable/eventlog/EventLog.ts
+++ b/packages/effect/src/unstable/eventlog/EventLog.ts
@@ -854,9 +854,10 @@ const make = Effect.gen(function*() {
         Effect.scoped,
         Effect.catchCause(Effect.logError),
         Effect.repeat(
-          Schedule.exponential(200, 1.5).pipe(
-            Schedule.either(Schedule.spaced({ seconds: 10 }))
-          )
+          Schedule.min([
+            Schedule.exponential(200, 1.5),
+            Schedule.spaced({ seconds: 10 })
+          ])
         ),
         Effect.annotateLogs({
           service: "EventLog",

--- a/packages/effect/src/unstable/rpc/RpcClient.ts
+++ b/packages/effect/src/unstable/rpc/RpcClient.ts
@@ -1136,9 +1136,10 @@ export const makeProtocolSocket = (options?: {
     }
   }))
 
-const defaultRetryPolicy = Schedule.exponential(500, 1.5).pipe(
-  Schedule.either(Schedule.spaced(5000))
-)
+const defaultRetryPolicy = Schedule.min([
+  Schedule.exponential(500, 1.5),
+  Schedule.spaced(5000)
+])
 
 const makePinger = Effect.fnUntraced(function*<A, E, R>(writePing: Effect.Effect<A, E, R>) {
   let recievedPong = true

--- a/packages/effect/src/unstable/workflow/Activity.ts
+++ b/packages/effect/src/unstable/workflow/Activity.ts
@@ -178,9 +178,11 @@ export const make = <
   return self
 }
 
-const interruptRetryPolicy = Schedule.exponential(4.0, 1.5).pipe(
-  Schedule.either(Schedule.spaced("10 seconds")),
-  Schedule.either(Schedule.recurs(10)),
+const interruptRetryPolicy = Schedule.min([
+  Schedule.exponential(4.0, 1.5),
+  Schedule.spaced("10 seconds"),
+  Schedule.recurs(10)
+]).pipe(
   Schedule.satisfiesInputType<Cause.Cause<unknown>>(),
   Schedule.while((meta) => Effect.succeed(Cause.hasInterrupts(meta.input)))
 )

--- a/packages/effect/src/unstable/workflow/DurableQueue.ts
+++ b/packages/effect/src/unstable/workflow/DurableQueue.ts
@@ -239,9 +239,10 @@ export const process: <
   return yield* DurableDeferred.await(deferred)
 })
 
-const defaultRetrySchedule = Schedule.exponential(500, 1.5).pipe(
-  Schedule.either(Schedule.spaced("1 minute"))
-)
+const defaultRetrySchedule = Schedule.min([
+  Schedule.exponential(500, 1.5),
+  Schedule.spaced("1 minute")
+])
 
 /**
  * Create a worker effect that processes items from the durable queue.

--- a/packages/effect/src/unstable/workflow/WorkflowEngine.ts
+++ b/packages/effect/src/unstable/workflow/WorkflowEngine.ts
@@ -552,9 +552,10 @@ export const makeUnsafe = (options: Encoded): WorkflowEngine["Service"] =>
       )
   })
 
-const defaultRetrySchedule = Schedule.exponential(200, 1.5).pipe(
-  Schedule.either(Schedule.spaced(30000))
-)
+const defaultRetrySchedule = Schedule.min([
+  Schedule.exponential(200, 1.5),
+  Schedule.spaced(30000)
+])
 
 /**
  * Layer that provides an in-memory `WorkflowEngine`.

--- a/packages/effect/test/Schedule.test.ts
+++ b/packages/effect/test/Schedule.test.ts
@@ -216,6 +216,40 @@ describe("Schedule", () => {
       }))
   })
 
+  describe("combining", () => {
+    it.effect("min - uses the fastest delay as output and delay", () =>
+      Effect.gen(function*() {
+        const schedule = Schedule.min([
+          Schedule.fixed("5 seconds"),
+          Schedule.exponential("5 seconds"),
+          Schedule.spaced("10 seconds")
+        ])
+        const step = yield* Schedule.toStep(schedule)
+
+        const first = yield* step(0, undefined)
+        const second = yield* step(5_000, undefined)
+
+        expect(first).toEqual([Duration.seconds(5), Duration.seconds(5)])
+        expect(second).toEqual([Duration.seconds(5), Duration.seconds(5)])
+      }))
+
+    it.effect("min - continues while any schedule recurs", () =>
+      Effect.gen(function*() {
+        const schedule = Schedule.min([
+          Schedule.duration("1 second"),
+          Schedule.spaced("2 seconds").pipe(Schedule.take(2))
+        ])
+        const inputs = Array.makeBy(4, constUndefined)
+        const output = yield* runDelays(schedule, inputs)
+
+        expect(output).toEqual([
+          Duration.seconds(1),
+          Duration.seconds(2),
+          Duration.zero
+        ])
+      }))
+  })
+
   describe("reduce", () => {
     it.effect("accumulates state with synchronous combine", () =>
       Effect.gen(function*() {

--- a/packages/effect/typetest/Schedule.tst.ts
+++ b/packages/effect/typetest/Schedule.tst.ts
@@ -1,4 +1,5 @@
 import { type Effect, hole } from "effect"
+import type * as Duration from "effect/Duration"
 import * as Schedule from "effect/Schedule"
 import { describe, expect, it } from "tstyche"
 
@@ -17,5 +18,19 @@ describe("Schedule", () => {
       return hole<Effect.Effect<void, "tapError", "tapService">>()
     })
     expect(schedule).type.toBe<Schedule.Schedule<number, string, "error" | "tapError", "service" | "tapService">>()
+  })
+
+  it("min", () => {
+    const left = hole<Schedule.Schedule<number, { readonly left: string }, "leftError", "leftService">>()
+    const right = hole<Schedule.Schedule<string, { readonly right: number }, "rightError", "rightService">>()
+    const schedule = Schedule.min([left, right])
+    expect(schedule).type.toBe<
+      Schedule.Schedule<
+        Duration.Duration,
+        { readonly left: string } & { readonly right: number },
+        "leftError" | "rightError",
+        "leftService" | "rightService"
+      >
+    >()
   })
 })


### PR DESCRIPTION
## Summary

- Remove the Schedule.either/eitherLeft/eitherRight/eitherWith APIs and add Schedule.min for fastest-delay schedule composition.
- Replace existing Schedule.either retry policies with Schedule.min arrays.
- Update schedule docs, AI docs, runtime tests, type tests, and add a changeset.

## Validation

- pnpm lint-fix
- pnpm test packages/effect/test/Schedule.test.ts
- pnpm test-types packages/effect/typetest/Schedule.tst.ts
- pnpm check:tsgo
