### PR TITLE
Fix stripped declaration for SchemaError type identifier

### DIFF
--- a/.changeset/fix-schema-error-type-id-declaration.md
+++ b/.changeset/fix-schema-error-type-id-declaration.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix published `SchemaError` declarations by retaining `SchemaErrorTypeId`.

--- a/packages/effect/src/internal/schema/schema.ts
+++ b/packages/effect/src/internal/schema/schema.ts
@@ -42,7 +42,6 @@ export function make<S extends Schema.Constraint>(ast: S["ast"], options?: objec
   return self
 }
 
-/** @internal */
 export const SchemaErrorTypeId = "~effect/Schema/SchemaError"
 
 // purposefully not internal

--- a/packages/effect/typetest/schema/Schema.tst.ts
+++ b/packages/effect/typetest/schema/Schema.tst.ts
@@ -107,6 +107,13 @@ describe("Schema", () => {
     })
   })
 
+  describe("SchemaError", () => {
+    it("includes the runtime type identifier", () => {
+      const error = hole<Schema.SchemaError>()
+      expect(error).type.toHaveProperty("~effect/Schema/SchemaError")
+    })
+  })
+
   describe("make", () => {
     it("Never", () => {
       const schema = Schema.Never


### PR DESCRIPTION
## Summary

When internal declarations are stripped, `SchemaError` retained a reference to `SchemaErrorTypeId` without emitting its declaration.

## Fix

Keep `SchemaErrorTypeId` in generated declarations.

## Tests

- `pnpm test-types packages/effect/typetest/schema/Schema.tst.ts`
- `pnpm --dir packages/effect test --run test/schema/Schema.test.ts`
- `pnpm check`
- `pnpm build` with `stripInternal` enabled
- `pnpm jsdocs`
- `pnpm exec dprint check packages/effect/src/internal/schema/schema.ts packages/effect/typetest/schema/Schema.tst.ts`
- `pnpm exec oxlint packages/effect/src/internal/schema/schema.ts packages/effect/typetest/schema/Schema.tst.ts`