### PR TITLE
Compile HttpApi SSE client decoders once

### DIFF
--- a/packages/effect/benchmark/httpapi/sseClientDecoder.ts
+++ b/packages/effect/benchmark/httpapi/sseClientDecoder.ts
@@ -1,0 +1,52 @@
+import { Effect, Schema, Stream } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { HttpApi, HttpApiClient, HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "effect/unstable/httpapi"
+import { Bench } from "tinybench"
+
+const Event = Schema.Struct({
+  event: Schema.Literal("tick"),
+  data: Schema.String
+})
+
+const Api = HttpApi.make("Api").add(
+  HttpApiGroup.make("test").add(
+    HttpApiEndpoint.get("events", "/events", {
+      success: HttpApiSchema.StreamSse({
+        events: Event,
+        error: Schema.String
+      })
+    })
+  )
+)
+
+const httpClient = HttpClient.make((request) =>
+  Effect.sync(() =>
+    HttpClientResponse.fromWeb(
+      request,
+      new Response("event: tick\ndata: payload\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      })
+    )
+  )
+)
+
+const client = await Effect.runPromise(HttpApiClient.makeWith(Api, {
+  baseUrl: "http://localhost",
+  httpClient
+}))
+const consumeResponse = Effect.flatMap(client.test.events({}), Stream.runDrain)
+const responsesPerIteration = 25
+const responses = Array.from({ length: responsesPerIteration })
+const runIteration = Effect.forEach(responses, () => consumeResponse, {
+  concurrency: 1,
+  discard: true
+})
+
+const bench = new Bench({ time: 3000 })
+
+bench.add(`${responsesPerIteration} sequential SSE responses through one client`, () => Effect.runPromise(runIteration))
+
+await bench.run()
+
+console.table(bench.table())

--- a/packages/effect/src/unstable/httpapi/HttpApiClient.ts
+++ b/packages/effect/src/unstable/httpapi/HttpApiClient.ts
@@ -815,20 +815,25 @@ function getStreamSuccessSchemas(endpoint: HttpApiEndpoint.Top): Array<HttpApiSc
 }
 
 function streamToResponse(streamSchema: HttpApiSchema.StreamSchema) {
+  const sse = HttpApiSchema.isStreamUint8Array(streamSchema)
+    ? undefined
+    : {
+      declaration: streamSchema,
+      decoder: makeSseDecoder(streamSchema)
+    }
   return (response: HttpClientResponse.HttpClientResponse) =>
     Effect.map(Effect.context<never>(), (context) =>
       Stream.provideContext(
-        HttpApiSchema.isStreamUint8Array(streamSchema) ?
+        sse === undefined ?
           response.stream :
-          decodeSseStream(response.stream, streamSchema),
+          decodeSseStream(response.stream, sse.declaration, sse.decoder),
         context as Context.Context<unknown>
       ))
 }
 
-function decodeSseStream(
-  stream: Stream.Stream<Uint8Array, HttpClientError.HttpClientError>,
+function makeSseDecoder(
   declaration: HttpApiSchema.StreamSse<Sse.EventCodec, Schema.Constraint, unknown>
-): Stream.Stream<unknown, unknown, unknown> {
+) {
   const Event = Schema.Union([
     declaration.events,
     Schema.Struct({
@@ -836,10 +841,18 @@ function decodeSseStream(
       data: Schema.fromJsonString(Schema.toCodecJson(Schema.Cause(declaration.error, Schema.Defect())))
     })
   ])
+  return Sse.decodeSchema(Event)
+}
+
+function decodeSseStream(
+  stream: Stream.Stream<Uint8Array, HttpClientError.HttpClientError>,
+  declaration: HttpApiSchema.StreamSse<Sse.EventCodec, Schema.Constraint, unknown>,
+  decoder: ReturnType<typeof makeSseDecoder>
+): Stream.Stream<unknown, unknown, unknown> {
   const events = Stream.transformPull(
     stream.pipe(
       Stream.decodeText,
-      Stream.pipeThroughChannel(Sse.decodeSchema(Event))
+      Stream.pipeThroughChannel(decoder)
     ),
     (pull) =>
       Effect.sync(() => {

--- a/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
+++ b/packages/effect/test/unstable/httpapi/HttpApiClient.test.ts
@@ -27,6 +27,25 @@ describe("HttpApiClient", () => {
         assert.deepStrictEqual(first, [{ event: "first", data: "one" }])
       }))
 
+    it.effect("keeps StreamSse parser state isolated between responses", () =>
+      Effect.gen(function*() {
+        const bodies = [
+          "event: first\ndata: one\n\n",
+          "event: second\ndata: two\n\n"
+        ]
+        let index = 0
+        const client = yield* HttpApiClient.makeWith(StreamingApi, {
+          baseUrl: "http://test",
+          httpClient: clientFromResponse(() => new Response(textStream([bodies[index++]!]), { status: 200 }))
+        })
+
+        const first = yield* client.test.events({}).pipe(Effect.flatMap(Stream.runCollect))
+        const second = yield* client.test.events({}).pipe(Effect.flatMap(Stream.runCollect))
+
+        assert.deepStrictEqual(first, [{ event: "first", data: "one" }])
+        assert.deepStrictEqual(second, [{ event: "second", data: "two" }])
+      }))
+
     it.effect("decodes StreamSse reserved failure events as full causes", () =>
       Effect.gen(function*() {
         const expectedCause = Cause.fail({ reason: "boom" })


### PR DESCRIPTION
Compile the SSE schema decoder once per generated endpoint instead of once per response.

The generated-client benchmark improves throughput from approximately 7,800 to 41,300 responses per second (about 5.3x), while median latency drops from approximately 116 to 23 microseconds per response.
