### PR TITLE
Fix transactional cluster request handling

### DIFF
--- a/.changeset/fix-cluster-transactional-rpc.md
+++ b/.changeset/fix-cluster-transactional-rpc.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep transactional cluster request handlers and their durable replies inside the same storage transaction.

--- a/packages/effect/src/unstable/cluster/MessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/MessageStorage.ts
@@ -73,6 +73,11 @@ export class MessageStorage extends Context.Service<MessageStorage, {
   readonly clearReplies: (requestId: Snowflake.Snowflake) => Effect.Effect<void, PersistenceError>
 
   /**
+   * Release a claimed request so it can be read again after handling rolls back.
+   */
+  readonly releaseRequest: (requestId: Snowflake.Snowflake) => Effect.Effect<void, PersistenceError>
+
+  /**
    * Retrieves the replies for the specified requests.
    *
    * **Details**
@@ -168,6 +173,11 @@ export class MessageStorage extends Context.Service<MessageStorage, {
    * Used to wrap requests with transactions.
    */
   readonly withTransaction: <A, E, R>(
+    effect: Effect.Effect<A, E, R>
+  ) => Effect.Effect<A, E, R>
+
+  /** @internal */
+  readonly withTransactionAndDeferredReplies: <A, E, R>(
     effect: Effect.Effect<A, E, R>
   ) => Effect.Effect<A, E, R>
 }>()("effect/cluster/MessageStorage") {}
