### PR TITLE
Handle large millis passed to sleep

### DIFF
--- a/.changeset/floppy-rats-leave.md
+++ b/.changeset/floppy-rats-leave.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fixed Clock.sleep handling of large durations

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5838,8 +5838,8 @@ class ClockImpl implements Clock.Clock {
     const millis = Duration.toMillis(duration)
     if (millis <= 0) return yieldNow
     return callback((resume) => {
-      if (millis > MAX_TIMER_MILLIS) return
-      const handle = setTimeout(() => resume(void_), millis)
+      const continuation = millis > MAX_TIMER_MILLIS ? this.sleep(millis - MAX_TIMER_MILLIS) : void_
+      const handle = setTimeout(() => resume(continuation), Math.min(millis, MAX_TIMER_MILLIS))
       return sync(() => clearTimeout(handle))
     })
   }

--- a/packages/effect/src/internal/effect.ts
+++ b/packages/effect/src/internal/effect.ts
@@ -5835,10 +5835,15 @@ class ClockImpl implements Clock.Clock {
   }
   readonly currentTimeNanos: Effect.Effect<bigint> = sync(() => this.currentTimeNanosUnsafe())
   sleep(duration: Duration.Duration): Effect.Effect<void> {
-    const millis = Duration.toMillis(duration)
+    return this.sleepMillis(Duration.toMillis(duration))
+  }
+  private sleepMillis(millis: number): Effect.Effect<void> {
     if (millis <= 0) return yieldNow
+    else if (!Number.isFinite(millis)) return never
     return callback((resume) => {
-      const continuation = millis > MAX_TIMER_MILLIS ? this.sleep(millis - MAX_TIMER_MILLIS) : void_
+      const continuation = millis > MAX_TIMER_MILLIS
+        ? this.sleepMillis(millis - MAX_TIMER_MILLIS)
+        : void_
       const handle = setTimeout(() => resume(continuation), Math.min(millis, MAX_TIMER_MILLIS))
       return sync(() => clearTimeout(handle))
     })


### PR DESCRIPTION
## Type
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes how Clock.sleep handles large duration