### PR TITLE
Fix durable race result replay

### DIFF
--- a/.changeset/fix-durable-race-replay.md
+++ b/.changeset/fix-durable-race-replay.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fix replay of persisted `DurableDeferred.raceAll` results.

--- a/packages/effect/src/unstable/workflow/DurableDeferred.ts
+++ b/packages/effect/src/unstable/workflow/DurableDeferred.ts
@@ -280,7 +280,7 @@ export const raceAll = <
     const engine = yield* EngineTag
     const exit = yield* engine.deferredResult(deferred)
     if (Option.isSome(exit)) {
-      return yield* exit.value as Exit.Exit<any, any>
+      return yield* exit.value
     }
     return yield* into(
       Effect.raceAll(options.effects),

--- a/packages/effect/src/unstable/workflow/DurableDeferred.ts
+++ b/packages/effect/src/unstable/workflow/DurableDeferred.ts
@@ -280,7 +280,7 @@ export const raceAll = <
     const engine = yield* EngineTag
     const exit = yield* engine.deferredResult(deferred)
     if (Option.isSome(exit)) {
-      return yield* Effect.flatten(exit.value) as Effect.Effect<any, any, any>
+      return yield* exit.value as Exit.Exit<any, any>
     }
     return yield* into(
       Effect.raceAll(options.effects),

--- a/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
+++ b/packages/effect/test/cluster/ClusterWorkflowEngine.test.ts
@@ -176,8 +176,9 @@ describe.concurrent("ClusterWorkflowEngine", () => {
       expect(flags.get("interrupt3")).toBeFalsy()
     }).pipe(Effect.provide(TestWorkflowLayer)))
 
-  it.effect("Activity.raceAll resumes the first durable activity", () =>
+  it.effect("Activity.raceAll replays the first durable activity", () =>
     Effect.gen(function*() {
+      const flags = yield* Flags
       const sharding = yield* Sharding.Sharding
       yield* TestClock.adjust(1)
 
@@ -187,6 +188,15 @@ describe.concurrent("ClusterWorkflowEngine", () => {
 
       yield* TestClock.adjust(1)
       yield* TestClock.adjust(1000)
+      yield* sharding.pollStorage
+      yield* TestClock.adjust(5000)
+
+      const token = flags.get("durable-race-token")
+      assert(typeof token === "string")
+      yield* DurableDeferred.done(DurableRaceGate, {
+        token: DurableDeferred.Token.make(token),
+        exit: Exit.void
+      })
       yield* sharding.pollStorage
       yield* TestClock.adjust(5000)
 
@@ -526,6 +536,8 @@ const DurableRaceWorkflow = Workflow.make("DurableRaceWorkflow", {
   idempotencyKey: ({ id }) => id
 })
 
+const DurableRaceGate = DurableDeferred.make("DurableRaceGate")
+
 const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(function*() {
   const flags = yield* Flags
 
@@ -535,7 +547,7 @@ const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(f
     })
   )
 
-  return yield* Activity.raceAll("race", [
+  const result = yield* Activity.raceAll("race", [
     Activity.make({
       name: "Activity1",
       success: Schema.String,
@@ -573,6 +585,9 @@ const DurableRaceWorkflowLayer = DurableRaceWorkflow.toLayer(Effect.fnUntraced(f
       )
     })
   ])
+  flags.set("durable-race-token", yield* DurableDeferred.token(DurableRaceGate))
+  yield* DurableDeferred.await(DurableRaceGate)
+  return result
 }))
 
 const ParentWorkflow = Workflow.make("ParentWorkflow", {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix replay of successful `DurableDeferred.raceAll` results.

`WorkflowEngine.deferredResult` already returns a decoded `Exit`. The replay path used `Effect.flatten`, causing the successful payload to be executed as an Effect and fail with `Fiber.runLoop: Not a valid effect`.

Yield the persisted `Exit` directly, matching `DurableDeferred.await`.

The regression test forces a second workflow evaluation after the race winner is persisted, covering the replay path.

Validation:

- `pnpm lint-fix`
- `pnpm test packages/effect/test/cluster/ClusterWorkflowEngine.test.ts`
- `pnpm check`

## Related

- Related Issue: None
- Closes: None