@@ -308,6 +318,11 @@ export type Encoded = {
    * Remove the replies for the specified request.
    */
   readonly clearReplies: (requestId: Snowflake.Snowflake) => Effect.Effect<void, PersistenceError>
+
+  /**
+   * Release a claimed request without changing its replies or envelopes.
+   */
+  readonly releaseRequest: (requestId: Snowflake.Snowflake) => Effect.Effect<void, PersistenceError>
 
   /**
    * Retrieves the request id for the specified primary key.
@@ -452,7 +467,10 @@ export type EncodedRepliesOptions<A> = {
 export const make = (
   storage: Omit<
     MessageStorage["Service"],
-    "registerReplyHandler" | "unregisterReplyHandler" | "unregisterShardReplyHandlers"
+    | "registerReplyHandler"
+    | "unregisterReplyHandler"
+    | "unregisterShardReplyHandlers"
+    | "withTransactionAndDeferredReplies"
   >
 ): Effect.Effect<MessageStorage["Service"]> =>
   Effect.sync(() => {
@@ -464,8 +482,54 @@ export const make = (
     }
     const replyHandlers = new Map<Snowflake.Snowflake, Array<ReplyHandler>>()
     const replyHandlersShard = new Map<string, Set<ReplyHandler>>()
+    const TransactionReplies = Context.Reference<
+      Array<Effect.Effect<void, PersistenceError | MalformedMessage>> | undefined
+    >(
+      "effect/cluster/MessageStorage/TransactionReplies",
+      { defaultValue: () => undefined }
+    )
+    const deliverReply = (reply: Reply.ReplyWithContext<any>) =>
+      Effect.suspend(() => {
+        const requestId = reply.reply.requestId
+        const handlers = replyHandlers.get(requestId)
+        if (!handlers) {
+          return Effect.void
+        } else if (reply.reply._tag === "WithExit") {
+          replyHandlers.delete(requestId)
+          for (let i = 0; i < handlers.length; i++) {
+            const handler = handlers[i]
+            handler.shardSet.delete(handler)
+            handler.resume(Effect.void)
+          }
+        }
+        return handlers.length === 1
+          ? handlers[0].respond(reply)
+          : Effect.forEach(handlers, (handler) => handler.respond(reply))
+      })
     return MessageStorage.of({
       ...storage,
+      withTransactionAndDeferredReplies: (effect) =>
+        Effect.suspend(() => {
+          const replies: Array<Effect.Effect<void, PersistenceError | MalformedMessage>> = []
+          return storage.withTransaction(
+            Effect.provideService(effect, TransactionReplies, replies)
+          ).pipe(
+            Effect.flatMap((value) =>
+              Effect.as(
+                Effect.forEach(
+                  replies,
+                  (delivery) =>
+                    Effect.catchCause(
+                      delivery,
+                      (cause) => Effect.logWarning("Could not deliver committed transactional reply", cause)
+                    ),
+                  { discard: true }
+                ),
+                value
+              )
+            )
+          )
+        }),
       registerReplyHandler: (message) => {
         const requestId = message.envelope.requestId
         return Effect.callback<void, EntityNotAssignedToRunner>((resume) => {
@@ -526,23 +590,13 @@ export const make = (
           })
         }),
       saveReply(reply) {
-        const requestId = reply.reply.requestId
-        return Effect.flatMap(storage.saveReply(reply), () => {
-          const handlers = replyHandlers.get(requestId)
-          if (!handlers) {
+        return Effect.flatMap(storage.saveReply(reply), () =>
+          Effect.flatMap(TransactionReplies, (replies) => {
+            const delivery = deliverReply(reply)
+            if (replies === undefined) return delivery
+            replies.push(delivery)
             return Effect.void
-          } else if (reply.reply._tag === "WithExit") {
-            replyHandlers.delete(requestId)
-            for (let i = 0; i < handlers.length; i++) {
-              const handler = handlers[i]
-              handler.shardSet.delete(handler)
-              handler.resume(Effect.void)
-            }
-          }
-          return handlers.length === 1
-            ? handlers[0].respond(reply)
-            : Effect.forEach(handlers, (handler) => handler.respond(reply))
-        })
+          }))
       }
     })
   })
@@ -612,6 +666,7 @@ export const makeEncoded: (encoded: Encoded) => Effect.Effect<
         encoded.saveReply
       ),
     clearReplies: encoded.clearReplies,
+    releaseRequest: encoded.releaseRequest,
     repliesFor: Effect.fnUntraced(function*(messages) {
       const requestIds = Arr.empty<string>()
       const map = new Map<string, Message.OutgoingRequest<any>>()
@@ -774,6 +829,7 @@ export const noop: MessageStorage["Service"] = Effect.runSync(make({
   saveEnvelope: () => Effect.void,
   saveReply: () => Effect.void,
   clearReplies: () => Effect.void,
+  releaseRequest: () => Effect.void,
   repliesFor: () => Effect.succeed([]),
   repliesForUnfiltered: () => Effect.succeed([]),
   requestIdForPrimaryKey: () => Effect.succeedNone,
@@ -1008,6 +1064,13 @@ export class MemoryDriver extends Context.Service<MemoryDriver>()("effect/cluste
           }
         }),
       resetShards: () => Effect.void,
+      releaseRequest: (id) =>
+        Effect.sync(() => {
+          const entry = requests.get(String(id))
+          if (entry && !entry.replies.some((reply) => reply._tag === "WithExit")) {
+            unprocessed.add(entry.envelope)
+          }
+        }),
       withTransaction: Effect.provideService(MemoryTransaction, true)
     }
 

--- a/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
+++ b/packages/effect/src/unstable/cluster/SqlMessageStorage.ts
@@ -487,6 +487,23 @@ export const make: (options?: {
       withTracerDisabled
     ),
 
+    releaseRequest: (requestId) =>
+      sql`
+        UPDATE ${messagesTableSql}
+        SET last_read = NULL
+        WHERE request_id = ${String(requestId)}
+          AND processed = ${sqlFalse}
+          AND NOT EXISTS (
+            SELECT 1 FROM ${repliesTableSql}
+            WHERE request_id = ${String(requestId)}
+              AND kind = ${replyKind.WithExit}
+          )
+      `.pipe(
+        Effect.asVoid,
+        PersistenceError.refail,
+        withTracerDisabled
+      ),
+
     requestIdForPrimaryKey: (primaryKey) =>
       sql<{ id: string | bigint }>`SELECT id FROM ${messagesTableSql} WHERE message_id = ${primaryKey}`.pipe(
         Effect.map((rows) => Option.map(Option.fromNullishOr(rows[0]?.id), Snowflake.Snowflake)),

--- a/packages/effect/src/unstable/cluster/internal/entityManager.ts
+++ b/packages/effect/src/unstable/cluster/internal/entityManager.ts
@@ -75,6 +75,9 @@ export type EntityState = {
   }>
   lastActiveCheck: number
   write: RpcServer.RpcServer<any>["write"]
+  writeAndAwaitCompletion: RpcServer.RpcServer<any>["writeAndAwaitCompletion"]
+  readonly completeRequest: (requestId: Snowflake.Snowflake) => void
+  readonly restart: (cause: Cause.Cause<never>) => Effect.Effect<void>
   readonly keepAliveLatch: Latch.Latch
   keepAliveEnabled: boolean
 }
@@ -186,7 +189,8 @@ export const make = Effect.fnUntraced(function*<
                 const request = activeRequests.get(Snowflake.Snowflake(response.requestId))
                 if (!request) return Effect.void
 
-                request.sentReply = true
+                const transactional = Context.get(request.message.annotations, WithTransaction)
+                if (!transactional) request.sentReply = true
 
                 if (
                   isShuttingDown &&
@@ -235,15 +239,7 @@ export const make = Effect.fnUntraced(function*<
                   )
                 ).pipe(
                   Effect.flatMap(() => {
-                    processedRequestIds.add(request.message.envelope.requestId)
-                    activeRequests.delete(Snowflake.Snowflake(response.requestId))
-
-                    // ensure that the reaper does not remove the entity as we haven't
-                    // been "idle" yet
-                    if (activeRequests.size === 0) {
-                      state.lastActiveCheck = clock.currentTimeMillisUnsafe()
-                    }
-
+                    if (!transactional) completeRequest(request.message.envelope.requestId)
                     return Effect.void
                   }),
                   Effect.orDie
@@ -296,7 +292,7 @@ export const make = Effect.fnUntraced(function*<
             const request = activeRequests.get(id)
             if (!request) continue
             const { lastSentChunk, message } = request
-            yield* server.write(0, {
+            const rpcRequest = {
               ...message.envelope,
               id: message.envelope.requestId as any,
               tag: message.envelope.tag as any,
@@ -304,12 +300,20 @@ export const make = Effect.fnUntraced(function*<
                 ...message.envelope,
                 lastSentChunk
               } as any) as any
-            })
+            }
+            if (Context.get(message.annotations, WithTransaction)) {
+              yield* options.storage.withTransactionAndDeferredReplies(
+                server.writeAndAwaitCompletion(0, rpcRequest)
+              )
+              completeRequest(message.envelope.requestId)
+            } else {
+              yield* server.write(0, rpcRequest)
+            }
           }
           defectRequestIds.clear()
         }
 
-        return server.write
+        return server
       })
     )
 
@@ -338,15 +342,34 @@ export const make = Effect.fnUntraced(function*<
       )
     }
 
+    function completeRequest(requestId: Snowflake.Snowflake): void {
+      processedRequestIds.add(requestId)
+      activeRequests.delete(requestId)
+      if (activeRequests.size === 0) {
+        state.lastActiveCheck = clock.currentTimeMillisUnsafe()
+      }
+    }
+
     const state: EntityState = {
       scope,
       address,
       write(clientId, message) {
         if (writeRef.state.current._tag !== "Acquired") {
-          return Effect.flatMap(writeRef.await, (write) => write(clientId, message))
+          return Effect.flatMap(writeRef.await, (server) => server.write(clientId, message))
         }
-        return writeRef.state.current.value(clientId, message)
+        return writeRef.state.current.value.write(clientId, message)
       },
+      writeAndAwaitCompletion(clientId, message) {
+        if (writeRef.state.current._tag !== "Acquired") {
+          return Effect.flatMap(
+            writeRef.await,
+            (server) => server.writeAndAwaitCompletion(clientId, message)
+          )
+        }
+        return writeRef.state.current.value.writeAndAwaitCompletion(clientId, message)
+      },
+      completeRequest,
+      restart: onDefect,
       activeRequests,
       lastActiveCheck: clock.currentTimeMillisUnsafe(),
       keepAliveLatch,
@@ -472,7 +495,7 @@ export const make = Effect.fnUntraced(function*<
                 })
               }
               server.activeRequests.set(message.envelope.requestId, entry)
-              let write = server.write(0, {
+              const request = {
                 ...message.envelope,
                 id: message.envelope.requestId as any,
                 payload: new Request({
@@ -482,11 +505,37 @@ export const make = Effect.fnUntraced(function*<
                     (reply): reply is Reply.Chunk<R> => reply._tag === "Chunk"
                   )
                 })
-              })
-              if (Context.get(message.annotations, WithTransaction)) {
-                write = options.storage.withTransaction(write)
               }
-              return write
+              if (Context.get(message.annotations, WithTransaction)) {
+                return Effect.matchCauseEffect(
+                  options.storage.withTransactionAndDeferredReplies(
+                    server.writeAndAwaitCompletion(0, request)
+                  ),
+                  {
+                    onSuccess: () => Effect.sync(() => server.completeRequest(message.envelope.requestId)),
+                    onFailure: (cause) => {
+                      if (!Cause.hasInterrupts(cause)) return server.restart(cause)
+                      return Effect.andThen(
+                        Effect.uninterruptible(
+                          Effect.catchCause(
+                            options.storage.releaseRequest(message.envelope.requestId),
+                            (releaseCause) =>
+                              Effect.andThen(
+                                Effect.logError("Could not release transactional entity request", releaseCause),
+                                Effect.interrupt
+                              )
+                          )
+                        ),
+                        Effect.sync(() => {
+                          processedRequestIds.delete(message.envelope.requestId)
+                          server.activeRequests.delete(message.envelope.requestId)
+                        })
+                      ).pipe(Effect.andThen(Effect.interrupt))
+                    }
+                  }
+                )
+              }
+              return server.write(0, request)
             }
             case "IncomingEnvelope": {
               const entry = server.activeRequests.get(message.envelope.requestId)

--- a/packages/effect/src/unstable/rpc/RpcServer.ts
+++ b/packages/effect/src/unstable/rpc/RpcServer.ts
@@ -68,6 +68,7 @@ import { withRun } from "./Utils.ts"
  */
 export interface RpcServer<A extends Rpc.Any> {
   readonly write: (clientId: number, message: FromClient<A>) => Effect.Effect<void>
+  readonly writeAndAwaitCompletion: (clientId: number, message: FromClient<A>) => Effect.Effect<void>
   readonly disconnect: (clientId: number) => Effect.Effect<void>
 }
 
@@ -164,57 +165,69 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
       return Effect.void
     })
 
