### PR TITLE
Implement McpServer Middleware API

### DIFF
--- a/.changeset/mcp-middleware-api.md
+++ b/.changeset/mcp-middleware-api.md
@@ -1,0 +1,7 @@
+---
+"effect": minor
+---
+
+Add robust, transforming Middleware support for Effect MCP servers. 
+
+The new Middleware API (`McpServer.middleware`) allows intercepting, modifying, short-circuiting, and observing MCP requests and responses seamlessly. It provides full access to request metadata (headers, `mcpSessionId`, `clientInfo`) and seamlessly supports 3rd-party integration needs like advanced telemetry, and schema modification.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -42,6 +42,7 @@ import * as RpcServer from "../rpc/RpcServer.ts"
 import {
   CallToolResult,
   ClientNotificationRpcs,
+  ClientRequestRpcs,
   ClientRpcs,
   CompleteResult,
   Elicit,
@@ -63,22 +64,90 @@ import {
   ServerNotificationRpcs,
   ServerRequestRpcs,
   TextContent,
+  type CallTool,
+  type ClientCapabilities,
+  type Complete,
+  type GetPrompt,
+  type Initialize,
+  type Param,
+  type PromptArgument,
+  type PromptMessage,
+  type ReadResourceResult,
+  type ServerCapabilities,
   Tool as McpTool
-} from "./McpSchema.ts"
-import type {
-  CallTool,
-  ClientCapabilities,
-  Complete,
-  GetPrompt,
-  Initialize,
-  Param,
-  PromptArgument,
-  PromptMessage,
-  ReadResourceResult,
-  ServerCapabilities
 } from "./McpSchema.ts"
 import * as Tool from "./Tool.ts"
 import type * as Toolkit from "./Toolkit.ts"
+
+type ClientRequestRpc = RpcGroup.Rpcs<typeof ClientRequestRpcs>
+type ClientRequestRpcByMethod<Method extends MiddlewareMethod> = Extract<ClientRequestRpc, { readonly _tag: Method }>
+
+/**
+ * MCP request methods that can be observed or transformed by server middleware.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export type MiddlewareMethod = Rpc.Tag<ClientRequestRpc>
+
+/**
+ * Decoded payload type for an MCP middleware method.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export type MiddlewarePayload<Method extends MiddlewareMethod> = Rpc.Payload<ClientRequestRpcByMethod<Method>>
+
+/**
+ * Decoded success type for an MCP middleware method.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export type MiddlewareSuccess<Method extends MiddlewareMethod> = Rpc.SuccessExit<ClientRequestRpcByMethod<Method>>
+
+/**
+ * Decoded error type for an MCP middleware method.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export type MiddlewareError<Method extends MiddlewareMethod> = Rpc.ErrorExit<ClientRequestRpcByMethod<Method>>
+
+/**
+ * Request context passed to MCP server middleware.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export interface MiddlewareRequest<Method extends MiddlewareMethod = MiddlewareMethod> {
+  readonly method: Method
+  readonly payload: MiddlewarePayload<Method>
+  readonly requestId: RpcMessage.RequestId
+  readonly clientId: number
+  readonly headers: Headers.Headers
+  readonly serverInfo: {
+    readonly name: string
+    readonly version: string
+  }
+  readonly initializedClient: Option.Option<typeof Initialize.payloadSchema.Type>
+  readonly mcpSessionId: Option.Option<string>
+  readonly next: (
+    payload?: MiddlewarePayload<Method>
+  ) => Effect.Effect<MiddlewareSuccess<Method>, MiddlewareError<Method>, McpServerClient>
+}
+
+/**
+ * Middleware that can observe, transform, or short-circuit MCP server requests.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export interface Middleware<R = never> {
+  <Method extends MiddlewareMethod>(
+    request: MiddlewareRequest<Method>
+  ): Effect.Effect<MiddlewareSuccess<Method>, MiddlewareError<Method>, R | McpServerClient>
+}
 
 /**
  * Service that stores and serves an MCP server's registered tools, resources,
@@ -96,6 +165,8 @@ export class McpServer extends Context.Service<McpServer, {
   readonly notifications: RpcClient.RpcClient<RpcGroup.Rpcs<typeof ServerNotificationRpcs>>
   readonly notificationsQueue: Queue.Dequeue<RpcMessage.Request<any>>
   readonly initializedClients: Set<number>
+  readonly middlewares: ReadonlyArray<Middleware>
+  readonly addMiddleware: (middleware: Middleware) => Effect.Effect<void>
 
   readonly tools: ReadonlyArray<{
     readonly tool: McpTool
@@ -199,6 +270,7 @@ export class McpServer extends Context.Service<McpServer, {
       readonly prompt: Prompt
       readonly annotations: Context.Context<never>
     }> = []
+    const middlewares = Arr.empty<Middleware>()
     const promptMap = new Map<
       string,
       (params: Record<string, string>) => Effect.Effect<GetPromptResult, InternalError | InvalidParams, McpServerClient>
@@ -243,6 +315,13 @@ export class McpServer extends Context.Service<McpServer, {
       notifications: notifications.client,
       notificationsQueue,
       initializedClients: new Set(),
+      get middlewares() {
+        return middlewares
+      },
+      addMiddleware: (middleware) =>
+        Effect.sync(() => {
+          middlewares.push(middleware)
+        }),
       get tools() {
         return tools
       },
@@ -662,6 +741,37 @@ export const layerHttp = (options: {
   layer(options).pipe(
     Layer.provide(RpcServer.layerProtocolHttp(options)),
     Layer.provide(RpcSerialization.layerJsonRpc())
+  )
+
+/**
+ * Registers MCP server middleware.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export const registerMiddleware: <R>(
+  middleware: Middleware<R>
+) => Effect.Effect<void, never, McpServer | R> = Effect.fnUntraced(function*<R>(middleware: Middleware<R>) {
+  const server = yield* McpServer
+  const services = yield* Effect.context<R>()
+  yield* server.addMiddleware(((request) =>
+    Effect.updateContext(
+      middleware(request),
+      (context) => Context.merge(services as Context.Context<never>, context)
+    )) as Middleware)
+})
+
+/**
+ * Creates a layer that registers MCP server middleware.
+ *
+ * @category middleware
+ * @since 4.0.0
+ */
+export const middleware = <R>(
+  middleware: Middleware<R>
+): Layer.Layer<never, never, R> =>
+  Layer.effectDiscard(registerMiddleware(middleware)).pipe(
+    Layer.provide(McpServer.layer)
   )
 
 /**
@@ -1280,64 +1390,111 @@ const layerHandlers = (serverInfo: {
     Effect.gen(function*() {
       const server = yield* McpServer
       let currentLogLevel = yield* CurrentLogLevel
+      const runMiddlewares = <Method extends MiddlewareMethod>(
+        method: Method,
+        payload: MiddlewarePayload<Method>,
+        handlerOptions: {
+          readonly client: Rpc.ServerClient
+          readonly requestId: RpcMessage.RequestId
+          readonly headers: Headers.Headers
+        },
+        handler: (
+          payload: MiddlewarePayload<Method>
+        ) => Effect.Effect<MiddlewareSuccess<Method>, MiddlewareError<Method>, McpServerClient>
+      ): Effect.Effect<MiddlewareSuccess<Method>, MiddlewareError<Method>, McpServerClient> => {
+        const run = (
+          index: number,
+          payload: MiddlewarePayload<Method>
+        ): Effect.Effect<MiddlewareSuccess<Method>, MiddlewareError<Method>, McpServerClient> => {
+          const middleware = server.middlewares[index]
+          if (!middleware) {
+            return handler(payload)
+          }
+          return middleware({
+            method,
+            payload,
+            requestId: handlerOptions.requestId,
+            clientId: handlerOptions.client.id,
+            headers: handlerOptions.headers,
+            serverInfo: {
+              name: serverInfo.name,
+              version: serverInfo.version
+            },
+            initializedClient: Option.fromUndefinedOr(
+              getInitializedClient(options.clientSessions, handlerOptions.client.id, handlerOptions.headers)
+            ),
+            mcpSessionId: Option.fromUndefinedOr(handlerOptions.headers[mcpSessionIdHeader]),
+            next: (nextPayload) => run(index + 1, nextPayload === undefined ? payload : nextPayload)
+          } as MiddlewareRequest<Method>) as Effect.Effect<
+            MiddlewareSuccess<Method>,
+            MiddlewareError<Method>,
+            McpServerClient
+          >
+        }
+        return run(0, payload)
+      }
 
       return ClientRpcs.of({
         // Requests
-        ping: () => Effect.succeed({}),
-        initialize(params, { client }) {
-          const requestedVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(params.protocolVersion)
-            ? params.protocolVersion
-            : LATEST_PROTOCOL_VERSION
-          if (requestedVersion !== params.protocolVersion) {
-            params = {
-              ...params,
-              protocolVersion: requestedVersion
+        ping: (params, options) =>
+          runMiddlewares("ping", params, options, () => Effect.succeed({})),
+        initialize(params, handlerOptions) {
+          return runMiddlewares("initialize", params, handlerOptions, (params) => {
+            const requestedVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(params.protocolVersion)
+              ? params.protocolVersion
+              : LATEST_PROTOCOL_VERSION
+            if (requestedVersion !== params.protocolVersion) {
+              params = {
+                ...params,
+                protocolVersion: requestedVersion
+              }
             }
-          }
-          const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
-            completions: {}
-          }
-          if (server.tools.length > 0) {
-            capabilities.tools = { listChanged: true }
-          }
-          if (server.resources.length > 0 || server.resourceTemplates.length > 0) {
-            capabilities.resources = {
-              listChanged: true,
-              subscribe: false
+            const capabilities: Types.DeepMutable<typeof ServerCapabilities.Type> = {
+              completions: {}
             }
-          }
-          if (server.prompts.length > 0) {
-            capabilities.prompts = { listChanged: true }
-          }
-          if (serverInfo.extensions) {
-            capabilities.extensions = serverInfo.extensions as any
-          }
-          return Effect.withFiber((fiber) => {
-            const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
-            if (httpRequest) {
-              const sessionId = crypto.randomUUID()
-              options.clientSessions.set(sessionId, params)
-              appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
-                Effect.succeed(HttpServerResponse.setHeaders(res, {
-                  [mcpSessionIdHeader]: sessionId,
-                  [mcpProtocolVersionHeader]: requestedVersion
-                })))
-            } else {
-              options.clientSessions.set(String(client.id), params)
+            if (server.tools.length > 0) {
+              capabilities.tools = { listChanged: true }
             }
-            return Effect.succeed({
-              capabilities,
-              serverInfo,
-              protocolVersion: requestedVersion
+            if (server.resources.length > 0 || server.resourceTemplates.length > 0) {
+              capabilities.resources = {
+                listChanged: true,
+                subscribe: false
+              }
+            }
+            if (server.prompts.length > 0) {
+              capabilities.prompts = { listChanged: true }
+            }
+            if (serverInfo.extensions) {
+              capabilities.extensions = serverInfo.extensions as any
+            }
+            return Effect.withFiber((fiber) => {
+              const httpRequest = Context.getOrUndefined(fiber.context, HttpServerRequest.HttpServerRequest)
+              if (httpRequest) {
+                const sessionId = crypto.randomUUID()
+                options.clientSessions.set(sessionId, params)
+                appendPreResponseHandlerUnsafe(httpRequest, (_req, res) =>
+                  Effect.succeed(HttpServerResponse.setHeaders(res, {
+                    [mcpSessionIdHeader]: sessionId,
+                    [mcpProtocolVersionHeader]: requestedVersion
+                  })))
+              } else {
+                options.clientSessions.set(String(handlerOptions.client.id), params)
+              }
+              return Effect.succeed({
+                capabilities,
+                serverInfo,
+                protocolVersion: requestedVersion
+              })
             })
           })
         },
-        "completion/complete": (r) =>
-          server.completion(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "logging/setLevel": ({ level }) =>
-          Effect.sync(() => {
+        "completion/complete": (r, options) =>
+          runMiddlewares("completion/complete", r, options, (r) =>
+            server.completion(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            )),
+        "logging/setLevel": (r, options) =>
+          runMiddlewares("logging/setLevel", r, options, ({ level }) => Effect.sync(() => {
             switch (level) {
               case "notice":
               case "info":
@@ -1358,47 +1515,50 @@ const layerHandlers = (serverInfo: {
                 currentLogLevel = "Fatal"
                 break
             }
-          }),
-        "prompts/get": (r) =>
-          server.getPromptResult(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "prompts/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+          })),
+        "prompts/get": (r, options) =>
+          runMiddlewares("prompts/get", r, options, (r) =>
+            server.getPromptResult(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            )),
+        "prompts/list": (r, handlerOptions) =>
+          runMiddlewares("prompts/list", r, handlerOptions, () => Effect.sync(() => {
+            const initialized = getInitializedClient(options.clientSessions, handlerOptions.client.id, handlerOptions.headers)
             return new ListPromptsResult({ prompts: filterByClient(initialized, server.prompts, "prompt") })
-          }),
-        "resources/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+          })),
+        "resources/list": (r, handlerOptions) =>
+          runMiddlewares("resources/list", r, handlerOptions, () => Effect.sync(() => {
+            const initialized = getInitializedClient(options.clientSessions, handlerOptions.client.id, handlerOptions.headers)
             return new ListResourcesResult({ resources: filterByClient(initialized, server.resources, "resource") })
-          }),
-        "resources/read": ({ uri }) =>
-          server.findResource(uri).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "resources/subscribe": () =>
-          InternalError.notImplemented,
-        "resources/unsubscribe": () =>
-          InternalError.notImplemented,
-        "resources/templates/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+          })),
+        "resources/read": (r, options) =>
+          runMiddlewares("resources/read", r, options, ({ uri }) =>
+            server.findResource(uri).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            )),
+        "resources/subscribe": (r, options) =>
+          runMiddlewares("resources/subscribe", r, options, () => InternalError.notImplemented),
+        "resources/unsubscribe": (r, options) =>
+          runMiddlewares("resources/unsubscribe", r, options, () => InternalError.notImplemented),
+        "resources/templates/list": (r, handlerOptions) =>
+          runMiddlewares("resources/templates/list", r, handlerOptions, () => Effect.sync(() => {
+            const initialized = getInitializedClient(options.clientSessions, handlerOptions.client.id, handlerOptions.headers)
             return new ListResourceTemplatesResult({
               resourceTemplates: filterByClient(initialized, server.resourceTemplates, "template")
             })
-          }),
-        "tools/call": (r) =>
-          server.callTool(r).pipe(
-            Effect.provideService(CurrentLogLevel, currentLogLevel)
-          ),
-        "tools/list": (_, { client, headers }) =>
-          Effect.sync(() => {
-            const initialized = getInitializedClient(options.clientSessions, client.id, headers)
+          })),
+        "tools/call": (r, options) =>
+          runMiddlewares("tools/call", r, options, (r) =>
+            server.callTool(r).pipe(
+              Effect.provideService(CurrentLogLevel, currentLogLevel)
+            )),
+        "tools/list": (r, handlerOptions) =>
+          runMiddlewares("tools/list", r, handlerOptions, () => Effect.sync(() => {
+            const initialized = getInitializedClient(options.clientSessions, handlerOptions.client.id, handlerOptions.headers)
             return new ListToolsResult({
               tools: filterByClient(initialized, server.tools, "tool")
             })
-          }),
+          })),
 
         // Notifications
         "notifications/cancelled": (_) => Effect.void,

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -1,8 +1,10 @@
 import { describe, it } from "@effect/vitest"
-import { strictEqual } from "@effect/vitest/utils"
-import { Effect, Layer } from "effect"
+import { deepStrictEqual, strictEqual } from "@effect/vitest/utils"
+import { Effect, Layer, Option, Schema } from "effect"
 import * as McpSchema from "effect/unstable/ai/McpSchema"
 import * as McpServer from "effect/unstable/ai/McpServer"
+import * as Tool from "effect/unstable/ai/Tool"
+import * as Toolkit from "effect/unstable/ai/Toolkit"
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient"
 import * as HttpClient from "effect/unstable/http/HttpClient"
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest"
@@ -10,14 +12,34 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 
-const makeTestClient = Effect.gen(function*() {
+const EchoTool = Tool.make("echo", {
+  parameters: Schema.Struct({
+    message: Schema.String
+  }),
+  success: Schema.String
+})
+
+const EchoToolkit = Toolkit.make(EchoTool)
+
+const EchoLayer = McpServer.toolkit(EchoToolkit).pipe(
+  Layer.provideMerge(
+    EchoToolkit.toLayer({
+      echo: ({ message }) => Effect.succeed(message)
+    })
+  )
+)
+
+const makeTestClient = (
+  serverParts: Layer.Layer<never, never, never> = Layer.empty
+) =>
+Effect.gen(function*() {
   const responses: Array<Response> = []
 
-  const serverLayer = McpServer.layerHttp({
+  const serverLayer = serverParts.pipe(Layer.provide(McpServer.layerHttp({
     name: "TestServer",
     version: "1.0.0",
     path: "/mcp"
-  })
+  })))
   const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
   yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
 
@@ -28,7 +50,7 @@ const makeTestClient = Effect.gen(function*() {
       request.headers.set("Mcp-Session-Id", sessionId)
     }
     const response = await handler(request)
-    sessionId = response.headers.get("Mcp-Session-Id")
+    sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
     responses.push(response.clone())
     return response
   }
@@ -51,7 +73,7 @@ const makeTestClient = Effect.gen(function*() {
 describe("McpServer", () => {
   it.effect("replays MCP session and negotiated protocol headers after initialize", () =>
     Effect.gen(function*() {
-      const { client, responses } = yield* makeTestClient
+      const { client, responses } = yield* makeTestClient()
 
       yield* client.initialize({
         protocolVersion: "9999-01-01",
@@ -70,7 +92,7 @@ describe("McpServer", () => {
 
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
     Effect.gen(function*() {
-      const { httpClient } = yield* makeTestClient
+      const { httpClient } = yield* makeTestClient()
 
       const response = yield* HttpClientRequest.post("http://locahost/mcp").pipe(
         HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", method: "ping", params: {}, id: 0 }),
@@ -78,5 +100,369 @@ describe("McpServer", () => {
       )
 
       strictEqual(response.status, 404)
+    }))
+
+  it.effect("runs middleware with MCP request metadata", () =>
+    Effect.gen(function*() {
+      const seen: Array<{
+        readonly method: string
+        readonly clientId: number
+        readonly requestId: string
+        readonly serverName: string
+        readonly mcpSessionId: string | undefined
+        readonly initializedClientName: string | undefined
+      }> = []
+
+      const { client } = yield* makeTestClient(McpServer.middleware((request) =>
+        Effect.gen(function*() {
+          seen.push({
+            method: request.method,
+            clientId: request.clientId,
+            requestId: request.requestId.toString(),
+            serverName: request.serverInfo.name,
+            mcpSessionId: Option.getOrUndefined(request.mcpSessionId),
+            initializedClientName: Option.getOrUndefined(request.initializedClient)?.clientInfo.name
+          })
+          return yield* request.next()
+        })
+      ))
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+      yield* client.ping({})
+
+      strictEqual(seen[0]?.method, "initialize")
+      strictEqual(seen[0]?.serverName, "TestServer")
+      strictEqual(seen[0]?.initializedClientName, undefined)
+      strictEqual(seen[1]?.method, "ping")
+      strictEqual(seen[1]?.initializedClientName, "TestClient")
+      strictEqual(typeof seen[1]?.mcpSessionId, "string")
+    }))
+
+  it.effect("allows middleware to transform initialize and tools/list results", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          EchoLayer,
+          McpServer.middleware((request) =>
+            Effect.gen(function*() {
+              const result = yield* request.next()
+              if (request.method === "initialize") {
+                return {
+                  ...result,
+                  capabilities: {
+                    ...result.capabilities,
+                    tools: { listChanged: true }
+                  }
+                }
+              }
+              if (request.method === "tools/list") {
+                return new McpSchema.ListToolsResult({
+                  ...result,
+                  tools: [
+                    ...result.tools,
+                    new McpSchema.Tool({
+                      name: "synthetic",
+                      description: "Synthetic tool",
+                      inputSchema: {
+                        type: "object",
+                        properties: {}
+                      }
+                    })
+                  ]
+                })
+              }
+              return result
+            })
+          )
+        )
+      )
+
+      const initialized = yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+      const listed = yield* client["tools/list"](undefined)
+
+      deepStrictEqual(initialized.capabilities.tools, { listChanged: true })
+      deepStrictEqual(listed.tools.map((tool) => tool.name), ["echo", "synthetic"])
+    }))
+
+  it.effect("allows middleware to rewrite and short-circuit tool calls", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          EchoLayer,
+          McpServer.middleware((request) => {
+            if (request.method !== "tools/call") {
+              return request.next()
+            }
+            if (request.payload.name === "synthetic") {
+              return Effect.succeed(new McpSchema.CallToolResult({
+                content: [{
+                  type: "text",
+                  text: "handled by middleware"
+                }]
+              }))
+            }
+            return request.next({
+              ...request.payload,
+              arguments: {
+                ...request.payload.arguments,
+                message: "rewritten"
+              }
+            })
+          })
+        )
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+
+      const rewritten = yield* client["tools/call"]({
+        name: "echo",
+        arguments: {
+          message: "original"
+        }
+      })
+      const synthetic = yield* client["tools/call"]({
+        name: "synthetic",
+        arguments: {}
+      })
+
+      strictEqual(rewritten.content[0]?.type, "text")
+      strictEqual(rewritten.content[0]?.text, "\"rewritten\"")
+      strictEqual(synthetic.content[0]?.type, "text")
+      strictEqual(synthetic.content[0]?.text, "handled by middleware")
+    }))
+
+  it.effect("runs multiple middlewares in registration order", () =>
+    Effect.gen(function*() {
+      const order: Array<string> = []
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          McpServer.middleware((request) =>
+            Effect.gen(function*() {
+              order.push("a-before")
+              const result = yield* request.next()
+              order.push("a-after")
+              return result
+            })
+          ),
+          McpServer.middleware((request) =>
+            Effect.gen(function*() {
+              order.push("b-before")
+              const result = yield* request.next()
+              order.push("b-after")
+              return result
+            })
+          )
+        )
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+
+      deepStrictEqual(order, ["a-before", "b-before", "b-after", "a-after"])
+    }))
+
+  it.effect("does not run middleware for client notifications", () =>
+    Effect.gen(function*() {
+      const methods: Array<string> = []
+      const { client, httpClient } = yield* makeTestClient(McpServer.middleware((request) =>
+        Effect.sync(() => methods.push(request.method)).pipe(
+          Effect.andThen(request.next())
+        )
+      ))
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "TestClient",
+          version: "1.0.0"
+        }
+      })
+      yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {}
+        }),
+        httpClient.execute
+      )
+
+      deepStrictEqual(methods, ["initialize"])
+    }))
+
+  it.effect("allows middleware to reject requests with MCP errors", () =>
+    Effect.gen(function*() {
+      const { client } = yield* makeTestClient(
+        McpServer.middleware((request) => {
+          if (request.method === "tools/call") {
+            return Effect.fail(new McpSchema.InvalidParams({ message: "Rate limit exceeded" }))
+          }
+          return request.next()
+        })
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const result = yield* client["tools/call"]({ name: "echo", arguments: { message: "test" } }).pipe(
+        Effect.flip
+      )
+
+      strictEqual(result._tag, "InvalidParams")
+      strictEqual(result.message, "Rate limit exceeded")
+    }))
+
+  it.effect("allows middleware to observe tool execution failures and time execution", () =>
+    Effect.gen(function*() {
+      let observedError = false
+      let durationObserved = false
+
+      const ErrorToolLayer = McpServer.toolkit(Toolkit.make(Tool.make("error_tool", {
+        parameters: Schema.Struct({}),
+        success: Schema.String
+      }))).pipe(
+        Layer.provideMerge(
+          Toolkit.make(Tool.make("error_tool", {
+            parameters: Schema.Struct({}),
+            success: Schema.String
+          })).toLayer({
+            error_tool: () => Effect.fail(new Error("Downstream failure"))
+          })
+        )
+      )
+
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          ErrorToolLayer,
+          McpServer.middleware((request) => 
+            Effect.gen(function*() {
+              const [duration, result] = yield* Effect.timed(request.next())
+              if (request.method === "tools/call" && "isError" in result && result.isError === true) {
+                observedError = true
+              }
+              durationObserved = true
+              return result
+            })
+          )
+        )
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      const result = yield* client["tools/call"]({ name: "error_tool", arguments: {} })
+
+      strictEqual(observedError, true)
+      strictEqual(durationObserved, true)
+      strictEqual(result.isError, true)
+    }))
+
+  it.effect("allows middleware to access the McpServer service from context", () =>
+    Effect.gen(function*() {
+      let toolsCount = -1
+
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          EchoLayer,
+          McpServer.middleware((request) =>
+            Effect.gen(function*() {
+              const server = yield* McpServer.McpServer
+              if (request.method === "tools/list") {
+                toolsCount = server.tools.length
+              }
+              return yield* request.next()
+            })
+          )
+        )
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+      yield* client["tools/list"](undefined)
+
+      strictEqual(toolsCount, 1) // EchoTool is registered
+    }))
+
+  it.effect("intercepts prompts and resources", () =>
+    Effect.gen(function*() {
+      const intercepted: Array<string> = []
+
+      const TestPrompt = McpServer.prompt({
+        name: "test_prompt",
+        description: "A test prompt",
+        content: () => Effect.succeed("Prompt content")
+      })
+
+      const TestResource = McpServer.resource({
+        uri: "file:///test.txt",
+        name: "test_resource",
+        content: Effect.succeed("Resource content")
+      })
+
+      const { client } = yield* makeTestClient(
+        Layer.mergeAll(
+          TestPrompt,
+          TestResource,
+          McpServer.middleware((request) => {
+            intercepted.push(request.method)
+            return request.next()
+          })
+        )
+      )
+
+      yield* client.initialize({
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "TestClient", version: "1.0.0" }
+      })
+
+      yield* client["prompts/list"](undefined)
+      yield* client["prompts/get"]({ name: "test_prompt", arguments: {} })
+      yield* client["resources/list"](undefined)
+      yield* client["resources/read"]({ uri: "file:///test.txt" })
+
+      deepStrictEqual(intercepted, [
+        "initialize",
+        "prompts/list",
+        "prompts/get",
+        "resources/list",
+        "resources/read"
+      ])
     }))
 })


### PR DESCRIPTION
Hi from the [AgentCat](https://github.com/agentcathq) team :) We're a fellow open source solution for user analytics on top of MCP servers. We had a request from one of our customers to support Effect's MCP server implementation, but in order to do so, Effect needs a clean middleware API for us to properly "plug in". 

Happy to make this better in anyway :)

<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR introduces robust, transforming Middleware support to `effect/unstable/ai/McpServer`.

The new Middleware API (`McpServer.middleware`) safely enables full interception, modification, short-circuiting, and observation of MCP requests and responses. Middlewares have full access to request metadata (including headers,`mcpSessionId`, and `clientInfo`) and smoothly integrate with Effect's dependency injection (`Context`) so that underlying `McpServer` properties (like registered tools) can be queried.

**Key Capabilities:**
    - Seamlessly wrap core handlers (`initialize`, `tools/list`, `tools/call`, `prompts`, `resources`, etc.) using `request.next()`.
    - Rewrite outgoing responses or incoming payloads.
    - Short-circuit operations with immediate success results or valid MCP JSON-RPC errors (like `InvalidParams`).
    - Time exact execution duration of sub-handlers using `Effect.timed`.

This feature establishes a stable foundation for advanced 3rd-party integrations to hook into Effect servers natively empowering use cases like custom telemetry/observability solutions (e.g., AgentCat), and dynamic injection.

Comprehensive test coverage (`packages/effect/test/unstable/ai/McpServer.test.ts`) has been added as well as a `.changeset` is included.
