### PR TITLE
Fix MCP Streamable HTTP transport compliance

### DIFF
--- a/.changeset/calm-servers-share.md
+++ b/.changeset/calm-servers-share.md
@@ -1,0 +1,5 @@
+---
+"effect": minor
+---
+
+Update `McpServer.layerHttp` to return `405` for unsupported HTTP methods, reject unsupported `MCP-Protocol-Version` headers with `400`, and return an empty `202` for accepted notifications and responses.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -342,6 +342,7 @@ const SUPPORTED_PROTOCOL_VERSIONS = [
 ]
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
+const acceptedHttpResponse = HttpServerResponse.empty({ status: 202 })
 
 /**
  * Runs an MCP server over the current `RpcServer.Protocol`.
@@ -439,14 +440,38 @@ export const run: (options: {
     ...protocol,
     run: (f) =>
       protocol.run((clientId, request_) => {
-        const request = request_ as any as
+        const request = request_ as unknown as
           | RpcMessage.FromServerEncoded
           | RpcMessage.FromClientEncoded
+        const httpRequest = isHttp
+          ? Context.getUnsafe(Fiber.getCurrent()!.context, HttpServerRequest.HttpServerRequest)
+          : undefined
+        if (httpRequest !== undefined) {
+          const protocolVersion = httpRequest.headers[mcpProtocolVersionHeader]
+          if (
+            protocolVersion !== undefined &&
+            !SUPPORTED_PROTOCOL_VERSIONS.includes(protocolVersion)
+          ) {
+            appendPreResponseHandlerUnsafe(
+              httpRequest,
+              () => Effect.succeed(HttpServerResponse.empty({ status: 400 }))
+            )
+            return Effect.die(new Error(`Unsupported MCP-Protocol-Version`))
+          }
+        }
+        if (httpRequest !== undefined && request._tag !== "Eof") {
+          appendPreResponseHandlerUnsafe(httpRequest, (_, response) =>
+            Effect.succeed(
+              response.status === 200 &&
+                response.body._tag === "Uint8Array" &&
+                response.body.contentLength === 0
+                ? acceptedHttpResponse
+                : response
+            ))
+        }
         switch (request._tag) {
           case "Request": {
-            if (isHttp) {
-              const fiber = Fiber.getCurrent()!
-              const httpRequest = Context.getUnsafe(fiber.context, HttpServerRequest.HttpServerRequest)
+            if (httpRequest !== undefined) {
               const client = getInitializedClient(clientSessions, clientId, httpRequest.headers)
               if (client) {
                 appendPreResponseHandlerUnsafe(httpRequest, (_, res) =>
@@ -635,8 +660,7 @@ export const layerStdio = (options: {
   )
 
 /**
- * Registers an HTTP POST JSON-RPC route at `options.path` on the current
- * `HttpRouter`.
+ * Registers a Streamable HTTP MCP endpoint at `options.path`.
  *
  * **When to use**
  *
@@ -644,8 +668,9 @@ export const layerStdio = (options: {
  *
  * **Details**
  *
- * This layer composes `layer(options)`, `RpcServer.layerProtocolHttp(options)`,
- * and `RpcSerialization.layerJsonRpc()`.
+ * POST serves JSON-RPC and accepted notification-only requests return `202`.
+ * Unsupported protocol versions return `400`; methods without MCP handlers
+ * return `405`.
  *
  * @see {@link layerStdio} for exposing the server over stdio
  * @see {@link layer} for the base MCP server layer without a transport protocol
@@ -658,11 +683,22 @@ export const layerHttp = (options: {
   readonly version: string
   readonly path: HttpRouter.PathInput
   readonly extensions?: Record<`${string}/${string}`, unknown> | undefined
-}): Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter> =>
-  layer(options).pipe(
+}): Layer.Layer<McpServer | McpServerClient, never, HttpRouter.HttpRouter> => {
+  const methodNotAllowedResponse = HttpServerResponse.empty({
+    status: 405,
+    headers: { allow: "POST" }
+  })
+  const routes = Layer.mergeAll(
+    HttpRouter.add("GET", options.path, methodNotAllowedResponse),
+    HttpRouter.add("PUT", options.path, methodNotAllowedResponse),
+    HttpRouter.add("PATCH", options.path, methodNotAllowedResponse),
+    HttpRouter.add("DELETE", options.path, methodNotAllowedResponse)
+  )
+  return Layer.merge(layer(options), routes).pipe(
     Layer.provide(RpcServer.layerProtocolHttp(options)),
     Layer.provide(RpcSerialization.layerJsonRpc())
   )
+}
 
 /**
  * Registers a `Toolkit` with the `McpServer`.

--- a/packages/effect/src/unstable/ai/McpServer.ts
+++ b/packages/effect/src/unstable/ai/McpServer.ts
@@ -342,7 +342,6 @@ const SUPPORTED_PROTOCOL_VERSIONS = [
 ]
 const mcpSessionIdHeader = "mcp-session-id"
 const mcpProtocolVersionHeader = "mcp-protocol-version"
-const acceptedHttpResponse = HttpServerResponse.empty({ status: 202 })
 
 /**
  * Runs an MCP server over the current `RpcServer.Protocol`.
@@ -465,7 +464,10 @@ export const run: (options: {
               response.status === 200 &&
                 response.body._tag === "Uint8Array" &&
                 response.body.contentLength === 0
-                ? acceptedHttpResponse
+                ? HttpServerResponse.empty({
+                  headers: Headers.remove(response.headers, "content-type"),
+                  status: 202
+                })
                 : response
             ))
         }

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -10,6 +10,22 @@ import * as HttpRouter from "effect/unstable/http/HttpRouter"
 import { RpcSerialization } from "effect/unstable/rpc"
 import * as RpcClient from "effect/unstable/rpc/RpcClient"
 
+const initializePayload = {
+  protocolVersion: "2025-06-18",
+  capabilities: {},
+  clientInfo: {
+    name: "TestClient",
+    version: "1.0.0"
+  }
+}
+
+const pingBody = {
+  jsonrpc: "2.0",
+  method: "ping",
+  params: {},
+  id: 0
+}
+
 const makeTestClient = Effect.gen(function*() {
   const responses: Array<Response> = []
 
@@ -28,7 +44,7 @@ const makeTestClient = Effect.gen(function*() {
       request.headers.set("Mcp-Session-Id", sessionId)
     }
     const response = await handler(request)
-    sessionId = response.headers.get("Mcp-Session-Id")
+    sessionId = response.headers.get("Mcp-Session-Id") ?? sessionId
     responses.push(response.clone())
     return response
   }
@@ -66,17 +82,106 @@ describe("McpServer", () => {
 
       strictEqual(responses.length, 2)
       strictEqual(responses[0].headers.get("Mcp-Protocol-Version"), "2025-06-18")
+      strictEqual(responses[1].headers.get("Mcp-Protocol-Version"), "2025-06-18")
     }))
 
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
     Effect.gen(function*() {
       const { httpClient } = yield* makeTestClient
 
-      const response = yield* HttpClientRequest.post("http://locahost/mcp").pipe(
+      const response = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
         HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", method: "ping", params: {}, id: 0 }),
         httpClient.execute
       )
 
       strictEqual(response.status, 404)
+    }))
+
+  it.effect("rejects unsupported HTTP methods without disturbing an initialized session", () =>
+    Effect.gen(function*() {
+      const { client, httpClient } = yield* makeTestClient
+
+      yield* client.initialize(initializePayload)
+
+      for (const method of ["GET", "PUT", "PATCH", "DELETE", "HEAD"] as const) {
+        const response = yield* HttpClientRequest.make(method)("http://localhost/mcp").pipe(
+          httpClient.execute
+        )
+        strictEqual(response.status, 405)
+        strictEqual(response.headers["allow"], "POST")
+      }
+
+      yield* client.ping({})
+    }))
+
+  it.effect("returns an empty 202 for notifications and responses and remains successful for request POSTs", () =>
+    Effect.gen(function*() {
+      const { client, httpClient } = yield* makeTestClient
+
+      yield* client.initialize(initializePayload)
+
+      const notificationResponse = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+          params: {}
+        }),
+        httpClient.execute
+      )
+      strictEqual(notificationResponse.status, 202)
+      strictEqual(yield* notificationResponse.text, "")
+
+      const responseOnly = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", id: 1, result: {} }),
+        httpClient.execute
+      )
+      strictEqual(responseOnly.status, 202)
+      strictEqual(yield* responseOnly.text, "")
+
+      const pingResponse = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe(pingBody),
+        httpClient.execute
+      )
+      strictEqual(pingResponse.status, 200)
+      const pingResponseBody = yield* pingResponse.text
+      strictEqual(pingResponseBody.length > 0, true)
+    }))
+
+  it.effect("validates supplied protocol versions on POST", () =>
+    Effect.gen(function*() {
+      const { client, httpClient } = yield* makeTestClient
+
+      yield* client.initialize(initializePayload)
+
+      const unsupportedResponse = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe(pingBody),
+        HttpClientRequest.setHeader("Mcp-Protocol-Version", "9999-01-01"),
+        httpClient.execute
+      )
+      strictEqual(unsupportedResponse.status, 400)
+      strictEqual(yield* unsupportedResponse.text, "")
+
+      const responseOnly = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", id: 1, result: {} }),
+        HttpClientRequest.setHeader("Mcp-Protocol-Version", "9999-01-01"),
+        httpClient.execute
+      )
+      strictEqual(responseOnly.status, 400)
+      strictEqual(yield* responseOnly.text, "")
+
+      const absentVersionResponse = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+        HttpClientRequest.bodyJsonUnsafe(pingBody),
+        httpClient.execute
+      )
+      strictEqual(absentVersionResponse.status, 200)
+
+      for (const protocolVersion of ["2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"]) {
+        const response = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
+          HttpClientRequest.bodyJsonUnsafe(pingBody),
+          HttpClientRequest.setHeader("Mcp-Protocol-Version", protocolVersion),
+          httpClient.execute
+        )
+        strictEqual(response.status, 200)
+      }
     }))
 })

--- a/packages/effect/test/unstable/ai/McpServer.test.ts
+++ b/packages/effect/test/unstable/ai/McpServer.test.ts
@@ -26,7 +26,9 @@ const pingBody = {
   id: 0
 }
 
-const makeTestClient = Effect.gen(function*() {
+const makeTestClient = Effect.fnUntraced(function*(options?: {
+  readonly routerLayer?: Layer.Layer<never, never, HttpRouter.HttpRouter> | undefined
+}) {
   const responses: Array<Response> = []
 
   const serverLayer = McpServer.layerHttp({
@@ -34,7 +36,8 @@ const makeTestClient = Effect.gen(function*() {
     version: "1.0.0",
     path: "/mcp"
   })
-  const { handler, dispose } = HttpRouter.toWebHandler(serverLayer, { disableLogger: true })
+  const appLayer = options?.routerLayer ? Layer.merge(serverLayer, options.routerLayer) : serverLayer
+  const { handler, dispose } = HttpRouter.toWebHandler(appLayer, { disableLogger: true })
   yield* Effect.addFinalizer(() => Effect.promise(() => dispose()))
 
   let sessionId: string | null = null
@@ -67,7 +70,7 @@ const makeTestClient = Effect.gen(function*() {
 describe("McpServer", () => {
   it.effect("replays MCP session and negotiated protocol headers after initialize", () =>
     Effect.gen(function*() {
-      const { client, responses } = yield* makeTestClient
+      const { client, responses } = yield* makeTestClient()
 
       yield* client.initialize({
         protocolVersion: "9999-01-01",
@@ -87,7 +90,7 @@ describe("McpServer", () => {
 
   it.effect("returns 404 when a non-initialize request omits the MCP session id", () =>
     Effect.gen(function*() {
-      const { httpClient } = yield* makeTestClient
+      const { httpClient } = yield* makeTestClient()
 
       const response = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
         HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", method: "ping", params: {}, id: 0 }),
@@ -99,7 +102,7 @@ describe("McpServer", () => {
 
   it.effect("rejects unsupported HTTP methods without disturbing an initialized session", () =>
     Effect.gen(function*() {
-      const { client, httpClient } = yield* makeTestClient
+      const { client, httpClient } = yield* makeTestClient()
 
       yield* client.initialize(initializePayload)
 
@@ -116,7 +119,7 @@ describe("McpServer", () => {
 
   it.effect("returns an empty 202 for notifications and responses and remains successful for request POSTs", () =>
     Effect.gen(function*() {
-      const { client, httpClient } = yield* makeTestClient
+      const { client, httpClient } = yield* makeTestClient({ routerLayer: HttpRouter.cors() })
 
       yield* client.initialize(initializePayload)
 
@@ -130,6 +133,9 @@ describe("McpServer", () => {
       )
       strictEqual(notificationResponse.status, 202)
       strictEqual(yield* notificationResponse.text, "")
+      strictEqual(notificationResponse.headers["content-type"], undefined)
+      strictEqual(notificationResponse.headers["access-control-allow-origin"], "*")
+      strictEqual(notificationResponse.headers["mcp-protocol-version"], "2025-06-18")
 
       const responseOnly = yield* HttpClientRequest.post("http://localhost/mcp").pipe(
         HttpClientRequest.bodyJsonUnsafe({ jsonrpc: "2.0", id: 1, result: {} }),
@@ -149,7 +155,7 @@ describe("McpServer", () => {
 
   it.effect("validates supplied protocol versions on POST", () =>
     Effect.gen(function*() {
-      const { client, httpClient } = yield* makeTestClient
+      const { client, httpClient } = yield* makeTestClient()
 
       yield* client.initialize(initializePayload)
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updates `McpServer.layerHttp` to comply with the [MCP Streamable HTTP transport specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http).

- Returns `405 Method Not Allowed` with `Allow: POST` for unsupported GET, HEAD, PUT, PATCH, and DELETE requests at the MCP endpoint.
- Returns an empty `202 Accepted` response for accepted JSON-RPC notifications and responses while preserving normal `200` JSON-RPC request responses.
- Validates supplied `MCP-Protocol-Version` headers before dispatch and returns an empty `400 Bad Request` response for unsupported versions.
- Preserves the negotiated `MCP-Protocol-Version` response header after initialization.
- Adds coverage for unsupported methods, notification-only and response-only POSTs, normal request POSTs, missing protocol-version headers, and every supported protocol version.

## Related

- None