+  const writeInternal = (
+    clientId: number,
+    message: FromClient<Rpcs>,
+    awaitCompletion: boolean
+  ): Effect.Effect<void> =>
+    Effect.withFiber((requestFiber) => {
+      if (isShutdown) return Effect.interrupt
+      let client = clients.get(clientId)
+      if (!client) {
+        client = {
+          id: clientId,
+          latches: new Map(),
+          fibers: new Map(),
+          ended: false,
+          serverClient: new Rpc.ServerClient(clientId)
+        }
+        clients.set(clientId, client)
+      } else if (client.ended) {
+        return Effect.interrupt
+      }
+
+      switch (message._tag) {
+        case "Request": {
+          return handleRequest(requestFiber, client, message, awaitCompletion)
+        }
+        case "Ack": {
+          const latch = client.latches.get(message.requestId)
+          return latch ? latch.open : Effect.void
+        }
+        case "Interrupt": {
+          const fiber = client.fibers.get(message.requestId)
+          if (fiber) {
+            fiber.interruptUnsafe(requestFiber.id, RpcSchema.ClientAbort.annotation)
+            return Effect.void
+          }
+          return options.onFromServer({
+            _tag: "Exit",
+            clientId,
+            requestId: message.requestId,
+            exit: Exit.interrupt()
+          })
+        }
+        case "Eof": {
+          client.ended = true
+          if (client.fibers.size > 0) return Effect.void
+          return endClient(client)
+        }
+        default: {
+          return sendDefect(client, `Unknown request tag: ${(message as any)._tag}`)
+        }
+      }
+    })
+
   const write = (clientId: number, message: FromClient<Rpcs>): Effect.Effect<void> =>
     Effect.catchDefect(
-      Effect.withFiber((requestFiber) => {
-        if (isShutdown) return Effect.interrupt
-        let client = clients.get(clientId)
-        if (!client) {
-          client = {
-            id: clientId,
-            latches: new Map(),
-            fibers: new Map(),
-            ended: false,
-            serverClient: new Rpc.ServerClient(clientId)
-          }
-          clients.set(clientId, client)
-        } else if (client.ended) {
-          return Effect.interrupt
-        }
-
-        switch (message._tag) {
-          case "Request": {
-            return handleRequest(requestFiber, client, message)
-          }
-          case "Ack": {
-            const latch = client.latches.get(message.requestId)
-            return latch ? latch.open : Effect.void
-          }
-          case "Interrupt": {
-            const fiber = client.fibers.get(message.requestId)
-            if (fiber) {
-              fiber.interruptUnsafe(requestFiber.id, RpcSchema.ClientAbort.annotation)
-              return Effect.void
-            }
-            return options.onFromServer({
-              _tag: "Exit",
-              clientId,
-              requestId: message.requestId,
-              exit: Exit.interrupt()
-            })
-          }
-          case "Eof": {
-            client.ended = true
-            if (client.fibers.size > 0) return Effect.void
-            return endClient(client)
-          }
-          default: {
-            return sendDefect(client, `Unknown request tag: ${(message as any)._tag}`)
-          }
-        }
-      }),
+      writeInternal(clientId, message, false),
       (defect) => sendDefect(clients.get(clientId)!, defect)
     )
