### PR TITLE
EFF-938 Fix Atom.kvs async writes

### DIFF
--- a/.changeset/fix-atom-kvs-async-write.md
+++ b/.changeset/fix-atom-kvs-async-write.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix `Atom.kvs` async mode to retain its `AsyncResult` value shape after writes.

--- a/packages/effect/src/unstable/reactivity/Atom.ts
+++ b/packages/effect/src/unstable/reactivity/Atom.ts
@@ -2150,7 +2150,7 @@ export const kvs = <S extends Schema.ConstraintCodec<any, any>, const Mode exten
       },
     (ctx, value: S["Type"]) => {
       ctx.set(setAtom, value as any)
-      ctx.setSelf(value)
+      ctx.setSelf(options.mode === "async" ? AsyncResult.success(value) : value)
     }
   ) as any
 }

--- a/packages/effect/test/reactivity/Atom.test.ts
+++ b/packages/effect/test/reactivity/Atom.test.ts
@@ -2504,6 +2504,12 @@ describe.sequential("Atom", () => {
       expect(result.value).toEqual(42)
       expect(result.waiting).toEqual(false)
       expect(storage.get("test-key")).toEqual(JSON.stringify(42))
+
+      r.set(atom, 24)
+
+      const updated = r.get(atom)
+      assert(AsyncResult.isSuccess(updated))
+      expect(updated.value).toEqual(24)
     })
   })
 })


### PR DESCRIPTION
## Summary
- preserve the `AsyncResult` value shape when writing to `Atom.kvs` in async mode
- add regression coverage for reading an async KVS atom immediately after a write
- add an `effect` patch changeset

## Validation
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test packages/effect/test/reactivity/Atom.test.ts` (97 tests)
- `git diff --check`