+
+  const writeAndAwaitCompletion = (
+    clientId: number,
+    message: FromClient<Rpcs>
+  ): Effect.Effect<void> => writeInternal(clientId, message, true)
 
   const endClient = (client: Client) => {
     clients.delete(client.id)
@@ -231,7 +244,8 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
   const handleRequest = (
     requestFiber: Fiber.Fiber<any, any>,
     client: Client,
-    request: Request<Rpcs>
+    request: Request<Rpcs>,
+    awaitCompletion: boolean
   ): Effect.Effect<void> => {
     if (client.fibers.has(request.id)) {
       return Effect.interrupt
@@ -276,10 +290,29 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
       : handler
     let responded = false
     const scope = Scope.makeUnsafe()
+    const completion = awaitCompletion ? Latch.makeUnsafe(false) : undefined
+    let completionFailure: Cause.Cause<never> | undefined
+    let terminalFailure: unknown | undefined
+    let terminalInterrupted = false
+    let interruptRequested = false
     let deferred: Deferred.Deferred<unknown, unknown> | undefined = undefined
+    const trackResponse = (write: Effect.Effect<void>): Effect.Effect<void> => {
+      if (!completion) return write
+      return Effect.onExit(
+        write,
+        (exit) =>
+          Effect.sync(() => {
+            if (exit._tag === "Failure") completionFailure = exit.cause
+          })
+      )
+    }
     let effect = Effect.onExit(withMiddleware, (exit) => {
       responded = true
       let write: Effect.Effect<void>
+      if (exit._tag === "Failure") {
+        terminalFailure = Cause.squash(exit.cause)
+        terminalInterrupted = Cause.hasInterrupts(exit.cause)
+      }
       if (exit._tag === "Success") {
         if (Deferred.isDeferred(exit.value)) {
           deferred = exit.value
@@ -297,7 +330,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
         Cause.hasDies(exit.cause) &&
         !Cause.hasInterrupts(exit.cause)
       ) {
-        write = sendDefect(client, Cause.squash(exit.cause))
+        write = sendDefect(client, terminalFailure)
       } else {
         write = options.onFromServer({
           _tag: "Exit",
@@ -310,7 +343,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
       if (exit._tag === "Failure") {
         reportCauseUnsafe(Fiber.getCurrent()!, exit.cause)
       }
-      return close ? Effect.ensuring(write, close) : write
+      return trackResponse(close ? Effect.ensuring(write, close) : write)
     })
     if (enableTracing) {
       const parentSpan = requestFiber.context.mapUnsafe.get(
@@ -352,37 +385,78 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
     client.fibers.set(request.id, fiber)
     fiber.addObserver(function onExit(exit: Exit.Exit<any, any>): void {
       if (deferred) {
-        const fiber = trackFiber(runFork(Effect.onExit(Deferred.await(deferred), (exit) =>
-          options.onFromServer({
+        const fiber = trackFiber(runFork(Effect.onExit(Deferred.await(deferred), (exit) => {
+          if (exit._tag === "Failure") {
+            terminalFailure = Cause.squash(exit.cause)
+            terminalInterrupted = Cause.hasInterrupts(exit.cause)
+          }
+          return trackResponse(options.onFromServer({
             _tag: "Exit",
             clientId: client.id,
             requestId: request.id,
             exit: exit as any
-          }))))
+          }))
+        })))
         client.fibers.set(request.id, fiber)
         deferred = undefined
         fiber.addObserver(onExit)
+        if (interruptRequested) {
+          fiber.interruptUnsafe(requestFiber.id)
+        }
         return
       }
       if (!responded && exit._tag === "Failure") {
-        trackFiber(
+        const responseFiber = trackFiber(
           runFork(
-            options.onFromServer({
+            trackResponse(options.onFromServer({
               _tag: "Exit",
               clientId: client.id,
               requestId: request.id,
               exit: Exit.interrupt()
-            })
+            }))
           )
         )
+        if (completion) {
+          client.fibers.set(request.id, responseFiber)
+          responseFiber.addObserver(() => finishRequest())
+          if (interruptRequested) {
+            responseFiber.interruptUnsafe(requestFiber.id)
+          }
+          return
+        }
       }
+      finishRequest()
+    })
+
+    function finishRequest(): void {
       client.fibers.delete(request.id)
       client.latches.delete(request.id)
       if (client.ended && client.fibers.size === 0) {
         trackFiber(runFork(endClient(client)))
       }
-    })
-    return Effect.void
+      completion?.openUnsafe()
+    }
+
+    if (!completion) return Effect.void
+
+    const awaitResult = Effect.andThen(
+      completion.await,
+      Effect.suspend(() => {
+        if (completionFailure) return Effect.failCause(completionFailure)
+        if (terminalInterrupted) return Effect.interrupt
+        if (terminalFailure !== undefined) return Effect.die(terminalFailure)
+        return Effect.void
+      })
+    )
+    return Effect.onInterrupt(
+      awaitResult,
+      () =>
+        Effect.suspend(() => {
+          interruptRequested = true
+          client.fibers.get(request.id)?.interruptUnsafe(requestFiber.id)
+          return completion.await
+        })
+    )
   }
 
   const streamEffect = (
@@ -449,6 +523,7 @@ export const makeNoSerialization: <Rpcs extends Rpc.Any>(
 
   return identity<RpcServer<Rpcs>>({
     write,
+    writeAndAwaitCompletion,
     disconnect
   })
 })

--- a/packages/effect/test/cluster/MessageStorage.test.ts
+++ b/packages/effect/test/cluster/MessageStorage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest"
+import { assert, describe, expect, it } from "@effect/vitest"
 import { Context, Effect, Exit, Fiber, Latch, Layer, Option, Schema } from "effect"
 import { TestClock } from "effect/testing"
 import {
@@ -90,6 +90,45 @@ describe("MessageStorage", () => {
         yield* storage.saveReply(yield* makeReply(request))
         yield* latch.await
         yield* Fiber.await(fiber)
+      }).pipe(Effect.provide(MemoryLive)))
+
+    it.effect("delays transactional reply delivery until commit", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const latch = yield* Latch.make()
+        const request = yield* makeRequest()
+        yield* storage.saveRequest(request)
+        const fiber = yield* storage.registerReplyHandler(
+          new Message.OutgoingRequest({
+            ...request,
+            respond: () => latch.open
+          })
+        ).pipe(Effect.forkChild)
+        yield* TestClock.adjust(1)
+
+        yield* storage.withTransactionAndDeferredReplies(
+          Effect.gen(function*() {
+            yield* storage.saveReply(yield* makeReply(request))
+            assert.isFalse(latch.isOpen())
+          })
+        )
+
+        assert.isTrue(latch.isOpen())
+        yield* Fiber.await(fiber)
+      }).pipe(Effect.provide(MemoryLive)))
+
+    it.effect("releases an incomplete request", () =>
+      Effect.gen(function*() {
+        const storage = yield* MessageStorage.MessageStorage
+        const driver = yield* MessageStorage.MemoryDriver
+        const request = yield* makeRequest()
+        yield* storage.saveRequest(request)
+        const entry = driver.requests.get(String(request.envelope.requestId))!
+        driver.unprocessed.delete(entry.envelope)
+
+        yield* storage.releaseRequest(request.envelope.requestId)
+
+        assert.isTrue(driver.unprocessed.has(entry.envelope))
       }).pipe(Effect.provide(MemoryLive)))
   })
 })

--- a/packages/effect/test/cluster/Sharding.test.ts
+++ b/packages/effect/test/cluster/Sharding.test.ts
@@ -547,6 +547,7 @@ describe.concurrent("Sharding", () => {
   it.effect("WithTransaction is propagated to the entity handler", () =>
     Effect.gen(function*() {
       let isTransaction = false
+      let transactionOpen = false
       yield* Effect.gen(function*() {
         const makeClient = yield* TestEntity.client
         yield* TestClock.adjust(1)
@@ -558,9 +559,21 @@ describe.concurrent("Sharding", () => {
       }).pipe(Effect.provide(TestShardingWithoutStorage.pipe(
         Layer.updateService(MessageStorage.MessageStorage, (storage) => ({
           ...storage,
+          withTransactionAndDeferredReplies: (effect) =>
+            Effect.acquireUseRelease(
+              Effect.sync(() => {
+                transactionOpen = true
+              }),
+              () => storage.withTransactionAndDeferredReplies(effect),
+              () =>
+                Effect.sync(() => {
+                  transactionOpen = false
+                })
+            ),
           saveReply(reply) {
             return MessageStorage.MemoryTransaction.use((isTransaction_) => {
               isTransaction = isTransaction_
+              assert.isTrue(transactionOpen)
               return storage.saveReply(reply)
             })
           }

--- a/packages/effect/test/cluster/TestEntity.ts
+++ b/packages/effect/test/cluster/TestEntity.ts
@@ -123,7 +123,7 @@ export const TestEntityNoState = TestEntity.toLayer(
           Stream.rechunk(1)
         )
       },
-      WithTransaction: () => MemoryTransaction
+      WithTransaction: () => Effect.andThen(Effect.yieldNow, MemoryTransaction)
     })
   }),
   { defectRetryPolicy: Schedule.forever }

--- a/packages/effect/test/rpc/RpcServer.test.ts
+++ b/packages/effect/test/rpc/RpcServer.test.ts
@@ -1,0 +1,107 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Exit, Fiber, Latch, Option, Queue, Schema } from "effect"
+import { Headers } from "effect/unstable/http"
+import { Rpc, RpcGroup, RpcServer } from "effect/unstable/rpc"
+import type { FromServer } from "effect/unstable/rpc/RpcMessage"
+import { RequestId } from "effect/unstable/rpc/RpcMessage"
+
+const TestRpc = Rpc.make("RpcServerTest", { success: Schema.String })
+const TestGroup = RpcGroup.make(TestRpc)
+
+const request = {
+  _tag: "Request" as const,
+  id: RequestId("1"),
+  tag: TestRpc._tag,
+  payload: undefined,
+  headers: Headers.empty
+}
+
+describe("RpcServer", () => {
+  it.effect("write remains fire-and-forget", () => {
+    const started = Latch.makeUnsafe()
+    const release = Latch.makeUnsafe()
+    const HandlersLive = TestGroup.toLayer({
+      RpcServerTest: () => Effect.andThen(started.open, release.await).pipe(Effect.as("done"))
+    })
+
+    return Effect.scoped(
+      Effect.gen(function*() {
+        const responses = yield* Queue.unbounded<FromServer<typeof TestRpc>>()
+        const server = yield* RpcServer.makeNoSerialization(TestGroup, {
+          onFromServer: (response) => Queue.offer(responses, response)
+        })
+        const delivery = yield* server.write(1, request).pipe(Effect.forkChild({ startImmediately: true }))
+
+        yield* started.await
+        assert.isDefined(delivery.pollUnsafe())
+        assert(Option.isNone(yield* Queue.poll(responses)))
+
+        yield* release.open
+        const response = yield* Queue.take(responses)
+        assert(response._tag === "Exit")
+        assert.deepStrictEqual(response.exit, Exit.succeed("done"))
+      })
+    ).pipe(Effect.provide(HandlersLive))
+  })
+
+  it.effect("writeAndAwaitCompletion waits for the terminal response", () => {
+    const started = Latch.makeUnsafe()
+    const release = Latch.makeUnsafe()
+    const HandlersLive = TestGroup.toLayer({
+      RpcServerTest: () => Effect.andThen(started.open, release.await).pipe(Effect.as("done"))
+    })
+
+    return Effect.scoped(
+      Effect.gen(function*() {
+        const responses = yield* Queue.unbounded<FromServer<typeof TestRpc>>()
+        const server = yield* RpcServer.makeNoSerialization(TestGroup, {
+          onFromServer: (response) => Queue.offer(responses, response)
+        })
+        const delivery = yield* server.writeAndAwaitCompletion(1, request).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        yield* started.await
+        assert.isUndefined(delivery.pollUnsafe())
+
+        yield* release.open
+        yield* Fiber.join(delivery)
+        const response = yield* Queue.take(responses)
+        assert(response._tag === "Exit")
+        assert.deepStrictEqual(response.exit, Exit.succeed("done"))
+      })
+    ).pipe(Effect.provide(HandlersLive))
+  })
+
+  it.effect("writeAndAwaitCompletion interrupts the request handler", () => {
+    const started = Latch.makeUnsafe()
+    const interrupted = Latch.makeUnsafe()
+    const HandlersLive = TestGroup.toLayer({
+      RpcServerTest: () =>
+        Effect.andThen(started.open, Effect.never).pipe(
+          Effect.onInterrupt(() => interrupted.open)
+        )
+    })
+
+    return Effect.scoped(
+      Effect.gen(function*() {
+        const responses = yield* Queue.unbounded<FromServer<typeof TestRpc>>()
+        const server = yield* RpcServer.makeNoSerialization(TestGroup, {
+          onFromServer: (response) => Queue.offer(responses, response)
+        })
+        const delivery = yield* server.writeAndAwaitCompletion(1, request).pipe(
+          Effect.forkChild({ startImmediately: true })
+        )
+
+        yield* started.await
+        yield* Fiber.interrupt(delivery)
+
+        assert(Exit.hasInterrupts(delivery.pollUnsafe()!))
+        assert.isTrue(interrupted.isOpen())
+        const response = yield* Queue.take(responses)
+        assert(response._tag === "Exit")
+        assert(Exit.hasInterrupts(response.exit))
+      })
+    ).pipe(Effect.provide(HandlersLive))
+  })
+})


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

`ClusterSchema.WithTransaction` currently wraps `RpcServer.write`, but `write` forks the request handler and returns immediately. The storage transaction can therefore commit before the handler and durable reply complete.

This change:

- adds an awaited scalar request path to `RpcServer` while preserving ordinary fire-and-forget and streaming behavior
- keeps transactional entity handlers and durable replies inside the same message-storage transaction
- defers in-process reply delivery until the transaction commits
- releases interrupted transactional request claims so they can be reconstructed
- adds regression coverage for transaction lifetime, reply delivery, interruption, and existing `write` semantics

Validation:

- `npx --yes pnpm@10.17.1 lint-fix`
- `npx --yes pnpm@10.17.1 test packages/effect/test/rpc/RpcServer.test.ts packages/effect/test/cluster/MessageStorage.test.ts packages/effect/test/cluster/Sharding.test.ts packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `npx --yes pnpm@10.17.1 check`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue #1234 and automatically
close the issue once we merge the pull request.
-->

- None.
